### PR TITLE
feat(dev-seed): lightweight shareable dev fixture (rolling GitHub Release)

### DIFF
--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -276,6 +276,32 @@ go run ./cmd/migrate-catalog   # galgame models + catalog models — one entry p
 The snapshot is a **data** fixture and at most a drift *detector* — the
 migrations are the single source of truth for structure.
 
+## Lightweight dev-seed (step 02-lite — for collaborators without server access)
+
+The full snapshot pipeline needs SSH to the prod host. Collaborators who only
+need *something realistic to develop against* use the **dev-seed**: a few
+hundred entities per database (full FK closure, all seven core DBs), sampled
+from the desensitised snapshot and published as a rolling GitHub Release
+(`dev-seed` tag on this repo, a few MB total). All it needs is an
+authenticated `gh` with read access to the repo, plus `psql`/`pg_restore`:
+
+```sh
+./scripts/restore-dev-seed.sh --yes            # download + verify + drop/create/restore all 7 DBs
+DEVSEED_SUFFIX=_seed ./scripts/restore-dev-seed.sh --yes   # keep existing DBs, restore beside them
+```
+
+Every seeded account logs in with password `kungal-dev` (same dev-credential
+contract as the snapshot). Desensitisation is inherited — the seed is sampled
+*from* the scrubbed snapshot databases, never from raw prod. Content-side
+image/file hashes may dangle by design: bytes live in prod object storage and
+are not part of any seed.
+
+Producing it (maintainer side, this box): `scripts/dev-seed/build-seed.sh`
+samples the local snapshot DBs (`prune/<db>.sql` per DB, keep-sets + FK-enforced
+deletes) and `publish-seed.sh` replaces the release assets in place. A weekly
+systemd user timer (`scripts/dev-seed/systemd/`) keeps the release fresh —
+freshness tracks whatever the last `refresh-dev-db` pulled.
+
 ## Wiring a product repo (per-repo quickstart index)
 
 Once the stack is up (and optionally refreshed), each product repo needs only its

--- a/scripts/dev-seed/build-seed.sh
+++ b/scripts/dev-seed/build-seed.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# build-seed.sh — build the lightweight dev-seed dumps from the local
+# desensitised snapshot databases. See config.sh for the model.
+#
+# For each DB in SEED_DBS:
+#   1. drop + recreate <db>_seedbuild
+#   2. pipe a plain-SQL copy of the local <db> into it
+#   3. run prune/<db>.sql inside it (deletes down to a few hundred entities,
+#      FK constraints stay enforced, so closure is guaranteed by construction)
+#   4. pg_dump -Fc the result into the output dir
+#
+# Usage: ./build-seed.sh [--only <db>]   (--only reuses existing export CSVs)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
+
+ONLY_DB=""
+if [[ "${1:-}" == "--only" ]]; then
+  ONLY_DB="${2:?--only requires a database name}"
+fi
+
+PSQL=(psql -h "${LOCAL_PG_HOST}" -p "${LOCAL_PG_PORT}" -U "${LOCAL_PG_USER}" -v ON_ERROR_STOP=1 -q)
+STAMP="$(date +%Y%m%d-%H%M)"
+OUT_DIR="${SEED_OUT_ROOT}/${STAMP}"
+# --only refreshes one dump in place inside the newest full build, so the
+# output dir stays a complete publishable set.
+if [[ -n "${ONLY_DB}" && -d "${SEED_OUT_ROOT}/latest" ]]; then
+  OUT_DIR="$(readlink -f "${SEED_OUT_ROOT}/latest")"
+fi
+EXPORT_DIR="${SEED_OUT_ROOT}/exports"
+mkdir -p "${OUT_DIR}" "${EXPORT_DIR}"
+
+log() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+
+for db in "${SEED_DBS[@]}"; do
+  [[ -n "${ONLY_DB}" && "${db}" != "${ONLY_DB}" ]] && continue
+  build="${db}${SEED_BUILD_SUFFIX}"
+
+  log "${db}: rebuilding scratch ${build}"
+  # A leftover connection (e.g. from an aborted run) makes DROP DATABASE fail.
+  "${PSQL[@]}" -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${build}' AND pid <> pg_backend_pid()" >/dev/null
+  "${PSQL[@]}" -d postgres -c "DROP DATABASE IF EXISTS ${build}"
+  "${PSQL[@]}" -d postgres -c "CREATE DATABASE ${build}"
+
+  log "${db}: copying local snapshot into ${build}"
+  pg_dump -h "${LOCAL_PG_HOST}" -p "${LOCAL_PG_PORT}" -U "${LOCAL_PG_USER}" \
+    --no-owner --no-privileges -d "${db}" \
+    | "${PSQL[@]}" -d "${build}" >/dev/null
+
+  # CWD = export dir: psql's \copy does NOT interpolate variables (verified on
+  # psql 18), so prune scripts address export CSVs by bare relative filename.
+  log "${db}: pruning to seed size"
+  (cd "${EXPORT_DIR}" && "${PSQL[@]}" -d "${build}" \
+    -v export_dir="${EXPORT_DIR}" \
+    -v seed_works="${SEED_WORKS}" \
+    -v seed_topics="${SEED_TOPICS}" \
+    -v seed_users="${SEED_USERS}" \
+    -f "${SCRIPT_DIR}/prune/${db}.sql")
+
+  log "${db}: dumping seed"
+  pg_dump -h "${LOCAL_PG_HOST}" -p "${LOCAL_PG_PORT}" -U "${LOCAL_PG_USER}" \
+    --no-owner --no-privileges -Fc -Z6 -d "${build}" \
+    -f "${OUT_DIR}/${db}.dump"
+
+  "${PSQL[@]}" -d postgres -c "DROP DATABASE ${build}"
+done
+
+log "writing manifest + checksums"
+{
+  echo "stamp: $(basename "${OUT_DIR}")"
+  echo "source: local desensitised snapshot databases (refresh-dev-db)"
+  echo "restore: scripts/restore-dev-seed.sh (or pg_restore --no-owner per dump)"
+  for f in "${OUT_DIR}"/*.dump; do
+    printf '%s  %s\n' "$(du -h "$f" | cut -f1)" "$(basename "$f")"
+  done
+} > "${OUT_DIR}/MANIFEST.txt"
+(cd "${OUT_DIR}" && sha256sum ./*.dump > SHA256SUMS)
+
+ln -sfn "${OUT_DIR}" "${SEED_OUT_ROOT}/latest"
+log "done → ${OUT_DIR}"
+cat "${OUT_DIR}/MANIFEST.txt"

--- a/scripts/dev-seed/config.sh
+++ b/scripts/dev-seed/config.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# config.sh — single source of truth for the dev-seed pipeline.
+#
+# The dev-seed pipeline samples a few hundred entities (with full FK closure)
+# out of the LOCAL desensitised snapshot databases (which scripts/refresh-dev-db.sh
+# maintains) and publishes tiny per-DB dumps as a GitHub Release, so that
+# collaborators can bootstrap a working dev database set without any access to
+# the production server or to the full snapshot artifacts.
+#
+# Desensitisation is inherited: the sampling source is the local copy that the
+# refresh pipeline already scrubbed (scripts/dev-snapshot/scrub/*.sql), so no
+# scrub step exists here on purpose. Never point SEED_SOURCE at raw prod data.
+#
+# shellcheck disable=SC2034  # every value here is consumed by a sourcing script.
+
+# Reuse the local Postgres coordinates (LOCAL_PG_*) and dev constants from the
+# snapshot pipeline — one truth for both pipelines.
+DEV_SEED_CONFIG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../dev-snapshot/config.sh
+source "${DEV_SEED_CONFIG_DIR}/../dev-snapshot/config.sh"
+
+# Databases to seed, in build order. Exporter DBs (whose prune step \copy's
+# kept-user id lists into the work dir) MUST run before importer DBs (whose
+# prune step reads those lists to keep the matching platform-side rows).
+SEED_DBS=(
+  kungalgame          # exports kept user / topic / galgame / resource id lists
+  kungalgame_patch    # exports kept patch-local user ids
+  kun_catalog
+  kun_community       # imports forum content ids; exports kept platform uids
+  kun_galgame_infra   # imports all kept-user lists (accounts + site mappings)
+  kun_images
+  kun_artifacts
+)
+
+# Scratch database name suffix. build-seed.sh only ever drops/creates
+# databases carrying this suffix — never the snapshot-managed names.
+SEED_BUILD_SUFFIX="_seedbuild"
+
+# Rough sampling targets (each prune/<db>.sql consumes what it needs via -v).
+SEED_WORKS=300        # catalog works / forum galgame entries / patches
+SEED_TOPICS=300       # forum topics
+SEED_USERS=400        # per-site sampled users (content authors are always kept)
+
+# Where build artifacts land (outside the repo; safe for a systemd timer).
+SEED_OUT_ROOT="${HOME}/.cache/kungal-dev-seed"
+
+# Publishing target: a rolling release on a fixed tag, assets replaced in
+# place. A dedicated PRIVATE repo — kun-galgame-infra itself is public, and
+# the seed (scrubbed, but sampled from real data) is distributed by invite:
+# access control = that repo's collaborator list.
+SEED_REPO="KunMoe/kungal-dev-seed"
+SEED_TAG="dev-seed"

--- a/scripts/dev-seed/prune/kun_artifacts.sql
+++ b/scripts/dev-seed/prune/kun_artifacts.sql
@@ -1,0 +1,14 @@
+-- Prune kun_artifacts to the newest few hundred artifact records. Like the
+-- image seed, the underlying files stay in prod object storage; the rows are
+-- enough to exercise listings and the manifest model.
+
+BEGIN;
+
+CREATE TEMP TABLE keep_artifact (id bigint PRIMARY KEY);
+INSERT INTO keep_artifact
+SELECT id FROM artifacts ORDER BY id DESC LIMIT :seed_works;
+
+DELETE FROM manifests WHERE artifact_id NOT IN (SELECT id FROM keep_artifact);
+DELETE FROM artifacts WHERE id NOT IN (SELECT id FROM keep_artifact);
+
+COMMIT;

--- a/scripts/dev-seed/prune/kun_catalog.sql
+++ b/scripts/dev-seed/prune/kun_catalog.sql
@@ -1,0 +1,330 @@
+-- =============================================================================
+-- dev-seed prune: kun_catalog
+--
+-- Shrinks a full copy of kun_catalog (run against a *_seedbuild scratch DB,
+-- never the source) down to the newest :seed_works works plus full FK closure,
+-- so the result can be pg_dump'ed as a tiny collaborator seed.
+--
+-- Invocation (orchestrator):
+--   psql -v ON_ERROR_STOP=1 -q -d kun_catalog_seedbuild \
+--     -v seed_works=300 -f prune/kun_catalog.sql
+-- (export_dir / seed_topics / seed_users are accepted but unused here.)
+--
+-- Technique: FK constraints stay enforced throughout. Keep-sets are built in
+-- TEMP tables first, then children are deleted before parents so any ordering
+-- mistake fails loudly instead of corrupting the seed.
+--
+-- Entity-type constants (docs/catalog/01-service-and-contract.md):
+--   0=person 1=credit_name 2=org 3=label 4=character 5=work 6=release
+--   7=tag 8=engine   (7/8 and 2 are keep-all families in this seed)
+--
+-- Kept in full (small vocab/config, ride along):
+--   catalog_tag(+intro,+source_map), catalog_character_trait(+parent),
+--   catalog_series(+intro), catalog_engine, catalog_platform, catalog_medium,
+--   catalog_role, catalog_source(+role_map), catalog_relation_type,
+--   catalog_survivorship_rule, catalog_org (empty), the empty galgame_* family.
+-- =============================================================================
+
+BEGIN;
+
+-- =============================================================================
+-- 1. Keep-sets
+-- =============================================================================
+
+-- Roots (deterministic rich mix): the top (:seed_works - 50) works by
+-- popularity (max metric value across sources, tie-broken by work id) plus
+-- the newest 50 works by id so recent claim-era shapes stay represented.
+-- Popularity-ranked roots carry far denser character/release/credit closures
+-- than a plain newest-N slice.
+CREATE TEMP TABLE keep_work (id bigint PRIMARY KEY) ON COMMIT DROP;
+INSERT INTO keep_work
+SELECT work_id FROM catalog_work_popularity
+GROUP BY work_id
+ORDER BY max(value) DESC, work_id DESC
+LIMIT (:seed_works - 50);
+INSERT INTO keep_work
+SELECT id FROM (SELECT id FROM catalog_work ORDER BY id DESC LIMIT 50) newest
+ON CONFLICT DO NOTHING;
+
+-- Releases of kept works.
+CREATE TEMP TABLE keep_release (id bigint PRIMARY KEY) ON COMMIT DROP;
+INSERT INTO keep_release
+SELECT id FROM catalog_release WHERE work_id IN (SELECT id FROM keep_work);
+
+-- Characters: linked to kept works (work_character) or referenced by credits
+-- of kept works, plus the transitive instance_of ancestor closure (self-FK).
+CREATE TEMP TABLE keep_character (id bigint PRIMARY KEY) ON COMMIT DROP;
+INSERT INTO keep_character
+SELECT DISTINCT character_id FROM catalog_work_character
+WHERE work_id IN (SELECT id FROM keep_work)
+UNION
+SELECT DISTINCT character_id FROM catalog_credit
+WHERE work_id IN (SELECT id FROM keep_work) AND character_id IS NOT NULL;
+
+WITH RECURSIVE anc AS (
+    SELECT c.instance_of AS id
+    FROM catalog_character c JOIN keep_character k ON k.id = c.id
+    WHERE c.instance_of IS NOT NULL
+    UNION
+    SELECT c.instance_of
+    FROM catalog_character c JOIN anc ON c.id = anc.id
+    WHERE c.instance_of IS NOT NULL
+)
+INSERT INTO keep_character SELECT id FROM anc ON CONFLICT DO NOTHING;
+
+-- Credit names + persons. These two tables are mutually referencing
+-- (credit_name.person_id -> person, person.primary_credit_name_id ->
+-- credit_name), so close the pair to a fixpoint.
+CREATE TEMP TABLE keep_credit_name (id bigint PRIMARY KEY) ON COMMIT DROP;
+INSERT INTO keep_credit_name
+SELECT DISTINCT credit_name_id FROM catalog_credit
+WHERE work_id IN (SELECT id FROM keep_work);
+
+CREATE TEMP TABLE keep_person (id bigint PRIMARY KEY) ON COMMIT DROP;
+
+DO $$
+DECLARE
+    n_person integer;
+    n_name   integer;
+BEGIN
+    LOOP
+        INSERT INTO keep_person
+        SELECT DISTINCT cn.person_id
+        FROM catalog_credit_name cn JOIN keep_credit_name k ON k.id = cn.id
+        WHERE cn.person_id IS NOT NULL
+        ON CONFLICT DO NOTHING;
+        GET DIAGNOSTICS n_person = ROW_COUNT;
+
+        INSERT INTO keep_credit_name
+        SELECT p.primary_credit_name_id
+        FROM catalog_person p JOIN keep_person kp ON kp.id = p.id
+        WHERE p.primary_credit_name_id IS NOT NULL
+        ON CONFLICT DO NOTHING;
+        GET DIAGNOSTICS n_name = ROW_COUNT;
+
+        EXIT WHEN n_person = 0 AND n_name = 0;
+    END LOOP;
+END $$;
+
+-- Labels: referenced by work_label links of kept works or by kept credits.
+-- (catalog_label vocab is ~37k -> pruned to referenced rows.)
+CREATE TEMP TABLE keep_label (id bigint PRIMARY KEY) ON COMMIT DROP;
+INSERT INTO keep_label
+SELECT DISTINCT label_id FROM catalog_work_label
+WHERE work_id IN (SELECT id FROM keep_work)
+UNION
+SELECT DISTINCT label_id FROM catalog_credit
+WHERE work_id IN (SELECT id FROM keep_work) AND label_id IS NOT NULL;
+
+-- Unified (entity_type, id) map of every kept entity, for the polymorphic
+-- tables (external_ref / revision / redirect / merge / match).
+CREATE TEMP TABLE keep_entity (entity_type smallint, entity_id bigint,
+                               PRIMARY KEY (entity_type, entity_id)) ON COMMIT DROP;
+INSERT INTO keep_entity
+SELECT 0, id FROM keep_person
+UNION ALL SELECT 1, id FROM keep_credit_name
+UNION ALL SELECT 3, id FROM keep_label
+UNION ALL SELECT 4, id FROM keep_character
+UNION ALL SELECT 5, id FROM keep_work
+UNION ALL SELECT 6, id FROM keep_release
+-- keep-all vocab families: org(2, table is empty), tag(7), engine(8)
+UNION ALL SELECT 7, id FROM catalog_tag
+UNION ALL SELECT 8, id FROM catalog_engine;
+
+-- Temporary helper indexes: three FK columns have no index in the schema, so
+-- the per-row RI checks fired by the parent DELETEs below would seq-scan the
+-- (bloated) child tables and take hours. Constraints stay fully enforced;
+-- these plain indexes are dropped again before COMMIT so the dumped seed
+-- schema is byte-identical to the source schema.
+CREATE INDEX seed_tmp_credit_release ON catalog_credit (release_id);
+CREATE INDEX seed_tmp_credit_label   ON catalog_credit (label_id);
+CREATE INDEX seed_tmp_person_primary ON catalog_person (primary_credit_name_id);
+
+-- =============================================================================
+-- 2. Upstream source-mirror / staging schemas -> empty
+-- =============================================================================
+-- The source-mirror families (subject*, tags_vn, chars_traits, extlinks,
+-- releases_extlinks, person_character, ...) live in dedicated schemas:
+-- src_bangumi, src_llm, src_vndb, src_wiki (~3.2 GB total). Verified: not a
+-- single FK constraint references into or out of any src_* table, so all of
+-- them are emptied. The loop is dynamic so a snapshot that grows a new mirror
+-- table still prunes clean; no CASCADE, so if a future FK ever points at a
+-- src_* table this fails loudly instead of silently emptying a kept table.
+DO $$
+DECLARE
+    t record;
+BEGIN
+    FOR t IN SELECT schemaname, tablename FROM pg_tables
+             WHERE schemaname LIKE 'src\_%' ESCAPE '\'
+             ORDER BY schemaname, tablename LOOP
+        EXECUTE format('TRUNCATE TABLE %I.%I', t.schemaname, t.tablename);
+    END LOOP;
+END $$;
+
+-- The retired galgame_* family (public schema) is already 0 rows everywhere.
+-- The only true scratch table in public is tmp_pairs (getchu_id/work_id,
+-- no constraints).
+TRUNCATE TABLE tmp_pairs;
+
+-- =============================================================================
+-- 3. Work family (children first, then catalog_work last in section 8)
+-- =============================================================================
+
+-- cover_vote -> work_cover (FK ON DELETE CASCADE, but delete explicitly).
+DELETE FROM catalog_cover_vote v
+USING catalog_work_cover c
+WHERE v.cover_id = c.id AND c.work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_work_cover      WHERE work_id NOT IN (SELECT id FROM keep_work);
+
+DELETE FROM catalog_work_title      WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_work_intro      WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_work_tag        WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_work_label      WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_work_platform   WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_work_engine     WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_work_playtime   WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_work_popularity WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_work_rating     WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_work_screenshot WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_series_member   WHERE work_id NOT IN (SELECT id FROM keep_work);
+
+-- Work<->work relations survive only when both endpoints are kept.
+DELETE FROM catalog_work_relation
+WHERE a_work_id NOT IN (SELECT id FROM keep_work)
+   OR b_work_id NOT IN (SELECT id FROM keep_work);
+
+-- Claim events (soft work_id, no FK) pruned to kept works.
+DELETE FROM catalog_claim_event WHERE work_id NOT IN (SELECT id FROM keep_work);
+
+-- =============================================================================
+-- 4. Credits, then releases
+-- =============================================================================
+-- Credits must go before releases / characters / credit_names / labels: a
+-- credit references all of them. Kept credits (work kept) only reference kept
+-- rows by construction of the keep-sets above.
+DELETE FROM catalog_credit  WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_release WHERE id NOT IN (SELECT id FROM keep_release);
+
+-- =============================================================================
+-- 5. Character family
+-- =============================================================================
+DELETE FROM catalog_work_character WHERE work_id NOT IN (SELECT id FROM keep_work);
+DELETE FROM catalog_character_alias
+    WHERE character_id NOT IN (SELECT id FROM keep_character);
+DELETE FROM catalog_character_intro
+    WHERE character_id NOT IN (SELECT id FROM keep_character);
+-- Trait links pruned to kept characters; the trait vocabulary itself
+-- (catalog_character_trait + _parent, ~3.3k rows) is kept in full.
+DELETE FROM catalog_character_trait_link
+    WHERE character_id NOT IN (SELECT id FROM keep_character);
+-- Self-FK instance_of: keep_character is ancestor-closed, and NO ACTION FKs
+-- are checked at end of statement, so one DELETE is safe.
+DELETE FROM catalog_character WHERE id NOT IN (SELECT id FROM keep_character);
+
+-- =============================================================================
+-- 6. Credit names <-> persons (circular FK pair)
+-- =============================================================================
+DELETE FROM catalog_name_alias
+    WHERE credit_name_id NOT IN (SELECT id FROM keep_credit_name);
+DELETE FROM catalog_person_intro
+    WHERE person_id NOT IN (SELECT id FROM keep_person);
+
+-- Break the person -> credit_name half of the cycle on rows that are about to
+-- be deleted anyway, so the two DELETEs below cannot trip either FK.
+UPDATE catalog_person SET primary_credit_name_id = NULL
+WHERE id NOT IN (SELECT id FROM keep_person)
+  AND primary_credit_name_id IS NOT NULL;
+
+DELETE FROM catalog_credit_name WHERE id NOT IN (SELECT id FROM keep_credit_name);
+DELETE FROM catalog_person      WHERE id NOT IN (SELECT id FROM keep_person);
+
+-- =============================================================================
+-- 7. Label family (org table is empty; nothing to do there)
+-- =============================================================================
+DELETE FROM catalog_label_alias WHERE label_id NOT IN (SELECT id FROM keep_label);
+DELETE FROM catalog_label_intro WHERE label_id NOT IN (SELECT id FROM keep_label);
+DELETE FROM catalog_label       WHERE id       NOT IN (SELECT id FROM keep_label);
+
+-- =============================================================================
+-- 8. Works (parents of everything above)
+-- =============================================================================
+DELETE FROM catalog_work WHERE id NOT IN (SELECT id FROM keep_work);
+
+-- Helper indexes served their purpose; drop them so the seed schema matches
+-- the source schema exactly.
+DROP INDEX seed_tmp_credit_release;
+DROP INDEX seed_tmp_credit_label;
+DROP INDEX seed_tmp_person_primary;
+
+-- =============================================================================
+-- 9. Polymorphic (entity_type, entity_id) tables
+-- =============================================================================
+
+-- External refs of kept entities only.
+DELETE FROM catalog_external_ref r
+WHERE NOT EXISTS (SELECT 1 FROM keep_entity k
+                  WHERE k.entity_type = r.entity_type AND k.entity_id = r.entity_id);
+
+-- Revisions of kept entities, then capped at the ~2000 newest by id.
+DELETE FROM catalog_revision r
+WHERE NOT EXISTS (SELECT 1 FROM keep_entity k
+                  WHERE k.entity_type = r.entity_type AND k.entity_id = r.entity_id);
+DELETE FROM catalog_revision
+WHERE id NOT IN (SELECT id FROM catalog_revision ORDER BY id DESC LIMIT 2000);
+
+-- Redirects survive only when they land on a kept entity (old_id is the
+-- merged-away id and no longer exists by design).
+DELETE FROM catalog_redirect r
+WHERE NOT EXISTS (SELECT 1 FROM keep_entity k
+                  WHERE k.entity_type = r.entity_type AND k.entity_id = r.current_id);
+
+-- Merge proposals / match candidates: both endpoints must be kept.
+DELETE FROM catalog_merge_proposal p
+WHERE NOT EXISTS (SELECT 1 FROM keep_entity k
+                  WHERE k.entity_type = p.entity_type AND k.entity_id = p.source_entity_id)
+   OR NOT EXISTS (SELECT 1 FROM keep_entity k
+                  WHERE k.entity_type = p.entity_type AND k.entity_id = p.target_entity_id);
+DELETE FROM catalog_match_candidate c
+WHERE NOT EXISTS (SELECT 1 FROM keep_entity k
+                  WHERE k.entity_type = c.entity_type AND k.entity_id = c.a_id)
+   OR NOT EXISTS (SELECT 1 FROM keep_entity k
+                  WHERE k.entity_type = c.entity_type AND k.entity_id = c.b_id);
+DELETE FROM catalog_match_rejection r
+WHERE NOT EXISTS (SELECT 1 FROM keep_entity k
+                  WHERE k.entity_type = r.entity_type AND k.entity_id = r.entity_id);
+
+-- =============================================================================
+-- 10. Edit engine (soft entity refs; only family 'catalog'/'catalog.work'
+--     exists in the data today)
+-- =============================================================================
+DELETE FROM edit_revision e
+WHERE NOT (e.entity_family = 'catalog' AND e.entity_type = 'catalog.work'
+           AND e.entity_id IN (SELECT id FROM keep_work));
+DELETE FROM edit_proposal p
+WHERE NOT (p.entity_family = 'catalog' AND p.entity_type = 'catalog.work'
+           AND p.entity_id IN (SELECT id FROM keep_work));
+DELETE FROM edit_proposal_amendment a
+WHERE a.proposal_id NOT IN (SELECT id FROM edit_proposal);
+
+COMMIT;
+
+-- =============================================================================
+-- 11. Acceptance guard: no table may exceed 50,000 rows.
+-- =============================================================================
+DO $$
+DECLARE
+    t   record;
+    cnt bigint;
+BEGIN
+    FOR t IN SELECT schemaname, tablename FROM pg_tables
+             WHERE schemaname NOT IN ('pg_catalog', 'information_schema') LOOP
+        EXECUTE format('SELECT count(*) FROM %I.%I', t.schemaname, t.tablename)
+            INTO cnt;
+        IF cnt > 50000 THEN
+            RAISE EXCEPTION 'prune failed: table %.% still has % rows (> 50000)',
+                t.schemaname, t.tablename, cnt;
+        END IF;
+    END LOOP;
+END $$;
+
+ANALYZE;

--- a/scripts/dev-seed/prune/kun_community.sql
+++ b/scripts/dev-seed/prune/kun_community.sql
@@ -1,0 +1,77 @@
+-- Prune kun_community down to the threads whose anchors survive in the forum
+-- seed. Runs AFTER prune/kungalgame.sql, which exports the kept content ids.
+--
+-- Anchor model (site='kungal'): anchor_kind=1 anchors on a forum galgame id;
+-- anchor_kind=2 anchors on '<prefix>:<id>' where prefix 'resource' points at
+-- forum galgame_resource rows and quiz/toolset/website are site-global
+-- features we keep wholesale. 'rating' threads are dropped: their targets are
+-- per-user rating rows that do not survive sampling, so keeping them would
+-- only produce dangling anchors in dev.
+
+-- CSV paths are CWD-relative: \copy does not interpolate psql variables, so
+-- build-seed.sh runs this file with CWD = the shared export directory.
+
+BEGIN;
+
+CREATE TEMP TABLE in_galgame (id bigint PRIMARY KEY);
+\copy in_galgame FROM 'kungalgame_galgames.csv'
+CREATE TEMP TABLE in_resource (id bigint PRIMARY KEY);
+\copy in_resource FROM 'kungalgame_resources.csv'
+
+-- Root keep-set, then close it over merged_into_id chains so the thread
+-- self-FK stays satisfied after the delete.
+CREATE TEMP TABLE keep_thread (id bigint PRIMARY KEY);
+INSERT INTO keep_thread
+WITH RECURSIVE roots AS (
+  SELECT t.id
+  FROM community_thread t
+  WHERE t.site <> 'kungal'
+     OR (t.anchor_kind = 1 AND t.anchor_id ~ '^[0-9]+$'
+         AND t.anchor_id::bigint IN (SELECT id FROM in_galgame))
+     OR (t.anchor_kind = 2
+         AND split_part(t.anchor_id, ':', 1) IN ('quiz', 'toolset', 'website'))
+     OR (t.anchor_kind = 2 AND split_part(t.anchor_id, ':', 1) = 'resource'
+         AND split_part(t.anchor_id, ':', 2) ~ '^[0-9]+$'
+         AND split_part(t.anchor_id, ':', 2)::bigint IN (SELECT id FROM in_resource))
+), chain AS (
+  SELECT t.id, t.merged_into_id
+  FROM community_thread t JOIN roots r ON r.id = t.id
+  UNION
+  SELECT t.id, t.merged_into_id
+  FROM community_thread t JOIN chain c ON t.id = c.merged_into_id
+)
+SELECT DISTINCT id FROM chain;
+
+CREATE TEMP TABLE keep_post (id bigint PRIMARY KEY);
+INSERT INTO keep_post
+SELECT id FROM community_post WHERE thread_id IN (SELECT id FROM keep_thread);
+
+-- Children of posts first (soft refs, but keep the discipline), then posts,
+-- then threads.
+DELETE FROM community_reaction   WHERE post_id NOT IN (SELECT id FROM keep_post);
+DELETE FROM community_flag       WHERE post_id NOT IN (SELECT id FROM keep_post);
+DELETE FROM community_review_item WHERE post_id NOT IN (SELECT id FROM keep_post);
+DELETE FROM community_thread_user WHERE thread_id NOT IN (SELECT id FROM keep_thread);
+DELETE FROM community_post       WHERE id NOT IN (SELECT id FROM keep_post);
+DELETE FROM community_thread     WHERE id NOT IN (SELECT id FROM keep_thread);
+
+-- Platform uids still referenced by the kept rows. Exported for the
+-- kun_galgame_infra prune; trust rows shrink to the same set.
+CREATE TEMP TABLE keep_user (id bigint PRIMARY KEY);
+INSERT INTO keep_user
+SELECT DISTINCT u FROM (
+  SELECT author_id        FROM community_post
+  UNION SELECT target_user_id FROM community_post
+  UNION SELECT created_by     FROM community_thread
+  UNION SELECT fb_responder_id FROM community_thread
+  UNION SELECT user_id        FROM community_reaction
+  UNION SELECT flagger_id     FROM community_flag
+  UNION SELECT decided_by     FROM community_review_item
+  UNION SELECT user_id        FROM community_thread_user
+) s(u) WHERE u IS NOT NULL;
+
+DELETE FROM community_trust WHERE user_id NOT IN (SELECT id FROM keep_user);
+
+COMMIT;
+
+\copy (SELECT id FROM keep_user ORDER BY id) TO 'kun_community_users.csv'

--- a/scripts/dev-seed/prune/kun_galgame_infra.sql
+++ b/scripts/dev-seed/prune/kun_galgame_infra.sql
@@ -1,0 +1,85 @@
+-- Prune kun_galgame_infra (platform accounts / OAuth / sites) to the users the
+-- other seeds still reference. Runs LAST among the user-bearing DBs: it reads
+-- the kept-user id lists exported by prune/kungalgame.sql (forum-local ids),
+-- prune/kungalgame_patch.sql (patch-local ids) and prune/kun_community.sql
+-- (platform uids), and maps the site-local ones through user_migrations.
+--
+-- Kept wholesale: sites, oauth_clients, roles, signing_keys, developer_api_*
+-- (all tiny, all needed for a working dev login). Ephemeral credential tables
+-- (sessions / password_resets / authorization_codes) are emptied: a seed has
+-- no business carrying tokens, scrubbed or not.
+
+-- CSV paths are CWD-relative: \copy does not interpolate psql variables, so
+-- build-seed.sh runs this file with CWD = the shared export directory.
+
+BEGIN;
+
+CREATE TEMP TABLE in_kungal (id bigint PRIMARY KEY);
+\copy in_kungal FROM 'kungalgame_users.csv'
+CREATE TEMP TABLE in_moyu (id bigint PRIMARY KEY);
+\copy in_moyu FROM 'kungalgame_patch_users.csv'
+CREATE TEMP TABLE in_platform (id bigint PRIMARY KEY);
+\copy in_platform FROM 'kun_community_users.csv'
+
+CREATE TEMP TABLE keep_user (id bigint PRIMARY KEY);
+INSERT INTO keep_user
+SELECT DISTINCT u FROM (
+  -- site-local ids mapped to platform accounts
+  SELECT user_id FROM user_migrations
+    WHERE source_db = 'kungal' AND source_user_id IN (SELECT id FROM in_kungal)
+  UNION
+  SELECT user_id FROM user_migrations
+    WHERE source_db = 'moyu' AND source_user_id IN (SELECT id FROM in_moyu)
+  UNION
+  -- post-migration site accounts carry the platform uid directly as their
+  -- site-local id and have NO user_migrations row — resolve those verbatim
+  SELECT u.id FROM users u
+    WHERE u.id IN (SELECT id FROM in_kungal)
+      AND NOT EXISTS (SELECT 1 FROM user_migrations um
+                      WHERE um.source_db = 'kungal' AND um.source_user_id = u.id)
+  UNION
+  SELECT u.id FROM users u
+    WHERE u.id IN (SELECT id FROM in_moyu)
+      AND NOT EXISTS (SELECT 1 FROM user_migrations um
+                      WHERE um.source_db = 'moyu' AND um.source_user_id = u.id)
+  UNION
+  -- community exports platform uids directly; guard against stray ids
+  SELECT id FROM users WHERE id IN (SELECT id FROM in_platform)
+  UNION
+  -- privileged accounts always ride along (admin console needs them)
+  SELECT user_id FROM user_roles
+  UNION SELECT user_id    FROM user_site_roles
+  UNION SELECT granted_by FROM user_site_roles
+  UNION SELECT created_by_user_id FROM sites
+) s(u) WHERE u IS NOT NULL;
+
+-- Plus a deterministic sample of the newest accounts.
+INSERT INTO keep_user
+SELECT id FROM users ORDER BY id DESC LIMIT :seed_users
+ON CONFLICT DO NOTHING;
+
+-- Ephemeral credential tables: schema only. creator_applications joins them:
+-- its evidence/message columns are private user submissions the snapshot
+-- scrub does not touch, so a redistributable seed must not carry them.
+TRUNCATE sessions, password_resets, authorization_codes, creator_applications;
+
+-- FK children of users first, then users.
+DELETE FROM oauth_accounts  WHERE user_id NOT IN (SELECT id FROM keep_user);
+DELETE FROM user_follows    WHERE follower_id  NOT IN (SELECT id FROM keep_user)
+                               OR following_id NOT IN (SELECT id FROM keep_user);
+DELETE FROM user_roles      WHERE user_id NOT IN (SELECT id FROM keep_user);
+DELETE FROM user_migrations WHERE user_id NOT IN (SELECT id FROM keep_user);
+DELETE FROM user_site_data  WHERE user_id NOT IN (SELECT id FROM keep_user);
+-- Soft references (no FK) pruned to the same set.
+DELETE FROM moemoepoint_log
+  WHERE user_id NOT IN (SELECT id FROM keep_user)
+     OR (actor_user_id IS NOT NULL AND actor_user_id NOT IN (SELECT id FROM keep_user));
+DELETE FROM users WHERE id NOT IN (SELECT id FROM keep_user);
+
+-- Caps on log-ish tables that survive per-user filtering.
+DELETE FROM moemoepoint_log
+  WHERE id NOT IN (SELECT id FROM moemoepoint_log ORDER BY id DESC LIMIT 5000);
+DELETE FROM job_run
+  WHERE id NOT IN (SELECT id FROM job_run ORDER BY id DESC LIMIT 200);
+
+COMMIT;

--- a/scripts/dev-seed/prune/kun_images.sql
+++ b/scripts/dev-seed/prune/kun_images.sql
@@ -1,0 +1,17 @@
+-- Prune kun_images to a small metadata sample. Image BYTES live in prod
+-- MinIO/CDN and are not part of any seed, so content-side hash references
+-- dangle in dev no matter what we keep — the sample exists to exercise the
+-- image admin console and the usage bookkeeping, not to resolve every hash.
+
+BEGIN;
+
+TRUNCATE image_moderation_queue;
+
+CREATE TEMP TABLE keep_image (id bigint PRIMARY KEY, hash text);
+INSERT INTO keep_image
+SELECT id, hash FROM images ORDER BY id DESC LIMIT 2000;
+
+DELETE FROM image_site_usage WHERE hash NOT IN (SELECT hash FROM keep_image);
+DELETE FROM images           WHERE id   NOT IN (SELECT id   FROM keep_image);
+
+COMMIT;

--- a/scripts/dev-seed/prune/kungalgame.sql
+++ b/scripts/dev-seed/prune/kungalgame.sql
@@ -1,0 +1,404 @@
+-- ============================================================================
+-- dev-seed prune: kungalgame (forum database)
+--
+-- Shrinks a full copy of the `kungalgame` forum DB down to a few hundred
+-- entities with full FK closure, for the tiny collaborator seed dump.
+--
+-- Invocation (orchestrator):
+--   psql -h localhost -p 5432 -U postgres -v ON_ERROR_STOP=1 -q \
+--     -d kungalgame_seedbuild \
+--     -v export_dir=<dir> -v seed_works=300 -v seed_topics=300 -v seed_users=400 \
+--     -f prune/kungalgame.sql
+--
+-- Design notes:
+--   * FK constraints stay enforced the whole time. Deletion order relies on
+--     the schema's declared ON DELETE CASCADE for parent->child fans, and
+--     deletes RESTRICT children (galgame_rating) explicitly before parents.
+--   * The `user` table has NO incoming FK constraints in this schema: every
+--     user reference (user_id / sender_id / author_id / ...) is a soft
+--     reference. Kept-user closure is therefore computed here and the big
+--     per-user tables are pruned against it; residual soft-ref orphans are
+--     counted and reported at the end.
+--   * Deterministic: roots are the newest N rows by id; caps use ORDER BY id.
+-- ============================================================================
+
+-- Fail early if a required variable was not passed.
+\if :{?export_dir}
+\else
+  \echo 'FATAL: -v export_dir=... is required'
+  \quit 1
+\endif
+\if :{?seed_works}
+\else
+  \echo 'FATAL: -v seed_works=... is required'
+  \quit 1
+\endif
+\if :{?seed_topics}
+\else
+  \echo 'FATAL: -v seed_topics=... is required'
+  \quit 1
+\endif
+\if :{?seed_users}
+\else
+  \echo 'FATAL: -v seed_users=... is required'
+  \quit 1
+\endif
+
+-- ----------------------------------------------------------------------------
+-- Section 0: snapshot before-counts of every public table (for the report)
+-- ----------------------------------------------------------------------------
+CREATE TEMP TABLE _seed_counts (phase text, tbl text, n bigint);
+
+DO $$
+DECLARE r record; c bigint;
+BEGIN
+  FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
+    EXECUTE format('SELECT count(*) FROM %I', r.tablename) INTO c;
+    INSERT INTO _seed_counts VALUES ('before', r.tablename, c);
+  END LOOP;
+END $$;
+
+-- ----------------------------------------------------------------------------
+-- Section 1: root keep-sets — newest topics and newest galgames
+-- ----------------------------------------------------------------------------
+CREATE TEMP TABLE keep_topic AS
+  SELECT id FROM topic ORDER BY id DESC LIMIT :seed_topics;
+ALTER TABLE keep_topic ADD PRIMARY KEY (id);
+
+CREATE TEMP TABLE keep_galgame AS
+  SELECT id FROM galgame ORDER BY id DESC LIMIT :seed_works;
+ALTER TABLE keep_galgame ADD PRIMARY KEY (id);
+
+-- Quizzes: linked to galgames only through galgame_quiz_galgame
+-- (galgame_quiz.galgame_id is 0 for every row in this schema).
+-- Keep a quiz if it has no galgame links at all, or at least one link to a
+-- kept galgame.
+CREATE TEMP TABLE keep_quiz AS
+  SELECT q.id FROM galgame_quiz q
+  WHERE NOT EXISTS (SELECT 1 FROM galgame_quiz_galgame l WHERE l.quiz_id = q.id)
+     OR EXISTS (SELECT 1 FROM galgame_quiz_galgame l
+                JOIN keep_galgame kg ON kg.id = l.galgame_id
+                WHERE l.quiz_id = q.id);
+ALTER TABLE keep_quiz ADD PRIMARY KEY (id);
+
+-- ----------------------------------------------------------------------------
+-- Section 2: kept-user closure
+--   participants of kept content
+--   UNION staff-ish authors of small site-wide content (docs / update log /
+--         todo / permission audit) — the `user` table itself carries no
+--         role/status columns in this DB, so these stand in for admins
+--   UNION authors of small sections kept wholesale (toolsets, websites, quizzes)
+--   UNION the newest :seed_users users by id
+-- Everything is intersected with the real user table at the end.
+-- ----------------------------------------------------------------------------
+CREATE TEMP TABLE keep_user AS
+SELECT DISTINCT uid FROM (
+  -- topic authors of kept topics
+  SELECT t.user_id AS uid FROM topic t JOIN keep_topic k ON k.id = t.id
+  UNION ALL
+  -- reply / comment authors on kept topics
+  SELECT r.user_id FROM topic_reply r JOIN keep_topic k ON k.id = r.topic_id
+  UNION ALL
+  SELECT c.user_id FROM topic_comment c JOIN keep_topic k ON k.id = c.topic_id
+  UNION ALL
+  -- galgame contributors on kept galgames: creator, wiki-edit actors,
+  -- resource uploaders
+  SELECT g.creator_user_id FROM galgame g JOIN keep_galgame k ON k.id = g.id
+  WHERE g.creator_user_id IS NOT NULL
+  UNION ALL
+  SELECT a.user_id FROM galgame_activity a JOIN keep_galgame k ON k.id = a.galgame_id
+  UNION ALL
+  SELECT r.user_id FROM galgame_resource r JOIN keep_galgame k ON k.id = r.galgame_id
+  UNION ALL
+  -- staff-ish soft references from site-wide singletons (stand-in for admins)
+  SELECT author_id FROM doc_article
+  UNION ALL
+  SELECT user_id FROM update_log
+  UNION ALL
+  SELECT user_id FROM todo
+  UNION ALL
+  SELECT updated_by FROM role_permission_override
+  UNION ALL
+  SELECT operator_id FROM permission_audit_log
+  UNION ALL
+  -- authors of small sections that are kept wholesale
+  SELECT user_id FROM galgame_toolset
+  UNION ALL
+  SELECT user_id FROM galgame_toolset_resource
+  UNION ALL
+  SELECT user_id FROM galgame_toolset_contributor
+  UNION ALL
+  SELECT user_id FROM galgame_website
+  UNION ALL
+  SELECT q.user_id FROM galgame_quiz q JOIN keep_quiz k ON k.id = q.id
+  UNION ALL
+  -- newest N users by id
+  SELECT id FROM (SELECT id FROM "user" ORDER BY id DESC LIMIT :seed_users) newest
+) refs
+WHERE uid IS NOT NULL
+  AND EXISTS (SELECT 1 FROM "user" u WHERE u.id = refs.uid);
+ALTER TABLE keep_user ADD PRIMARY KEY (uid);
+
+-- ----------------------------------------------------------------------------
+-- Section 3: topic-side prune
+-- ----------------------------------------------------------------------------
+-- Dropping a topic cascades to: topic_reply (and its likes/dislikes/reactions
+-- via reply FK), topic_comment (+likes), topic_like/dislike/favorite/upvote,
+-- topic_reaction has no FK -> handled explicitly below, topic_poll
+-- (+options/votes), topic_section_relation.
+DELETE FROM topic WHERE id NOT IN (SELECT id FROM keep_topic);
+
+-- topic_reaction carries no FK to topic: prune to kept topics x kept users.
+DELETE FROM topic_reaction
+WHERE topic_id NOT IN (SELECT id FROM keep_topic)
+   OR user_id  NOT IN (SELECT uid FROM keep_user);
+
+-- Engagement rows on kept topics: restrict to kept users.
+DELETE FROM topic_like     WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM topic_dislike  WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM topic_upvote   WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM topic_favorite WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM topic_reply_like     WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM topic_reply_dislike  WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM topic_reply_reaction WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM topic_comment_like   WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM topic_poll_vote      WHERE user_id NOT IN (SELECT uid FROM keep_user);
+
+-- Per-user drafts.
+DELETE FROM topic_draft WHERE user_id NOT IN (SELECT uid FROM keep_user);
+
+-- ----------------------------------------------------------------------------
+-- Section 4: galgame-side prune
+-- ----------------------------------------------------------------------------
+-- galgame_rating references galgame with ON DELETE RESTRICT: remove ratings
+-- of dropped galgames first (cascades rating comments / likes), and restrict
+-- ratings on kept galgames to kept users.
+DELETE FROM galgame_rating
+WHERE galgame_id NOT IN (SELECT id FROM keep_galgame)
+   OR user_id    NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_rating_comment WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_rating_like    WHERE user_id NOT IN (SELECT uid FROM keep_user);
+
+-- Dropping a galgame cascades to: galgame_comment (+likes via comment FK),
+-- galgame_like, galgame_favorite, galgame_resource (+link/provider/like).
+DELETE FROM galgame WHERE id NOT IN (SELECT id FROM keep_galgame);
+
+-- Engagement on kept galgames: restrict to kept users. Galgame comment
+-- authors are not part of the kept-user closure, so their comments go too
+-- (descendant comments cascade through the parent/root comment FKs).
+DELETE FROM galgame_like     WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_favorite WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_comment  WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_comment_like  WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_resource_like WHERE user_id NOT IN (SELECT uid FROM keep_user);
+
+-- Wiki-edit activity rows of dropped galgames (soft galgame ref, no FK).
+DELETE FROM galgame_activity WHERE galgame_id NOT IN (SELECT id FROM keep_galgame);
+
+-- Community-thread migration maps carry soft refs only: keep rows whose
+-- underlying comment/galgame survived.
+DELETE FROM galgame_comment_community_map
+WHERE galgame_id NOT IN (SELECT id FROM keep_galgame)
+   OR old_comment_id NOT IN (SELECT id FROM galgame_comment);
+DELETE FROM resource_comment_community_map
+WHERE (source = 'rating'  AND old_id NOT IN (SELECT id FROM galgame_rating_comment))
+   OR (source = 'toolset' AND old_id NOT IN (SELECT id FROM galgame_toolset_comment))
+   OR (source = 'website' AND old_id NOT IN (SELECT id FROM galgame_website_comment));
+
+-- Likes on community posts about galgames (post_id lives in the community DB).
+DELETE FROM galgame_post_like WHERE user_id NOT IN (SELECT uid FROM keep_user);
+
+-- Collections: folders of kept users only (cascade items + viewers), then
+-- drop items pointing at dropped galgames and viewers who are not kept.
+DELETE FROM galgame_collection WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_collection_item
+WHERE galgame_id NOT IN (SELECT id FROM keep_galgame)
+   OR user_id    NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_collection_viewer WHERE user_id NOT IN (SELECT uid FROM keep_user);
+
+-- ----------------------------------------------------------------------------
+-- Section 5: quizzes / toolsets / websites (small sections)
+-- ----------------------------------------------------------------------------
+-- Quiz-galgame links to dropped galgames, then quizzes that lost every link
+-- (cascades answers / favorites / links).
+DELETE FROM galgame_quiz_galgame WHERE galgame_id NOT IN (SELECT id FROM keep_galgame);
+DELETE FROM galgame_quiz WHERE id NOT IN (SELECT id FROM keep_quiz);
+DELETE FROM galgame_quiz_answer   WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_quiz_favorite WHERE user_id NOT IN (SELECT uid FROM keep_user);
+-- Per-quiz analytics: only for surviving quizzes.
+DELETE FROM galgame_quiz_view_daily WHERE entity_id NOT IN (SELECT id FROM keep_quiz);
+
+-- Toolsets and websites are kept wholesale (their authors joined keep_user);
+-- restrict per-user engagement rows to kept users.
+DELETE FROM galgame_toolset_comment      WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_toolset_practicality WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_website_comment  WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_website_like     WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM galgame_website_favorite WHERE user_id NOT IN (SELECT uid FROM keep_user);
+
+-- ----------------------------------------------------------------------------
+-- Section 6: chat
+-- ----------------------------------------------------------------------------
+-- Keep the newest 200 rooms in which every participant is a kept user.
+-- Dropping a room cascades to messages, participants, admins, and message
+-- reactions / read receipts (via the chat_message FK).
+CREATE TEMP TABLE keep_chat_room AS
+  SELECT r.id FROM chat_room r
+  WHERE NOT EXISTS (
+          SELECT 1 FROM chat_room_participant p
+          WHERE p.chat_room_id = r.id
+            AND p.user_id NOT IN (SELECT uid FROM keep_user))
+    AND EXISTS (SELECT 1 FROM chat_room_participant p WHERE p.chat_room_id = r.id)
+  ORDER BY r.id DESC LIMIT 200;
+
+DELETE FROM chat_room WHERE id NOT IN (SELECT id FROM keep_chat_room);
+
+-- ----------------------------------------------------------------------------
+-- Section 7: notifications, feed, per-user state
+-- ----------------------------------------------------------------------------
+-- message (notifications): only between kept users, capped at 5,000 newest.
+DELETE FROM message
+WHERE sender_id   NOT IN (SELECT uid FROM keep_user)
+   OR receiver_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM message
+WHERE id NOT IN (SELECT id FROM message ORDER BY id DESC LIMIT 5000);
+
+-- feed_activity: rows by kept users about kept content, capped at 5,000
+-- newest. galgame_id and source_id are soft refs whose target depends on
+-- `type`; rows about content that did not survive are dropped.
+DELETE FROM feed_activity WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM feed_activity
+WHERE galgame_id <> 0 AND galgame_id NOT IN (SELECT id FROM keep_galgame);
+DELETE FROM feed_activity
+WHERE (type IN ('TOPIC_CREATION', 'TOPIC_UPVOTE')
+         AND source_id NOT IN (SELECT id FROM keep_topic))
+   OR (type = 'TOPIC_REPLY_CREATION'
+         AND source_id NOT IN (SELECT id FROM topic_reply))
+   OR (type = 'TOPIC_COMMENT_CREATION'
+         AND source_id NOT IN (SELECT id FROM topic_comment))
+   OR (type = 'GALGAME_QUIZ_CREATION'
+         AND source_id NOT IN (SELECT id FROM keep_quiz));
+DELETE FROM feed_activity
+WHERE id NOT IN (SELECT id FROM feed_activity ORDER BY id DESC LIMIT 5000);
+
+-- Per-user state rows for kept users only.
+DELETE FROM kungal_user_state WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM wiki_message_read_state WHERE user_id NOT IN (SELECT uid FROM keep_user);
+
+-- System-message read cursors: kept users, capped at the 2,000 newest.
+DELETE FROM system_message_read_state WHERE user_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM system_message_read_state
+WHERE user_id NOT IN (SELECT user_id FROM system_message_read_state
+                      ORDER BY user_id DESC LIMIT 2000);
+
+-- Social graph: both endpoints must be kept.
+DELETE FROM user_follow
+WHERE follower_id NOT IN (SELECT uid FROM keep_user)
+   OR followed_id NOT IN (SELECT uid FROM keep_user);
+DELETE FROM user_friend
+WHERE user_id   NOT IN (SELECT uid FROM keep_user)
+   OR friend_id NOT IN (SELECT uid FROM keep_user);
+
+-- Per-user permission overrides (empty in practice, kept consistent anyway).
+DELETE FROM user_permission_override WHERE user_id NOT IN (SELECT uid FROM keep_user);
+
+-- ----------------------------------------------------------------------------
+-- Section 8: users (no incoming FK constraints — soft refs only)
+-- ----------------------------------------------------------------------------
+DELETE FROM "user" WHERE id NOT IN (SELECT uid FROM keep_user);
+
+-- ----------------------------------------------------------------------------
+-- Section 9: analytics tables
+-- ----------------------------------------------------------------------------
+TRUNCATE galgame_view_daily;
+TRUNCATE topic_view_daily;
+
+-- ----------------------------------------------------------------------------
+-- Section 10: report — before/after counts, hard bar, orphan spot-checks
+-- ----------------------------------------------------------------------------
+DO $$
+DECLARE r record; c bigint;
+BEGIN
+  FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
+    EXECUTE format('SELECT count(*) FROM %I', r.tablename) INTO c;
+    INSERT INTO _seed_counts VALUES ('after', r.tablename, c);
+  END LOOP;
+END $$;
+
+\echo '=== kungalgame prune: before -> after (changed tables) ==='
+SELECT b.tbl, b.n AS before, a.n AS after
+FROM _seed_counts b
+JOIN _seed_counts a ON a.tbl = b.tbl AND a.phase = 'after'
+WHERE b.phase = 'before' AND b.n <> a.n
+ORDER BY b.n - a.n DESC;
+
+\echo '=== hard bar check: tables still over 20,000 rows (must be empty) ==='
+SELECT tbl, n FROM _seed_counts WHERE phase = 'after' AND n > 20000;
+
+-- Fail the run loudly if any table busts the row cap.
+DO $$
+DECLARE bad int;
+BEGIN
+  SELECT count(*) INTO bad FROM _seed_counts WHERE phase = 'after' AND n > 20000;
+  IF bad > 0 THEN
+    RAISE EXCEPTION 'seed prune failed: % table(s) exceed 20,000 rows', bad;
+  END IF;
+END $$;
+
+\echo '=== soft-reference orphan spot-checks (user refs without FK) ==='
+SELECT 'topic_comment.target_user_id' AS ref, count(*) AS orphans
+  FROM topic_comment c
+  WHERE target_user_id IS NOT NULL AND target_user_id <> 0
+    AND NOT EXISTS (SELECT 1 FROM "user" u WHERE u.id = c.target_user_id)
+UNION ALL
+SELECT 'galgame_rating_comment.target_user_id', count(*)
+  FROM galgame_rating_comment c
+  WHERE target_user_id IS NOT NULL AND target_user_id <> 0
+    AND NOT EXISTS (SELECT 1 FROM "user" u WHERE u.id = c.target_user_id)
+UNION ALL
+SELECT 'chat_room.last_message_sender_id', count(*)
+  FROM chat_room r
+  WHERE last_message_sender_id IS NOT NULL AND last_message_sender_id <> 0
+    AND NOT EXISTS (SELECT 1 FROM "user" u WHERE u.id = r.last_message_sender_id)
+UNION ALL
+SELECT 'system_message.user_id', count(*)
+  FROM system_message m
+  WHERE user_id IS NOT NULL AND user_id <> 0
+    AND NOT EXISTS (SELECT 1 FROM "user" u WHERE u.id = m.user_id)
+UNION ALL
+SELECT 'topic.best_answer_id (cross-check)', count(*)
+  FROM topic t
+  WHERE best_answer_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM topic_reply r WHERE r.id = t.best_answer_id);
+
+-- ----------------------------------------------------------------------------
+-- Section 11: export kept ids for the downstream platform/community prunes
+-- ----------------------------------------------------------------------------
+-- NOTE: \copy passes its arguments raw and performs NO psql variable
+-- interpolation (verified), so the files are written via \o redirection +
+-- server-side COPY TO STDOUT, where :var interpolation does work (verified).
+\set f_users     :export_dir '/kungalgame_users.csv'
+\set f_topics    :export_dir '/kungalgame_topics.csv'
+\set f_galgames  :export_dir '/kungalgame_galgames.csv'
+\set f_resources :export_dir '/kungalgame_resources.csv'
+
+\o :f_users
+COPY (SELECT id FROM "user" ORDER BY id) TO STDOUT WITH (FORMAT csv);
+\o
+\o :f_topics
+COPY (SELECT id FROM topic ORDER BY id) TO STDOUT WITH (FORMAT csv);
+\o
+\o :f_galgames
+COPY (SELECT id FROM galgame ORDER BY id) TO STDOUT WITH (FORMAT csv);
+\o
+\o :f_resources
+COPY (SELECT id FROM galgame_resource ORDER BY id) TO STDOUT WITH (FORMAT csv);
+\o
+
+\echo '=== export done ==='
+\echo 'users     -> ' :f_users
+\echo 'topics    -> ' :f_topics
+\echo 'galgames  -> ' :f_galgames
+\echo 'resources -> ' :f_resources
+
+ANALYZE;

--- a/scripts/dev-seed/prune/kungalgame_patch.sql
+++ b/scripts/dev-seed/prune/kungalgame_patch.sql
@@ -1,0 +1,319 @@
+-- =============================================================================
+-- dev-seed prune: kungalgame_patch (moyu.moe patch site)
+-- =============================================================================
+-- Shrinks a full scratch copy (TEMPLATE'd from the desensitised prod snapshot)
+-- down to the newest :seed_works patches plus full FK closure, for a tiny
+-- collaborator seed dump.
+--
+-- Invocation (orchestrator):
+--   psql -h localhost -p 5432 -U postgres -v ON_ERROR_STOP=1 -q \
+--     -d kungalgame_patch_seedbuild \
+--     -v export_dir=<dir> -v seed_works=300 -v seed_topics=300 -v seed_users=400 \
+--     -f prune/kungalgame_patch.sql
+--
+-- Variables used: :seed_works, :seed_users, :export_dir.
+-- :seed_topics is accepted but intentionally unused — this database has no
+-- topic concept (forum topics live in the platform DB).
+--
+-- Technique: FK constraints stay enforced. Keep-sets are materialised in TEMP
+-- tables, then children are deleted before parents; any closure mistake fails
+-- loudly as an FK violation. Fully deterministic (all sampling is ORDER BY id).
+--
+-- Schema notes discovered against the 2026-08 snapshot:
+--   * The desensitised "user" table carries NO role / name / email columns,
+--     so "admins & moderators" are approximated by the distinct actors of
+--     admin_log (18 users in the snapshot).
+--   * Soft (non-FK) reference columns: patch.creator_id, doc.author_uid,
+--     doc.user_id, claim_event_processed.actor_uid / work_id,
+--     patch_resource_revision.actor_id, patch_resource_file_history.actor_id.
+--     Orphan counts for these are reported at the end.
+--   * Left untouched (small config / vocab / ledger tables): doc, cron_state,
+--     site_setting, _migrations, wiki_message_processed, claim_event_processed,
+--     wiki_message_read_state, trust_disposition_applied.
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- Section 0: row counts before pruning (for the change report at the end)
+-- -----------------------------------------------------------------------------
+CREATE TEMP TABLE _rows_before (tbl text PRIMARY KEY, n bigint NOT NULL);
+
+DO $$
+DECLARE t text;
+BEGIN
+  FOR t IN
+    SELECT c.relname FROM pg_class c
+    JOIN pg_namespace ns ON ns.oid = c.relnamespace
+    WHERE ns.nspname = 'public' AND c.relkind = 'r'
+  LOOP
+    EXECUTE format(
+      'INSERT INTO _rows_before SELECT %L, count(*) FROM %I', t, t);
+  END LOOP;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- Section 1: keep-sets
+-- -----------------------------------------------------------------------------
+
+-- Roots: the newest :seed_works patches by id.
+CREATE TEMP TABLE keep_patch (id int PRIMARY KEY);
+INSERT INTO keep_patch
+SELECT id FROM patch ORDER BY id DESC LIMIT :seed_works;
+
+-- All resources attached to kept patches.
+CREATE TEMP TABLE keep_resource (id int PRIMARY KEY);
+INSERT INTO keep_resource
+SELECT r.id FROM patch_resource r JOIN keep_patch kp ON kp.id = r.galgame_id;
+
+-- All comments on kept patches (whole threads: parent chains never cross
+-- patches, so filtering by galgame_id keeps every ancestor of a kept comment).
+CREATE TEMP TABLE keep_comment (id int PRIMARY KEY);
+INSERT INTO keep_comment
+SELECT c.id FROM patch_comment c JOIN keep_patch kp ON kp.id = c.galgame_id;
+
+-- Users to keep:
+--   (a) authors of kept patches (patch.user_id, hard FK) and their soft
+--       creator_id when it still resolves to a real user;
+--   (b) uploaders of kept resources;
+--   (c) authors of comments on kept patches;
+--   (d) admin_log actors (role columns do not exist in this desensitised
+--       snapshot; acting-in-admin_log is the closest admin/moderator signal);
+--   (e) the newest :seed_users users by id.
+CREATE TEMP TABLE keep_user (id int PRIMARY KEY);
+INSERT INTO keep_user
+SELECT DISTINCT id FROM (
+  SELECT p.user_id       AS id FROM patch p JOIN keep_patch kp ON kp.id = p.id
+  UNION
+  SELECT p.creator_id    AS id FROM patch p JOIN keep_patch kp ON kp.id = p.id
+  WHERE p.creator_id IS NOT NULL
+    AND EXISTS (SELECT 1 FROM "user" u WHERE u.id = p.creator_id)
+  UNION
+  SELECT r.user_id       AS id FROM patch_resource r
+  JOIN keep_resource kr ON kr.id = r.id
+  UNION
+  SELECT c.user_id       AS id FROM patch_comment c
+  JOIN keep_comment kc ON kc.id = c.id
+  UNION
+  SELECT DISTINCT user_id AS id FROM admin_log
+  UNION
+  -- Parenthesised subselect: a bare ORDER BY/LIMIT here would bind to the
+  -- whole UNION and silently cap the entire keep set.
+  SELECT id FROM
+    (SELECT id FROM "user" ORDER BY id DESC LIMIT :seed_users) newest
+) s;
+
+-- Chat rooms kept: every member must be a kept user; cap at the newest 200
+-- rooms by id to stay small.
+CREATE TEMP TABLE keep_room (id int PRIMARY KEY);
+INSERT INTO keep_room
+SELECT cr.id FROM chat_room cr
+WHERE NOT EXISTS (
+  SELECT 1 FROM chat_member m
+  LEFT JOIN keep_user ku ON ku.id = m.user_id
+  WHERE m.chat_room_id = cr.id AND ku.id IS NULL
+)
+ORDER BY cr.id DESC LIMIT 200;
+
+-- Chat messages kept: in a kept room, from a kept sender (a sender may have
+-- left the room, so membership alone does not guarantee the sender is kept).
+CREATE TEMP TABLE keep_chat_message (id int PRIMARY KEY);
+INSERT INTO keep_chat_message
+SELECT cm.id FROM chat_message cm
+JOIN keep_room kr ON kr.id = cm.chat_room_id
+JOIN keep_user ku ON ku.id = cm.sender_id;
+
+-- Direct messages kept: both endpoints kept, capped at the ~3,000 newest.
+CREATE TEMP TABLE keep_user_message (id int PRIMARY KEY);
+INSERT INTO keep_user_message
+SELECT um.id FROM user_message um
+JOIN keep_user s ON s.id = um.sender_id
+JOIN keep_user r ON r.id = um.recipient_id
+ORDER BY um.id DESC LIMIT 3000;
+
+-- Admin log kept: the newest 500 entries (all actors are kept via rule (d)).
+CREATE TEMP TABLE keep_admin_log (id int PRIMARY KEY);
+INSERT INTO keep_admin_log
+SELECT id FROM admin_log ORDER BY id DESC LIMIT 500;
+
+ANALYZE keep_patch; ANALYZE keep_resource; ANALYZE keep_comment;
+ANALYZE keep_user;  ANALYZE keep_room;     ANALYZE keep_chat_message;
+ANALYZE keep_user_message; ANALYZE keep_admin_log;
+
+-- -----------------------------------------------------------------------------
+-- Section 2: truncate the stray backup table
+-- -----------------------------------------------------------------------------
+TRUNCATE TABLE patch_resource_update_time_bak_20260606;
+
+-- -----------------------------------------------------------------------------
+-- Section 3: deletes, children before parents
+-- -----------------------------------------------------------------------------
+
+-- 3.1 chat subtree ------------------------------------------------------------
+DELETE FROM chat_message_seen s
+WHERE NOT EXISTS (SELECT 1 FROM keep_chat_message k WHERE k.id = s.chat_message_id)
+   OR NOT EXISTS (SELECT 1 FROM keep_user ku WHERE ku.id = s.user_id);
+
+DELETE FROM chat_message_reaction x
+WHERE NOT EXISTS (SELECT 1 FROM keep_chat_message k WHERE k.id = x.chat_message_id)
+   OR NOT EXISTS (SELECT 1 FROM keep_user ku WHERE ku.id = x.user_id);
+
+DELETE FROM chat_message_edit_history h
+WHERE NOT EXISTS (SELECT 1 FROM keep_chat_message k WHERE k.id = h.chat_message_id);
+
+-- reply_to_id is a self-FK ON DELETE SET NULL, so cross-references from kept
+-- messages to deleted ones null out automatically.
+DELETE FROM chat_message m
+WHERE NOT EXISTS (SELECT 1 FROM keep_chat_message k WHERE k.id = m.id);
+
+DELETE FROM chat_member m
+WHERE NOT EXISTS (SELECT 1 FROM keep_room kr WHERE kr.id = m.chat_room_id);
+
+DELETE FROM chat_room r
+WHERE NOT EXISTS (SELECT 1 FROM keep_room kr WHERE kr.id = r.id);
+
+-- 3.2 comment subtree ---------------------------------------------------------
+DELETE FROM user_patch_comment_like_relation l
+WHERE NOT EXISTS (SELECT 1 FROM keep_comment kc WHERE kc.id = l.comment_id)
+   OR NOT EXISTS (SELECT 1 FROM keep_user ku WHERE ku.id = l.user_id);
+
+DELETE FROM patch_comment c
+WHERE NOT EXISTS (SELECT 1 FROM keep_comment kc WHERE kc.id = c.id);
+
+-- 3.3 resource subtree --------------------------------------------------------
+DELETE FROM user_patch_resource_like_relation l
+WHERE NOT EXISTS (SELECT 1 FROM keep_resource kr WHERE kr.id = l.resource_id)
+   OR NOT EXISTS (SELECT 1 FROM keep_user ku WHERE ku.id = l.user_id);
+
+DELETE FROM user_patch_resource_favorite_relation f
+WHERE NOT EXISTS (SELECT 1 FROM keep_resource kr WHERE kr.id = f.resource_id)
+   OR NOT EXISTS (SELECT 1 FROM keep_user ku WHERE ku.id = f.user_id);
+
+DELETE FROM patch_resource_revision v
+WHERE NOT EXISTS (SELECT 1 FROM keep_resource kr WHERE kr.id = v.resource_id);
+
+DELETE FROM patch_resource_file_history h
+WHERE NOT EXISTS (SELECT 1 FROM keep_resource kr WHERE kr.id = h.resource_id);
+
+DELETE FROM patch_resource r
+WHERE NOT EXISTS (SELECT 1 FROM keep_resource kr WHERE kr.id = r.id);
+
+-- 3.4 remaining patch children ------------------------------------------------
+DELETE FROM patch_link l
+WHERE NOT EXISTS (SELECT 1 FROM keep_patch kp WHERE kp.id = l.galgame_id);
+
+DELETE FROM user_patch_favorite_relation f
+WHERE NOT EXISTS (SELECT 1 FROM keep_patch kp WHERE kp.id = f.galgame_id)
+   OR NOT EXISTS (SELECT 1 FROM keep_user ku WHERE ku.id = f.user_id);
+
+DELETE FROM user_patch_contribute_relation c
+WHERE NOT EXISTS (SELECT 1 FROM keep_patch kp WHERE kp.id = c.galgame_id)
+   OR NOT EXISTS (SELECT 1 FROM keep_user ku WHERE ku.id = c.user_id);
+
+-- 3.5 user children -----------------------------------------------------------
+DELETE FROM user_message m
+WHERE NOT EXISTS (SELECT 1 FROM keep_user_message k WHERE k.id = m.id);
+
+DELETE FROM admin_log a
+WHERE NOT EXISTS (SELECT 1 FROM keep_admin_log k WHERE k.id = a.id);
+
+DELETE FROM user_follow_relation f
+WHERE NOT EXISTS (SELECT 1 FROM keep_user ku WHERE ku.id = f.follower_id)
+   OR NOT EXISTS (SELECT 1 FROM keep_user ku WHERE ku.id = f.following_id);
+
+-- 3.6 parents -----------------------------------------------------------------
+-- patch.user_id is ON DELETE RESTRICT: a mistake in keep_user would abort here.
+DELETE FROM patch p
+WHERE NOT EXISTS (SELECT 1 FROM keep_patch kp WHERE kp.id = p.id);
+
+DELETE FROM "user" u
+WHERE NOT EXISTS (SELECT 1 FROM keep_user ku WHERE ku.id = u.id);
+
+-- -----------------------------------------------------------------------------
+-- Section 4: acceptance gate — no table may exceed 10,000 rows
+-- -----------------------------------------------------------------------------
+DO $$
+DECLARE t text; c bigint;
+BEGIN
+  FOR t IN
+    SELECT cl.relname FROM pg_class cl
+    JOIN pg_namespace ns ON ns.oid = cl.relnamespace
+    WHERE ns.nspname = 'public' AND cl.relkind = 'r'
+  LOOP
+    EXECUTE format('SELECT count(*) FROM %I', t) INTO c;
+    IF c > 10000 THEN
+      RAISE EXCEPTION 'acceptance gate failed: table % still has % rows (max 10000)', t, c;
+    END IF;
+  END LOOP;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- Section 5: change report (before -> after, changed tables only)
+-- -----------------------------------------------------------------------------
+CREATE TEMP TABLE _rows_after (tbl text PRIMARY KEY, n bigint NOT NULL);
+
+DO $$
+DECLARE t text;
+BEGIN
+  FOR t IN
+    SELECT cl.relname FROM pg_class cl
+    JOIN pg_namespace ns ON ns.oid = cl.relnamespace
+    WHERE ns.nspname = 'public' AND cl.relkind = 'r'
+  LOOP
+    EXECUTE format('INSERT INTO _rows_after SELECT %L, count(*) FROM %I', t, t);
+  END LOOP;
+END $$;
+
+\echo '=== prune report: rows before -> after (changed tables only) ==='
+SELECT b.tbl, b.n AS before, a.n AS after
+FROM _rows_before b
+JOIN _rows_after a USING (tbl)
+WHERE b.n <> a.n
+ORDER BY b.tbl;
+
+\echo '=== soft-reference orphan counts (no enforced FK; informational) ==='
+SELECT 'patch.creator_id -> user' AS soft_ref, count(*) AS orphans
+FROM patch p
+WHERE p.creator_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM "user" u WHERE u.id = p.creator_id)
+UNION ALL
+SELECT 'doc.author_uid -> user', count(*)
+FROM doc d
+WHERE NOT EXISTS (SELECT 1 FROM "user" u WHERE u.id = d.author_uid)
+UNION ALL
+SELECT 'doc.user_id -> user', count(*)
+FROM doc d
+WHERE d.user_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM "user" u WHERE u.id = d.user_id)
+UNION ALL
+SELECT 'claim_event_processed.actor_uid -> user', count(*)
+FROM claim_event_processed e
+WHERE NOT EXISTS (SELECT 1 FROM "user" u WHERE u.id = e.actor_uid)
+UNION ALL
+SELECT 'claim_event_processed.work_id -> patch', count(*)
+FROM claim_event_processed e
+WHERE NOT EXISTS (SELECT 1 FROM patch p WHERE p.id = e.work_id)
+UNION ALL
+SELECT 'patch_resource_revision.actor_id -> user', count(*)
+FROM patch_resource_revision v
+WHERE NOT EXISTS (SELECT 1 FROM "user" u WHERE u.id = v.actor_id)
+UNION ALL
+SELECT 'patch_resource_file_history.actor_id -> user', count(*)
+FROM patch_resource_file_history h
+WHERE NOT EXISTS (SELECT 1 FROM "user" u WHERE u.id = h.actor_id);
+
+COMMIT;
+
+-- -----------------------------------------------------------------------------
+-- Section 6: export kept user ids for the platform DB prune
+-- -----------------------------------------------------------------------------
+-- One id per line, no header. The platform prune script consumes this file.
+-- Note: psql's \copy does NOT interpolate variables in its argument (verified
+-- on psql 18), so redirect COPY TO STDOUT through \o instead — \o does
+-- interpolate its filename argument.
+\set filepath :export_dir '/kungalgame_patch_users.csv'
+\o :filepath
+COPY (SELECT id FROM "user" ORDER BY id) TO STDOUT WITH (FORMAT csv);
+\o
+\echo '=== exported kept user ids ==='
+\echo :filepath

--- a/scripts/dev-seed/publish-seed.sh
+++ b/scripts/dev-seed/publish-seed.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# publish-seed.sh — upload the latest dev-seed build as a rolling GitHub
+# Release (fixed tag, assets replaced in place). Consumers always fetch the
+# same tag; see scripts/restore-dev-seed.sh.
+#
+# Usage: ./publish-seed.sh [build-dir]   (default: the `latest` symlink)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config.sh
+source "${SCRIPT_DIR}/config.sh"
+
+DIR="$(readlink -f "${1:-${SEED_OUT_ROOT}/latest}")"
+[[ -f "${DIR}/SHA256SUMS" ]] || { echo "no build at ${DIR} — run build-seed.sh first" >&2; exit 1; }
+STAMP="$(basename "${DIR}")"
+
+if ! gh release view "${SEED_TAG}" -R "${SEED_REPO}" >/dev/null 2>&1; then
+  gh release create "${SEED_TAG}" -R "${SEED_REPO}" --latest=false \
+    --title "Dev seed data (rolling)" \
+    --notes "placeholder — replaced on first publish"
+fi
+
+gh release upload "${SEED_TAG}" -R "${SEED_REPO}" --clobber \
+  "${DIR}"/*.dump "${DIR}/MANIFEST.txt" "${DIR}/SHA256SUMS"
+
+gh release edit "${SEED_TAG}" -R "${SEED_REPO}" \
+  --title "Dev seed data (rolling, ${STAMP})" \
+  --notes "$(printf 'Lightweight desensitised dev fixture: a few hundred entities per database, full FK closure, sampled from the desensitised snapshot pipeline.\n\nRestore: `scripts/restore-dev-seed.sh` (or `pg_restore --no-owner -d <db> <db>.dump`).\nEvery seeded user logs in with password `kungal-dev`.\n\nBuilt: %s\n\n%s' "${STAMP}" "$(cat "${DIR}/MANIFEST.txt")")"
+
+echo "published ${STAMP} → https://github.com/${SEED_REPO}/releases/tag/${SEED_TAG}"

--- a/scripts/dev-seed/systemd/kungal-dev-seed.service
+++ b/scripts/dev-seed/systemd/kungal-dev-seed.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Build and publish the kungal dev-seed release
+
+[Service]
+Type=oneshot
+# Adjust if the repo lives elsewhere; install with:
+#   systemctl --user link $(pwd)/scripts/dev-seed/systemd/kungal-dev-seed.service
+#   systemctl --user enable --now $(pwd)/scripts/dev-seed/systemd/kungal-dev-seed.timer
+ExecStart=/bin/bash -lc '%h/Desktop/code/website/kun-galgame-infra/scripts/dev-seed/build-seed.sh && %h/Desktop/code/website/kun-galgame-infra/scripts/dev-seed/publish-seed.sh'

--- a/scripts/dev-seed/systemd/kungal-dev-seed.timer
+++ b/scripts/dev-seed/systemd/kungal-dev-seed.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekly kungal dev-seed rebuild + publish
+
+[Timer]
+# Monday morning; if the box was off, run on next boot (Persistent).
+OnCalendar=Mon 09:30
+Persistent=true
+RandomizedDelaySec=10m
+
+[Install]
+WantedBy=timers.target

--- a/scripts/restore-dev-seed.sh
+++ b/scripts/restore-dev-seed.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# restore-dev-seed.sh — collaborator-facing: download the rolling dev-seed
+# release and restore it into a local Postgres. Needs only `gh` (authenticated
+# with read access to the repo), `psql` and `pg_restore`.
+#
+#   ./scripts/restore-dev-seed.sh --yes
+#
+# Target coordinates (override via env):
+#   SEED_PG_HOST=localhost SEED_PG_PORT=5432 SEED_PG_USER=postgres
+#   PGPASSWORD=...            (password for that user, if any)
+#   DEVSEED_SUFFIX=           (appended to every database name; use e.g.
+#                              _seed if the plain names already hold data
+#                              you care about — restore DROPS the targets)
+
+set -euo pipefail
+
+SEED_REPO="${SEED_REPO:-KunMoe/kungal-dev-seed}"
+SEED_TAG="${SEED_TAG:-dev-seed}"
+SEED_PG_HOST="${SEED_PG_HOST:-localhost}"
+SEED_PG_PORT="${SEED_PG_PORT:-5432}"
+SEED_PG_USER="${SEED_PG_USER:-postgres}"
+DEVSEED_SUFFIX="${DEVSEED_SUFFIX:-}"
+
+if [[ "${1:-}" != "--yes" ]]; then
+  cat >&2 <<EOF
+This DROPS and recreates the seed databases (suffix: '${DEVSEED_SUFFIX}') on
+${SEED_PG_HOST}:${SEED_PG_PORT}. If any of those names already hold data you
+care about, set DEVSEED_SUFFIX or abort. Re-run with --yes to proceed.
+EOF
+  exit 1
+fi
+
+PSQL=(psql -h "${SEED_PG_HOST}" -p "${SEED_PG_PORT}" -U "${SEED_PG_USER}" -v ON_ERROR_STOP=1 -q -d postgres)
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+echo "downloading ${SEED_REPO}@${SEED_TAG} ..."
+gh release download "${SEED_TAG}" -R "${SEED_REPO}" -D "${WORK}"
+(cd "${WORK}" && sha256sum -c SHA256SUMS)
+
+for dump in "${WORK}"/*.dump; do
+  db="$(basename "${dump}" .dump)${DEVSEED_SUFFIX}"
+  echo "restoring ${db}"
+  "${PSQL[@]}" -c "DROP DATABASE IF EXISTS ${db}"
+  "${PSQL[@]}" -c "CREATE DATABASE ${db}"
+  pg_restore -h "${SEED_PG_HOST}" -p "${SEED_PG_PORT}" -U "${SEED_PG_USER}" \
+    --no-owner --no-privileges -d "${db}" "${dump}"
+done
+
+echo "done. Every seeded user's password is: kungal-dev"


### PR DESCRIPTION
Samples the local desensitised snapshot databases down to a few hundred FK-closed entities per DB (all seven core DBs, ~5MB total) and publishes them as a rolling release on the private `KunMoe/kungal-dev-seed` repo. Collaborators need only `gh` + `psql`: `./scripts/restore-dev-seed.sh --yes`. A weekly systemd user timer on the maintainer box rebuilds and republishes.

- Cross-DB user closure covers both identity eras (user_migrations + platform-uid-verbatim).
- sessions / password_resets / authorization_codes / creator_applications ship empty.
- First release is live: https://github.com/KunMoe/kungal-dev-seed/releases/tag/dev-seed (verified end-to-end: download → sha256 → restore → spot checks).