### PR TITLE
fix(migrate): 修复空数据库中的 OAuth 客户端迁移

### DIFF
--- a/apps/api/internal/platform/devapi/integration_test.go
+++ b/apps/api/internal/platform/devapi/integration_test.go
@@ -64,16 +64,52 @@ func TestMain(m *testing.M) {
 }
 
 // provision mirrors cmd/migrate's order for the developer-platform schema:
-// ensure the oauth_clients table exists, add the dev_* columns via raw SQL, then
-// AutoMigrate the two new tables.
+// safely pre-migrate an existing oauth_clients table, then AutoMigrate the
+// complete OAuth client and developer-platform models. On a fresh database the
+// pre-migration is a no-op and AutoMigrate creates every column.
 func provision(db *gorm.DB) error {
-	if err := db.AutoMigrate(&siteModel.Site{}, &siteModel.OAuthClient{}); err != nil {
-		return err
-	}
 	if err := AddOAuthClientDevColumns(db); err != nil {
 		return err
 	}
-	return db.AutoMigrate(Models()...)
+	models := []any{&siteModel.Site{}, &siteModel.OAuthClient{}}
+	models = append(models, Models()...)
+	return db.AutoMigrate(models...)
+}
+
+func TestFreshDatabaseMigrationOrder(t *testing.T) {
+	tx := testDB.Begin()
+	if tx.Error != nil {
+		t.Fatalf("begin fresh-schema transaction: %v", tx.Error)
+	}
+	defer tx.Rollback()
+
+	const schema = "devapi_fresh_migration_test"
+	if err := tx.Exec(`CREATE SCHEMA devapi_fresh_migration_test`).Error; err != nil {
+		t.Fatalf("create fresh schema: %v", err)
+	}
+	if err := tx.Exec(`SET LOCAL search_path TO devapi_fresh_migration_test`).Error; err != nil {
+		t.Fatalf("select fresh schema: %v", err)
+	}
+
+	if tx.Migrator().HasTable("oauth_clients") {
+		t.Fatal("fresh schema unexpectedly contains oauth_clients")
+	}
+	if err := AddOAuthClientDevColumns(tx); err != nil {
+		t.Fatalf("pre-migrate fresh schema: %v", err)
+	}
+	if tx.Migrator().HasTable("oauth_clients") {
+		t.Fatal("pre-migration must leave fresh table creation to AutoMigrate")
+	}
+
+	if err := tx.AutoMigrate(&siteModel.Site{}, &siteModel.OAuthClient{}); err != nil {
+		t.Fatalf("auto-migrate fresh schema: %v", err)
+	}
+	if !tx.Migrator().HasColumn(&siteModel.OAuthClient{}, "dev_enabled") {
+		t.Fatal("fresh oauth_clients table is missing dev_enabled")
+	}
+	if err := AddOAuthClientDevColumns(tx); err != nil {
+		t.Fatalf("re-run pre-migration on created table: %v", err)
+	}
 }
 
 func acquireSuiteLock(db *sql.DB) func() {

--- a/apps/api/internal/platform/devapi/migrate.go
+++ b/apps/api/internal/platform/devapi/migrate.go
@@ -12,10 +12,12 @@ func Models() []any {
 	return []any{&DeveloperAPIKey{}, &DeveloperAPIUsage{}}
 }
 
-// AddOAuthClientDevColumns adds the developer-platform columns to the EXISTING
-// oauth_clients table using raw SQL (裁定 8). The NOT NULL intent columns are
-// added WITH a temporary DEFAULT so existing rows backfill, then the DEFAULT is
-// dropped so the GORM zero-value INSERT trap can't reintroduce a silent default.
+// AddOAuthClientDevColumns adds the developer-platform columns to an existing
+// oauth_clients table using raw SQL (裁定 8). A fresh database is a no-op here:
+// the later AutoMigrate call creates the table with every column already
+// present. For an existing table, the NOT NULL intent columns are added WITH a
+// temporary DEFAULT so existing rows backfill, then the DEFAULT is dropped so
+// the GORM zero-value INSERT trap can't reintroduce a silent default.
 // owner_user_id is nullable (third-party app owner; NULL for first-party site
 // clients) and gets a plain index.
 //
@@ -26,6 +28,10 @@ func Models() []any {
 // mapping for the model fields (Go int → bigint, string size:20 → varchar(20)),
 // so AutoMigrate reconciles to a no-op afterward.
 func AddOAuthClientDevColumns(db *gorm.DB) error {
+	if !db.Migrator().HasTable("oauth_clients") {
+		return nil
+	}
+
 	stmts := []string{
 		`ALTER TABLE oauth_clients ADD COLUMN IF NOT EXISTS owner_user_id bigint`,
 		`CREATE INDEX IF NOT EXISTS idx_oauth_clients_owner_user_id ON oauth_clients (owner_user_id)`,


### PR DESCRIPTION
## 修改内容

- 当 `oauth_clients` 表不存在时，跳过开发者平台字段的预迁移。
- 调整集成测试的数据库初始化顺序，使其与生产迁移流程保持一致。
- 添加针对全新 PostgreSQL 数据库迁移的回归测试。

## 问题原因

`AddOAuthClientDevColumns` 会在 `AutoMigrate` 之前执行。

在全新数据库中，`oauth_clients` 表尚未创建，因此对该表执行
`ALTER TABLE` 会导致迁移容器报错退出。

现在会先检查 `oauth_clients` 是否存在：

- 如果不存在，则跳过预迁移，由后续 `AutoMigrate` 创建完整表结构。
- 如果已经存在，则继续通过原始 SQL 添加开发者平台字段并回填旧数据。

## 测试结果

- 成功构建本地 `infra-migrate` Docker 镜像。
- 删除并重新创建空的 `kun_galgame_infra` 数据库。
- 首次执行完整数据库迁移成功。
- 再次执行迁移成功，确认迁移具有幂等性。
- 确认 `oauth_clients` 表成功创建并包含 38 个字段。
- 确认 6 个开发者平台字段的类型、可空性和默认值正确。
- 使用 `full` profile 启动完整开发环境成功。
- 所有迁移容器均以状态码 `0` 退出。
- OAuth、AI、Catalog、Community、Trust、Image 和 Artifact 等服务均通过健康检查。