### PR TITLE
feat(dev-seed): the seed release moves onto the infra repo itself

### DIFF
--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -283,7 +283,7 @@ need *something realistic to develop against* use the **dev-seed**: a few
 hundred entities per database (full FK closure, all seven core DBs), sampled
 from the desensitised snapshot and published as a rolling GitHub Release
 (`dev-seed` tag on this repo, a few MB total). All it needs is an
-authenticated `gh` with read access to the repo, plus `psql`/`pg_restore`:
+authenticated `gh`, plus `psql`/`pg_restore`:
 
 ```sh
 ./scripts/restore-dev-seed.sh --yes            # download + verify + drop/create/restore all 7 DBs

--- a/scripts/dev-seed/config.sh
+++ b/scripts/dev-seed/config.sh
@@ -46,8 +46,10 @@ SEED_USERS=400        # per-site sampled users (content authors are always kept)
 SEED_OUT_ROOT="${HOME}/.cache/kungal-dev-seed"
 
 # Publishing target: a rolling release on a fixed tag, assets replaced in
-# place. A dedicated PRIVATE repo — kun-galgame-infra itself is public, and
-# the seed (scrubbed, but sampled from real data) is distributed by invite:
-# access control = that repo's collaborator list.
-SEED_REPO="KunMoe/kungal-dev-seed"
+# place. Lives on the infra repo itself (PUBLIC, so the seed is world-
+# downloadable) — ruled acceptable 2026-08-06: the seed is fully desensitised
+# (scrubbed content, dev-only credentials, private-submission tables shipped
+# empty), and reusing the repo the collaborators already have beats
+# maintaining a separate invite list.
+SEED_REPO="KunMoe/kun-galgame-infra"
 SEED_TAG="dev-seed"

--- a/scripts/restore-dev-seed.sh
+++ b/scripts/restore-dev-seed.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-SEED_REPO="${SEED_REPO:-KunMoe/kungal-dev-seed}"
+SEED_REPO="${SEED_REPO:-KunMoe/kun-galgame-infra}"
 SEED_TAG="${SEED_TAG:-dev-seed}"
 SEED_PG_HOST="${SEED_PG_HOST:-localhost}"
 SEED_PG_PORT="${SEED_PG_PORT:-5432}"


### PR DESCRIPTION
Supersedes the dedicated private repo `KunMoe/kungal-dev-seed`: collaborators are already on this repo, so the rolling `dev-seed` release now lives here (repo is public — acceptable per ruling: seed is fully desensitised, private-submission tables ship empty). Release already migrated and e2e-verified via `restore-dev-seed.sh`.