### PR TITLE
fix(dev-seed): the catalog sample keeps the works both sites' gids anchor to

### DIFF
--- a/scripts/dev-seed/config.sh
+++ b/scripts/dev-seed/config.sh
@@ -25,8 +25,8 @@ source "${DEV_SEED_CONFIG_DIR}/../dev-snapshot/config.sh"
 # prune step reads those lists to keep the matching platform-side rows).
 SEED_DBS=(
   kungalgame          # exports kept user / topic / galgame / resource id lists
-  kungalgame_patch    # exports kept patch-local user ids
-  kun_catalog
+  kungalgame_patch    # exports kept patch-local user + patch (= wiki gid) ids
+  kun_catalog         # imports both sites' gid lists (curated work anchors)
   kun_community       # imports forum content ids; exports kept platform uids
   kun_galgame_infra   # imports all kept-user lists (accounts + site mappings)
   kun_images

--- a/scripts/dev-seed/prune/kun_catalog.sql
+++ b/scripts/dev-seed/prune/kun_catalog.sql
@@ -8,7 +8,9 @@
 -- Invocation (orchestrator):
 --   psql -v ON_ERROR_STOP=1 -q -d kun_catalog_seedbuild \
 --     -v seed_works=300 -f prune/kun_catalog.sql
--- (export_dir / seed_topics / seed_users are accepted but unused here.)
+-- (seed_topics / seed_users are accepted but unused here. Reads the kept-id
+--  CSVs exported by prune/kungalgame.sql and prune/kungalgame_patch.sql from
+--  the CWD, which the orchestrator sets to the shared export dir.)
 --
 -- Technique: FK constraints stay enforced throughout. Keep-sets are built in
 -- TEMP tables first, then children are deleted before parents so any ordering
@@ -44,6 +46,30 @@ ORDER BY max(value) DESC, work_id DESC
 LIMIT (:seed_works - 50);
 INSERT INTO keep_work
 SELECT id FROM (SELECT id FROM catalog_work ORDER BY id DESC LIMIT 50) newest
+ON CONFLICT DO NOTHING;
+
+-- Cross-DB consistency: the kungal forum and moyu patch site hydrate their
+-- lists by bridging their local galgame ids (both are wiki-gid-native) to
+-- catalog works through catalog_external_ref rows on the `curated` source
+-- (`galgame_wiki` during the rename window), entity_type 5 = work. An
+-- independently sampled keep_work shares almost nothing with the sites'
+-- newest-N samples (measured: 1/300 overlap), which makes every seeded list
+-- page render empty. So the works anchored to the sites' kept ids are part
+-- of the root set. CSV paths are CWD-relative: \copy does not interpolate
+-- psql variables, so build-seed.sh runs this file with CWD = the export dir.
+CREATE TEMP TABLE site_gid (id bigint PRIMARY KEY) ON COMMIT DROP;
+\copy site_gid FROM 'kungalgame_galgames.csv'
+CREATE TEMP TABLE site_pid (id bigint) ON COMMIT DROP;
+\copy site_pid FROM 'kungalgame_patch_patches.csv'
+INSERT INTO site_gid SELECT id FROM site_pid ON CONFLICT DO NOTHING;
+
+INSERT INTO keep_work
+SELECT DISTINCT r.entity_id
+FROM catalog_external_ref r
+JOIN catalog_source s ON s.id = r.source_id
+  AND s.key IN ('curated', 'galgame_wiki')
+JOIN site_gid g ON r.external_id = g.id::text
+WHERE r.entity_type = 5
 ON CONFLICT DO NOTHING;
 
 -- Releases of kept works.

--- a/scripts/dev-seed/prune/kungalgame_patch.sql
+++ b/scripts/dev-seed/prune/kungalgame_patch.sql
@@ -317,3 +317,14 @@ COPY (SELECT id FROM "user" ORDER BY id) TO STDOUT WITH (FORMAT csv);
 \o
 \echo '=== exported kept user ids ==='
 \echo :filepath
+
+-- Kept patch ids too: moyu is gid-native (patch.id IS the wiki galgame id),
+-- so the catalog prune must keep the works these ids anchor to via the
+-- `curated` external-ref source, or every moyu card's catalog hydration
+-- misses in the seed.
+\set filepath :export_dir '/kungalgame_patch_patches.csv'
+\o :filepath
+COPY (SELECT id FROM patch ORDER BY id) TO STDOUT WITH (FORMAT csv);
+\o
+\echo '=== exported kept patch ids ==='
+\echo :filepath


### PR DESCRIPTION
Fixes the collaborator-reported empty-list problem with the dev seed: forum/moyu list pages hydrate via the catalog `curated` external-ref bridge (gid → work), but the catalog seed's popularity-based sample shared exactly **1** gid with the two sites' newest-300 samples — so `GetBatchPublic` missed on nearly every id and `galgames: []`.

- `prune/kungalgame_patch.sql` now exports its kept patch ids (moyu is gid-native: `patch.id` IS the wiki gid).
- `prune/kun_catalog.sql` consumes both sites' kept-id CSVs and unions the anchored works (entity_type 5, source `curated`/`galgame_wiki`) into `keep_work`.

Verified on a fresh build (stamp `20260807-0200`, already published to the rolling `dev-seed` release): **286/300** kungal gids and **297/300** moyu pids resolve against the seed catalog (the remainder have no curated anchor even in the full data). Catalog dump 2.3M → 3.8M; total seed still ~6MB.

Related: PR #4's fresh-DB migration fix is unaffected and stands — this addresses the second, data-side half of the collaborator report.