### PR TITLE
修复本地 OAuth 授权页跳转端口

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -75,7 +75,7 @@ x-dev-env: &dev-env
   KUN_FRONTEND_CORS_ORIGIN: http://localhost:3000,http://127.0.0.1:3000,http://localhost:3001,http://127.0.0.1:3001,http://localhost:2333,http://127.0.0.1:2333,http://localhost:6969,http://127.0.0.1:6969,http://localhost:9420,http://127.0.0.1:9420,http://localhost:5364,http://127.0.0.1:5364,http://localhost:15008,http://127.0.0.1:15008,http://localhost:15009,http://127.0.0.1:15009,http://localhost:15011,http://127.0.0.1:15011,http://localhost:15013,http://127.0.0.1:15013
   # oauth identity URLs — the local oauth service
   KUN_SITE_URL: http://127.0.0.1:9277
-  KUN_FRONTEND_URL: http://127.0.0.1:9277
+  KUN_FRONTEND_URL: http://127.0.0.1:9420
   # image_service S3 → local MinIO (path-style). Dev key = the MinIO root user.
   # The image service os.Exit(1)s on empty key/secret/bucket, so these are set.
   KUN_IMAGE_S3_ENDPOINT: http://127.0.0.1:9000


### PR DESCRIPTION
## 问题

本地论坛发起 OAuth 登录时，会先访问 OAuth API 的 `9277` 端口。API 校验参数后本应跳转到运行在 `9420` 的 OAuth Web 授权页面，但开发编排误将 `KUN_FRONTEND_URL` 配置为 API 自身的 `9277`，导致浏览器继续停留在后端端口。

## 修改

- 保持 `KUN_SITE_URL=http://127.0.0.1:9277`，继续表示 OAuth API 地址。
- 将 `KUN_FRONTEND_URL` 修正为 `http://127.0.0.1:9420`，与本地 OAuth Web 的实际开发端口一致。

正确跳转链路为：

```text
论坛前端 :2333
→ OAuth API :9277/api/v1/oauth/authorize
→ OAuth Web :9420/oauth/authorize
→ 论坛回调 :2333/auth/callback
```