### PR TITLE
feat(catalog): mark anchors whose upstream entry is gone, instead of linking to a 404

### DIFF
--- a/apps/api/cmd/audit-vndb-anchors/audit.go
+++ b/apps/api/cmd/audit-vndb-anchors/audit.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"api/internal/platform/catalog/model"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+// sourceKeyVndb is the catalog_source registry key of the VNDB source. The
+// numeric id is looked up, never hard-coded — registry ids are data.
+const sourceKeyVndb = "vndb"
+
+// defaultMinMirrorRows is the MANDATORY mid-reload guardrail.
+//
+// src_vndb is rebuildable staging: cmd/ingest-vndb replaces src_vndb.vn
+// wholesale from the VNDB dump, so between the truncate and the end of the
+// COPY the table legitimately holds anything from zero rows upward. An audit
+// run landing inside that window would see ~64k anchors as "absent upstream"
+// and mark EVERY VNDB anchor dead in one transaction, stripping every VNDB
+// link from the site. That is the failure this number exists to prevent, and
+// it is why the guard is a refusal rather than a warning.
+//
+// The threshold is derived from the real table: src_vndb.vn holds ~65,300 rows
+// (local 2026-08 snapshot), and VNDB's catalogue only grows in the long run —
+// its ~20 deletions a week are far outrun by new entries. 50,000 sits ~23%
+// below today's count: comfortably below any plausible real dump for years,
+// while a partial load is overwhelmingly likely to be caught (a mid-COPY table
+// spends almost all of its life under this line). It is a flag so an operator
+// facing a genuinely smaller future dump can lower it deliberately, on the
+// record, instead of the tool silently doing the wrong thing.
+//
+// DOES THE GUARD ALSO PROTECT THE CLEAR-BACK DIRECTION, e.g. against a mirror
+// that is complete but STALE? Partly, and deliberately so. A row count cannot
+// detect staleness at all — an old full dump passes any count threshold. What
+// saves us is that the two directions have wildly asymmetric blast radii:
+//
+//   - mark-dead against an INCOMPLETE mirror is catastrophic and wholesale
+//     (all ~64k anchors at once), which is what the count threshold catches;
+//   - clear-back against a STALE mirror can at worst resurrect the handful of
+//     anchors deleted upstream since that dump, i.e. it re-exposes a few links
+//     that already 404 today — the pre-audit status quo, no worse — and the
+//     next run on a fresh mirror re-marks them.
+//
+// So one count gate on the whole apply is the right shape: both directions are
+// behind it, staleness is reported (the mirror's ingested_at is printed on
+// every run) rather than guessed at, and the tool never refuses to run for a
+// risk whose worst case is the state it was written to improve.
+const defaultMinMirrorRows int64 = 50_000
+
+// stats is one audit run's outcome.
+type stats struct {
+	Anchors     int64 // work-level exact VNDB anchors examined
+	MirrorRows  int64 // rows in src_vndb.vn
+	MirrorFresh *time.Time
+	ToMark      int64 // absent upstream, dead_at IS NULL
+	ToClear     int64 // present upstream, dead_at IS NOT NULL
+	Marked      int64
+	Cleared     int64
+}
+
+func run(ctx context.Context, dsn string, apply bool, minMirrorRows int64, w io.Writer) error {
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: gormlogger.Default.LogMode(gormlogger.Silent)})
+	if err != nil {
+		return fmt.Errorf("connect catalog db: %w", err)
+	}
+	if sqlDB, e := db.DB(); e == nil {
+		defer sqlDB.Close()
+	}
+	st, err := audit(ctx, db, apply, minMirrorRows)
+	if err != nil {
+		return err
+	}
+	report(w, st, apply)
+	return nil
+}
+
+// audit measures both directions and, with apply, writes them.
+func audit(ctx context.Context, db *gorm.DB, apply bool, minMirrorRows int64) (stats, error) {
+	var st stats
+	db = db.WithContext(ctx)
+
+	var srcID int16
+	if err := db.Raw(`SELECT id FROM catalog_source WHERE key = ?`, sourceKeyVndb).Scan(&srcID).Error; err != nil {
+		return st, fmt.Errorf("look up vndb source id: %w", err)
+	}
+	if srcID == 0 {
+		return st, fmt.Errorf("catalog_source has no %q row", sourceKeyVndb)
+	}
+
+	if err := db.Raw(`SELECT count(*) FROM src_vndb.vn`).Scan(&st.MirrorRows).Error; err != nil {
+		return st, fmt.Errorf("count src_vndb.vn (is the VNDB mirror loaded?): %w", err)
+	}
+	if err := db.Raw(`SELECT max(ingested_at) FROM src_vndb.vn`).Scan(&st.MirrorFresh).Error; err != nil {
+		return st, fmt.Errorf("read src_vndb.vn ingested_at: %w", err)
+	}
+
+	if err := db.Raw(`SELECT count(*) FROM catalog_external_ref
+		WHERE source_id = ? AND entity_type = ? AND link_kind = ?`,
+		srcID, model.EntityTypeWork, model.LinkKindExact).Scan(&st.Anchors).Error; err != nil {
+		return st, fmt.Errorf("count anchors: %w", err)
+	}
+
+	// external_id and src_vndb.vn.id share the "v"-prefixed spelling verbatim,
+	// so the comparison is a direct equality join with no transform.
+	const markPredicate = `source_id = ? AND entity_type = ? AND link_kind = ? AND dead_at IS NULL
+		AND NOT EXISTS (SELECT 1 FROM src_vndb.vn v WHERE v.id = catalog_external_ref.external_id)`
+	const clearPredicate = `source_id = ? AND entity_type = ? AND link_kind = ? AND dead_at IS NOT NULL
+		AND EXISTS (SELECT 1 FROM src_vndb.vn v WHERE v.id = catalog_external_ref.external_id)`
+	args := []any{srcID, model.EntityTypeWork, model.LinkKindExact}
+
+	if err := db.Raw(`SELECT count(*) FROM catalog_external_ref WHERE `+markPredicate, args...).
+		Scan(&st.ToMark).Error; err != nil {
+		return st, fmt.Errorf("count anchors absent upstream: %w", err)
+	}
+	if err := db.Raw(`SELECT count(*) FROM catalog_external_ref WHERE `+clearPredicate, args...).
+		Scan(&st.ToClear).Error; err != nil {
+		return st, fmt.Errorf("count revived anchors: %w", err)
+	}
+	if !apply {
+		return st, nil
+	}
+	if st.MirrorRows < minMirrorRows {
+		return st, fmt.Errorf(
+			"refusing to apply: src_vndb.vn holds %d rows, below the --min-mirror-rows floor of %d — "+
+				"the mirror looks partially loaded, and applying against it would mark live anchors dead wholesale",
+			st.MirrorRows, minMirrorRows)
+	}
+
+	// One transaction for both directions: an audit run is a single statement
+	// about the mirror it read, and half of it is not a coherent state.
+	err := db.Transaction(func(tx *gorm.DB) error {
+		res := tx.Exec(`UPDATE catalog_external_ref SET dead_at = now() WHERE `+markPredicate, args...)
+		if res.Error != nil {
+			return fmt.Errorf("mark dead: %w", res.Error)
+		}
+		st.Marked = res.RowsAffected
+		res = tx.Exec(`UPDATE catalog_external_ref SET dead_at = NULL WHERE `+clearPredicate, args...)
+		if res.Error != nil {
+			return fmt.Errorf("clear revived: %w", res.Error)
+		}
+		st.Cleared = res.RowsAffected
+		return nil
+	})
+	return st, err
+}
+
+func report(w io.Writer, st stats, apply bool) {
+	fresh := "unknown (mirror empty)"
+	if st.MirrorFresh != nil {
+		fresh = st.MirrorFresh.Format(time.RFC3339)
+	}
+	fmt.Fprintf(w, "[audit-vndb-anchors] mirror src_vndb.vn rows=%d ingested_at=%s\n", st.MirrorRows, fresh)
+	fmt.Fprintf(w, "[audit-vndb-anchors] work-level exact vndb anchors=%d\n", st.Anchors)
+	if apply {
+		fmt.Fprintf(w, "[audit-vndb-anchors] marked dead=%d cleared (revived)=%d\n", st.Marked, st.Cleared)
+		return
+	}
+	fmt.Fprintf(w, "[audit-vndb-anchors] would mark dead=%d would clear (revived)=%d (dry run — pass --apply to write)\n",
+		st.ToMark, st.ToClear)
+}

--- a/apps/api/cmd/audit-vndb-anchors/audit_test.go
+++ b/apps/api/cmd/audit-vndb-anchors/audit_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"api/internal/platform/catalog/migrate"
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/seed"
+	"api/internal/platform/catalog/srcvndb"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var testDB *gorm.DB
+
+func TestMain(m *testing.M) {
+	dsn := os.Getenv("TEST_DATABASE_DSN")
+	if dsn == "" {
+		dsn = "host=localhost port=5432 user=postgres password=postgres dbname=kun_catalog_test sslmode=disable"
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "SKIP: cannot connect to test database: %v\n", err)
+		os.Exit(0)
+	}
+	if err := migrate.Run(db); err != nil {
+		fmt.Fprintf(os.Stderr, "SKIP: catalog migration failed: %v\n", err)
+		os.Exit(0)
+	}
+	if err := seed.Run(db); err != nil {
+		fmt.Fprintf(os.Stderr, "SKIP: catalog seeding failed: %v\n", err)
+		os.Exit(0)
+	}
+	// src_vndb is rebuildable staging outside the catalog migration order, so
+	// the audit's mirror side has to be provisioned explicitly.
+	if err := srcvndb.EnsureSchema(db); err != nil {
+		fmt.Fprintf(os.Stderr, "SKIP: src_vndb schema failed: %v\n", err)
+		os.Exit(0)
+	}
+	testDB = db
+	os.Exit(m.Run())
+}
+
+func clean(t *testing.T) {
+	t.Helper()
+	require.NoError(t, testDB.Exec(
+		`TRUNCATE catalog_external_ref, catalog_work, src_vndb.vn RESTART IDENTITY CASCADE`).Error)
+}
+
+func vndbSourceID(t *testing.T) int16 {
+	t.Helper()
+	var id int16
+	require.NoError(t, testDB.Raw(`SELECT id FROM catalog_source WHERE key = ?`, sourceKeyVndb).Scan(&id).Error)
+	require.NotZero(t, id)
+	return id
+}
+
+func seedWork(t *testing.T, name string) int64 {
+	t.Helper()
+	w := model.CatalogWork{MediumID: 1, OLang: "ja", DisplayName: name}
+	require.NoError(t, testDB.Create(&w).Error)
+	return w.ID
+}
+
+func seedAnchor(t *testing.T, workID int64, externalID string, dead bool) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&model.CatalogExternalRef{
+		EntityType: model.EntityTypeWork, EntityID: workID, SourceID: vndbSourceID(t),
+		ExternalID: externalID, LinkKind: model.LinkKindExact, MatchedBy: "rule:wiki-vndb-id",
+	}).Error)
+	if dead {
+		require.NoError(t, testDB.Exec(`UPDATE catalog_external_ref SET dead_at = now()
+			WHERE entity_type = ? AND entity_id = ? AND external_id = ?`,
+			model.EntityTypeWork, workID, externalID).Error)
+	}
+}
+
+// seedMirror fills src_vndb.vn with n synthetic entries v1..vn, plus any extra
+// ids named. The count matters only for the guardrail, so the rows are minimal.
+func seedMirror(t *testing.T, n int, extra ...string) {
+	t.Helper()
+	ids := make([]string, 0, n+len(extra))
+	for i := 1; i <= n; i++ {
+		ids = append(ids, fmt.Sprintf("vfill%d", i))
+	}
+	ids = append(ids, extra...)
+	rows := make([]srcvndb.VN, 0, len(ids))
+	for _, id := range ids {
+		rows = append(rows, srcvndb.VN{ID: id, OLang: "ja", IngestedAt: time.Now()})
+	}
+	require.NoError(t, testDB.CreateInBatches(rows, 1000).Error)
+}
+
+func deadAt(t *testing.T, externalID string) *string {
+	t.Helper()
+	var got *string
+	require.NoError(t, testDB.Raw(`SELECT dead_at::text FROM catalog_external_ref WHERE external_id = ?`,
+		externalID).Scan(&got).Error)
+	return got
+}
+
+// The two directions, in one apply: an anchor whose VNDB entry is gone gets
+// dead_at; an anchor previously marked dead whose entry is back is cleared.
+func TestAuditMarksDeadAndClearsRevived(t *testing.T) {
+	clean(t)
+	ctx := context.Background()
+
+	gone := seedWork(t, "deleted upstream")
+	revived := seedWork(t, "restored upstream")
+	healthy := seedWork(t, "always fine")
+	seedAnchor(t, gone, "vgone", false)
+	seedAnchor(t, revived, "vback", true)
+	seedAnchor(t, healthy, "vlive", false)
+	seedMirror(t, 10, "vback", "vlive")
+
+	st, err := audit(ctx, testDB, true, 5)
+	require.NoError(t, err)
+	assert.EqualValues(t, 3, st.Anchors)
+	assert.EqualValues(t, 1, st.Marked)
+	assert.EqualValues(t, 1, st.Cleared)
+
+	assert.NotNil(t, deadAt(t, "vgone"), "an anchor absent upstream must be marked dead")
+	assert.Nil(t, deadAt(t, "vback"), "a restored anchor must be cleared back to live")
+	assert.Nil(t, deadAt(t, "vlive"), "a live anchor must be left alone")
+
+	// Re-runnable: a second pass over the same mirror writes nothing.
+	st, err = audit(ctx, testDB, true, 5)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, st.Marked)
+	assert.EqualValues(t, 0, st.Cleared)
+}
+
+// The dry run reports both directions and writes nothing.
+func TestAuditDryRunWritesNothing(t *testing.T) {
+	clean(t)
+	ctx := context.Background()
+
+	w := seedWork(t, "deleted upstream")
+	seedAnchor(t, w, "vgone", false)
+	seedMirror(t, 10)
+
+	st, err := audit(ctx, testDB, false, 5)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, st.ToMark)
+	assert.EqualValues(t, 0, st.Marked)
+	assert.Nil(t, deadAt(t, "vgone"), "a dry run must not write dead_at")
+}
+
+// The guardrail: an implausibly small mirror (the mid-reload window) must make
+// --apply REFUSE rather than mark every anchor dead. A dry run against the
+// same mirror is still allowed — it writes nothing, so it cannot do harm.
+func TestAuditRefusesApplyAgainstUndersizedMirror(t *testing.T) {
+	clean(t)
+	ctx := context.Background()
+
+	w := seedWork(t, "would be wrongly killed")
+	seedAnchor(t, w, "vgone", false)
+	seedMirror(t, 3) // far below the floor asked for below
+
+	_, err := audit(ctx, testDB, true, 50_000)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to apply")
+	assert.Nil(t, deadAt(t, "vgone"), "the refusal must happen before any write")
+
+	st, err := audit(ctx, testDB, false, 50_000)
+	require.NoError(t, err, "a dry run is safe against any mirror")
+	assert.EqualValues(t, 1, st.ToMark)
+}

--- a/apps/api/cmd/audit-vndb-anchors/main.go
+++ b/apps/api/cmd/audit-vndb-anchors/main.go
@@ -1,0 +1,59 @@
+// audit-vndb-anchors reconciles our work-level EXACT VNDB anchors against the
+// live VNDB mirror (src_vndb.vn, a schema INSIDE the catalog database) and
+// maintains catalog_external_ref.dead_at — the upstream-liveness axis.
+//
+// WHY THIS EXISTS. We anchor ~98.7% of VNDB and VNDB deletes roughly twenty
+// entries a week, so the set of anchors pointing at a vndb.org page that now
+// 404s grows continuously (112 on the 2026-08 production measurement). The
+// public faces render those anchors as links, so every one of them is a broken
+// link on a user-visible work page.
+//
+// WHY MARK AND NOT DELETE OR RE-POINT. The VNDB dump carries no redirect,
+// merge or tombstone table: a deleted entry has NO derivable successor, so
+// re-pointing is impossible and guessing is forbidden. Deleting the row does
+// not work either — 189 of the affected anchors carry
+// matched_by='rule:wiki-vndb-id' and are simply re-asserted by the next
+// importer run, which is precisely the "deletion is not a decision" failure.
+// The row therefore stays, keeps occupying its exact slot (so it still blocks
+// a duplicate claim on the same external id) and keeps recording what the wiki
+// asserted; only dead_at changes, and only user-facing projections read it.
+//
+// The audit is BIDIRECTIONAL and re-runnable:
+//
+//	absent upstream + dead_at IS NULL      → dead_at = now()
+//	present upstream + dead_at IS NOT NULL → dead_at = NULL
+//
+// The clear-back direction is what makes the tool self-healing when VNDB
+// restores an entry, and self-correcting when a previous run read a mirror
+// that was merely stale.
+//
+//	# report only (default) — safe against any mirror, writes nothing
+//	go run ./cmd/audit-vndb-anchors --dsn "host=127.0.0.1 user=postgres dbname=kun_catalog sslmode=disable"
+//
+//	# write
+//	go run ./cmd/audit-vndb-anchors --dsn "..." --apply
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"os"
+)
+
+func main() {
+	dsn := flag.String("dsn", "", "catalog DSN — REQUIRED, never inferred from the environment")
+	apply := flag.Bool("apply", false, "write dead_at (default: report-only dry run)")
+	minMirrorRows := flag.Int64("min-mirror-rows", defaultMinMirrorRows,
+		"refuse to --apply unless src_vndb.vn holds at least this many rows (mid-reload guard)")
+	flag.Parse()
+
+	if *dsn == "" {
+		slog.Error("audit-vndb-anchors", "error", "--dsn is required")
+		os.Exit(1)
+	}
+	if err := run(context.Background(), *dsn, *apply, *minMirrorRows, os.Stdout); err != nil {
+		slog.Error("audit-vndb-anchors", "error", err)
+		os.Exit(1)
+	}
+}

--- a/apps/api/internal/platform/catalog/model/reconciliation.go
+++ b/apps/api/internal/platform/catalog/model/reconciliation.go
@@ -35,6 +35,20 @@ type CatalogExternalRef struct {
 	VerifiedBy *int64     `json:"verified_by"`
 	VerifiedAt *time.Time `json:"verified_at"`
 	CreatedAt  time.Time  `json:"created_at"`
+	// DeadAt is UPSTREAM LIVENESS, not a soft delete: NULL = the external
+	// entry is believed to still exist at the source; non-NULL = the entry was
+	// OBSERVED ABSENT upstream at that moment. The assertion itself stays true
+	// and stays enforced — a dead anchor still occupies the exact slot, still
+	// blocks a duplicate claim on the same external id, and still records what
+	// the source (or the wiki) asserted. Only USER-FACING projections drop it,
+	// because a link to a deleted upstream entry is a 404.
+	//
+	// Generic across sources by design, even though cmd/audit-vndb-anchors is
+	// the only writer today: "did the upstream row disappear" is the same
+	// question for every source. No `default:` tag (the GORM default-tag
+	// zero-value trap) — the column is plain nullable and every writer sets it
+	// explicitly, including back to NULL when the entry reappears.
+	DeadAt *time.Time `json:"dead_at"`
 
 	Source *CatalogSource `gorm:"foreignKey:SourceID" json:"source,omitempty"`
 }

--- a/apps/api/internal/platform/catalog/service/public_refs.go
+++ b/apps/api/internal/platform/catalog/service/public_refs.go
@@ -2,6 +2,13 @@
 // (doc 106 G4: refs are isomorphic across every entity). EXACT tier only —
 // probable is a review-lane hypothesis and related is a non-identity link;
 // neither ever crosses the public face (硬红线). FROZEN after W1.
+//
+// ONE amendment since the freeze (upstream-liveness wave): the query now also
+// requires r.dead_at IS NULL. Anchors whose upstream entry has been deleted
+// (VNDB removes ~20 entries a week, and we anchor ~98.7% of it) were still
+// being rendered as vndb.org/v… links that 404. The wire SHAPE is untouched —
+// refs[] keeps its exact structure and ordering; dead entries simply drop out.
+// Nothing else about this loader changed.
 package service
 
 import (
@@ -28,6 +35,7 @@ func (s *PublicService) entityRefsFor(ctx context.Context, entityType int16, ids
 		SELECT r.entity_id, src.key AS source, r.external_id
 		FROM catalog_external_ref r JOIN catalog_source src ON src.id = r.source_id
 		WHERE r.entity_type = ? AND r.entity_id IN ? AND r.link_kind = ?
+			AND r.dead_at IS NULL
 		ORDER BY r.entity_id, r.source_id, r.external_id`,
 		entityType, ids, model.LinkKindExact).Scan(&rows).Error; err != nil {
 		return nil, err

--- a/apps/api/internal/platform/catalog/service/public_refs_liveness_test.go
+++ b/apps/api/internal/platform/catalog/service/public_refs_liveness_test.go
@@ -1,0 +1,94 @@
+// public_refs_liveness_test.go — upstream liveness (catalog_external_ref
+// .dead_at) on the read faces: an anchor whose upstream entry has been
+// observed absent stops being rendered, while its live siblings are untouched
+// and the wire shape is unchanged. Integration against the catalog test
+// database (service_test.go TestMain).
+package service
+
+import (
+	"testing"
+
+	"api/internal/platform/catalog/model"
+)
+
+// markRefDead sets dead_at on one anchor, exactly as cmd/audit-vndb-anchors
+// does when it finds the upstream entry gone.
+func markRefDead(t *testing.T, entityType int16, entityID int64, sourceID int16, externalID string) {
+	t.Helper()
+	res := testDB.Exec(`UPDATE catalog_external_ref SET dead_at = now()
+		WHERE entity_type = ? AND entity_id = ? AND source_id = ? AND external_id = ?`,
+		entityType, entityID, sourceID, externalID)
+	if res.Error != nil {
+		t.Fatalf("mark ref dead: %v", res.Error)
+	}
+	if res.RowsAffected != 1 {
+		t.Fatalf("mark ref dead: affected %d rows, want 1", res.RowsAffected)
+	}
+}
+
+func TestPublicRefsDropDeadAnchors(t *testing.T) {
+	cleanTables(t)
+	svc := newPublicSvc()
+	ctx := t.Context()
+
+	w := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "half-dead anchors")
+	addExternalRef(t, model.EntityTypeWork, w.ID, srcVNDB, "v42", model.LinkKindExact)
+	addExternalRef(t, model.EntityTypeWork, w.ID, srcDlsite, "RJ42", model.LinkKindExact)
+	markRefDead(t, model.EntityTypeWork, w.ID, srcVNDB, "v42")
+
+	// (1) the work DETAIL face (read_service loadWorkDetail → publicRefs).
+	rec, found, err := svc.WorkDetail(ctx, w.ID, PublicInclude{}, false, 0)
+	if err != nil || !found {
+		t.Fatalf("detail: found=%v err=%v", found, err)
+	}
+	if len(rec.Refs) != 1 || rec.Refs[0].Source != "dlsite" || rec.Refs[0].ExternalID != "RJ42" {
+		t.Fatalf("detail refs must drop the dead vndb anchor: %+v", rec.Refs)
+	}
+
+	// (2) the works LIST face (workListRefs).
+	listRefs, err := svc.workListRefs(ctx, []int64{w.ID})
+	if err != nil {
+		t.Fatalf("workListRefs: %v", err)
+	}
+	if got := listRefs[w.ID]; len(got) != 1 || got[0].ExternalID != "RJ42" {
+		t.Fatalf("list refs must drop the dead vndb anchor: %+v", got)
+	}
+
+	// (3) the generic per-entity loader every non-work identity face uses.
+	l := &model.CatalogLabel{DisplayName: "liveness label", Kind: model.LabelKindGameBrand}
+	if err := testDB.Create(l).Error; err != nil {
+		t.Fatalf("create label: %v", err)
+	}
+	addExternalRef(t, model.EntityTypeLabel, l.ID, srcVNDB, "p9", model.LinkKindExact)
+	addExternalRef(t, model.EntityTypeLabel, l.ID, srcDlsite, "RG9", model.LinkKindExact)
+	markRefDead(t, model.EntityTypeLabel, l.ID, srcVNDB, "p9")
+
+	byEntity, err := svc.entityRefsFor(ctx, model.EntityTypeLabel, []int64{l.ID})
+	if err != nil {
+		t.Fatalf("entityRefsFor: %v", err)
+	}
+	if got := byEntity[l.ID]; len(got) != 1 || got[0].ExternalID != "RG9" {
+		t.Fatalf("entity refs must drop the dead vndb anchor: %+v", got)
+	}
+}
+
+// A dead anchor is NOT a deleted anchor: it still holds its exact slot, so the
+// matching lane still sees it and a second entity cannot claim the same
+// external id. This is the guarantee that makes marking (rather than deleting)
+// the correct action for an importer-re-asserted anchor.
+func TestDeadRefStillBlocksTheExactSlot(t *testing.T) {
+	cleanTables(t)
+
+	a := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "holder")
+	b := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "squatter")
+	addExternalRef(t, model.EntityTypeWork, a.ID, srcVNDB, "v67491", model.LinkKindExact)
+	markRefDead(t, model.EntityTypeWork, a.ID, srcVNDB, "v67491")
+
+	err := testDB.Create(&model.CatalogExternalRef{
+		EntityType: model.EntityTypeWork, EntityID: b.ID, SourceID: srcVNDB,
+		ExternalID: "v67491", LinkKind: model.LinkKindExact, MatchedBy: "import:test",
+	}).Error
+	if err == nil {
+		t.Fatal("a dead anchor must still occupy its exact slot, but a second work claimed it")
+	}
+}

--- a/apps/api/internal/platform/catalog/service/public_service.go
+++ b/apps/api/internal/platform/catalog/service/public_service.go
@@ -998,6 +998,14 @@ func (s *PublicService) characterAliases(ctx context.Context, characterID int64)
 // anchors and web links never cross, a hard red line. Each external id is
 // rendered to an absolute URL per source; an unknown related source (a future
 // addition) has no template and is skipped, never guessed.
+//
+// dead_at IS NULL is the upstream-liveness predicate every user-facing
+// external-id projection carries (see CatalogExternalRef.DeadAt): a row whose
+// upstream entry has been observed absent renders as a 404. Only the VNDB
+// anchor audit writes that column today and it never touches related rows, so
+// this is a no-op right now — it is here so the liveness rule holds for the
+// whole face rather than for the one lane that happens to have a writer, and
+// personLinks / workLinks below carry it for the same reason.
 // Deterministic (source_id, external_id); empty → [].
 func (s *PublicService) labelLinks(ctx context.Context, labelID int64) ([]dto.PublicLabelLink, error) {
 	var rows []struct {
@@ -1007,7 +1015,7 @@ func (s *PublicService) labelLinks(ctx context.Context, labelID int64) ([]dto.Pu
 	if err := s.db.WithContext(ctx).Raw(`
 		SELECT src.key AS source, r.external_id
 		FROM catalog_external_ref r JOIN catalog_source src ON src.id = r.source_id
-		WHERE r.entity_type = ? AND r.entity_id = ? AND r.link_kind = ?
+		WHERE r.entity_type = ? AND r.entity_id = ? AND r.link_kind = ? AND r.dead_at IS NULL
 		ORDER BY r.source_id, r.external_id`,
 		model.EntityTypeLabel, labelID, model.LinkKindRelated).Scan(&rows).Error; err != nil {
 		return nil, err
@@ -1070,7 +1078,7 @@ func (s *PublicService) personLinks(ctx context.Context, personID int64) ([]dto.
 	if err := s.db.WithContext(ctx).Raw(`
 		SELECT src.key AS source, r.external_id
 		FROM catalog_external_ref r JOIN catalog_source src ON src.id = r.source_id
-		WHERE r.entity_type = ? AND r.entity_id = ? AND r.link_kind = ?
+		WHERE r.entity_type = ? AND r.entity_id = ? AND r.link_kind = ? AND r.dead_at IS NULL
 		ORDER BY r.source_id, r.external_id`,
 		model.EntityTypePerson, personID, model.LinkKindRelated).Scan(&rows).Error; err != nil {
 		return nil, err
@@ -1122,7 +1130,7 @@ func (s *PublicService) workLinks(ctx context.Context, workID int64) ([]dto.Publ
 	if err := s.db.WithContext(ctx).Raw(`
 		SELECT src.key AS source, r.external_id
 		FROM catalog_external_ref r JOIN catalog_source src ON src.id = r.source_id
-		WHERE r.entity_type = ? AND r.entity_id = ? AND r.link_kind = ?
+		WHERE r.entity_type = ? AND r.entity_id = ? AND r.link_kind = ? AND r.dead_at IS NULL
 		ORDER BY r.source_id, r.external_id`,
 		model.EntityTypeWork, workID, model.LinkKindRelated).Scan(&rows).Error; err != nil {
 		return nil, err

--- a/apps/api/internal/platform/catalog/service/public_works_include.go
+++ b/apps/api/internal/platform/catalog/service/public_works_include.go
@@ -183,7 +183,10 @@ func (s *PublicService) attachWorkListBlocks(
 // One query for the whole page — the release join happens in SQL rather than by
 // loading release rows per work. link_kind is pinned to EXACT in the predicate:
 // probable is an unreviewed hypothesis and related is a web link, and neither
-// has ever crossed the public face (硬红线). Works with no anchor are simply
+// has ever crossed the public face (硬红线). dead_at IS NULL joins that
+// predicate: an anchor whose upstream entry has been deleted would render as a
+// link that 404s, so it drops out of the projection (the assertion itself
+// stays in the table — see CatalogExternalRef.DeadAt). Works with no anchor are simply
 // absent from the map, so their block is omitted rather than an empty array —
 // the same "absent means nothing to say" rule the other include= blocks follow.
 func (s *PublicService) workListRefs(ctx context.Context, ids []int64) (map[int64][]dto.PublicCatalogRef, error) {
@@ -199,13 +202,13 @@ func (s *PublicService) workListRefs(ctx context.Context, ids []int64) (map[int6
 	if err := s.db.WithContext(ctx).Raw(`
 		SELECT r.entity_id AS work_id, src.key AS source, r.external_id
 		FROM catalog_external_ref r JOIN catalog_source src ON src.id = r.source_id
-		WHERE r.entity_type = ? AND r.entity_id IN ? AND r.link_kind = ?
+		WHERE r.entity_type = ? AND r.entity_id IN ? AND r.link_kind = ? AND r.dead_at IS NULL
 		UNION ALL
 		SELECT rel.work_id, src.key AS source, r.external_id
 		FROM catalog_external_ref r
 		JOIN catalog_release rel ON rel.id = r.entity_id AND rel.deleted_at IS NULL
 		JOIN catalog_source src ON src.id = r.source_id
-		WHERE r.entity_type = ? AND rel.work_id IN ? AND r.link_kind = ?
+		WHERE r.entity_type = ? AND rel.work_id IN ? AND r.link_kind = ? AND r.dead_at IS NULL
 		ORDER BY work_id, source, external_id`,
 		model.EntityTypeWork, ids, model.LinkKindExact,
 		model.EntityTypeRelease, ids, model.LinkKindExact).Scan(&rows).Error; err != nil {

--- a/apps/api/internal/platform/catalog/service/read_service.go
+++ b/apps/api/internal/platform/catalog/service/read_service.go
@@ -6,6 +6,7 @@ import (
 	stderrors "errors"
 	"sort"
 	"strings"
+	"time"
 
 	"api/internal/platform/catalog/model"
 
@@ -282,6 +283,16 @@ type AnchorDetail struct {
 	MatchedBy  string
 }
 
+// anchorKey identifies one release-level anchor inside a single work detail
+// load. It exists so upstream-liveness can be carried from the anchor query to
+// the Refs projection WITHOUT putting a dead_at field on AnchorDetail, which
+// is a serialized wire struct.
+type anchorKey struct {
+	EntityID   int64
+	Source     string
+	ExternalID string
+}
+
 // LabelAttribution is one work↔label edge with the label denormalized.
 type LabelAttribution struct {
 	LabelID     int64
@@ -372,6 +383,7 @@ func (s *ReadService) loadWorkDetail(ctx context.Context, workID int64, spoilers
 		return nil, err
 	}
 	anchorsByRelease := map[int64][]AnchorDetail{}
+	deadAnchors := map[anchorKey]struct{}{}
 	if len(releases) > 0 {
 		relIDs := make([]int64, len(releases))
 		for i, r := range releases {
@@ -383,8 +395,9 @@ func (s *ReadService) loadWorkDetail(ctx context.Context, workID int64, spoilers
 			ExternalID string
 			LinkKind   int16
 			MatchedBy  string
+			DeadAt     *time.Time
 		}
-		if err := db.Raw(`SELECT r.entity_id, s.key AS source, r.external_id, r.link_kind, r.matched_by
+		if err := db.Raw(`SELECT r.entity_id, s.key AS source, r.external_id, r.link_kind, r.matched_by, r.dead_at
 			FROM catalog_external_ref r JOIN catalog_source s ON s.id = r.source_id
 			WHERE r.entity_type = ? AND r.entity_id IN ?
 			ORDER BY r.link_kind, s.key`, model.EntityTypeRelease, relIDs).Scan(&arows).Error; err != nil {
@@ -393,6 +406,13 @@ func (s *ReadService) loadWorkDetail(ctx context.Context, workID int64, spoilers
 		for _, a := range arows {
 			anchorsByRelease[a.EntityID] = append(anchorsByRelease[a.EntityID],
 				AnchorDetail{Source: a.Source, ExternalID: a.ExternalID, LinkKind: a.LinkKind, MatchedBy: a.MatchedBy})
+			// Anchors[] is the full assertion record and keeps every row,
+			// dead ones included — it is what the matching lane reads. Only
+			// the Refs projection below drops them, so the dead keys are
+			// remembered here rather than filtered out of the query.
+			if a.DeadAt != nil {
+				deadAnchors[anchorKey{a.EntityID, a.Source, a.ExternalID}] = struct{}{}
+			}
 		}
 	}
 	for _, r := range releases {
@@ -412,13 +432,18 @@ func (s *ReadService) loadWorkDetail(ctx context.Context, workID int64, spoilers
 	// flattened into one list. Work-level refs come from a dedicated query;
 	// release-level refs are the exact subset of the anchors already loaded
 	// above (no second scan of the ref table).
+	//
+	// Refs is the rendered-identity projection (a consumer turns each entry
+	// into an upstream link), so it also drops anchors whose upstream entry is
+	// gone — dead_at IS NULL here, and the deadAnchors set for the
+	// release-level half. Anchors[] above deliberately keeps them.
 	var workRefs []struct {
 		Source     string
 		ExternalID string
 	}
 	if err := db.Raw(`SELECT s.key AS source, r.external_id
 		FROM catalog_external_ref r JOIN catalog_source s ON s.id = r.source_id
-		WHERE r.entity_type = ? AND r.entity_id = ? AND r.link_kind = ?
+		WHERE r.entity_type = ? AND r.entity_id = ? AND r.link_kind = ? AND r.dead_at IS NULL
 		ORDER BY s.key`, model.EntityTypeWork, workID, model.LinkKindExact).Scan(&workRefs).Error; err != nil {
 		return nil, err
 	}
@@ -427,6 +452,9 @@ func (s *ReadService) loadWorkDetail(ctx context.Context, workID int64, spoilers
 	}
 	for _, rd := range detail.Releases {
 		for _, a := range rd.Anchors {
+			if _, dead := deadAnchors[anchorKey{rd.Release.ID, a.Source, a.ExternalID}]; dead {
+				continue
+			}
 			if a.LinkKind == model.LinkKindExact {
 				detail.Refs = append(detail.Refs, RefDetail{
 					Source: a.Source, ExternalID: a.ExternalID,


### PR DESCRIPTION
VNDB deletes ~20 entries a week and we anchor 98.7% of it, so 133 works currently render a `vndb.org/v…` link that 404s.

Measured, not assumed:
- no redirect/tombstone data exists in the VNDB dump — a deleted entry has **no derivable successor** (0 unique matches over 111 candidates, matcher validated 300/300 on live anchors);
- 189 anchors carry `matched_by='rule:wiki-vndb-id'`, so **deleting the row just makes the importer put it back**;
- the dead set is **not** in any match-candidate queue (entity_type=5 queue is empty) and **squats nothing** (the id does not exist upstream, so no legitimate work needs the slot).

So the anchor stays and gains `dead_at`. It still records what the wiki asserted and still blocks a duplicate claim on its exact slot; it just stops reaching users.

`cmd/audit-vndb-anchors` marks absent ids and clears revived ones in one transaction, and **refuses to apply when `src_vndb.vn` looks mid-reload** — that window is the difference between marking 133 anchors dead and marking all 64,227.

**Migration required**: `catalog_external_ref` gains a nullable `dead_at timestamptz` (AutoMigrate, via `migrate-catalog`).