### PR TITLE
「我的提交」只显示自己提交的作品，新增 kind 供「我的审核」使用

### DIFF
--- a/apps/api/internal/platform/catalog/handler/user_claims_face.go
+++ b/apps/api/internal/platform/catalog/handler/user_claims_face.go
@@ -113,6 +113,7 @@ type userMineClaimsInput struct {
 	ClaimState string `query:"claim_state" doc:"Comma-separated subset of none, live, draft, pending, declined, hidden; absent = every state"`
 	Before     int64  `query:"before" doc:"Exclusive cursor: return works whose last_event_id is smaller (0 = first page)"`
 	Limit      int    `query:"limit" doc:"Page size (default 20, max 100)"`
+	Kind       string `query:"kind" doc:"Which events qualify the actor: submitted (works they own) or audited (works they reviewed but do not own). Absent = every work they touched"`
 }
 
 func (s *UserClaimServer) mine(ctx context.Context, in *userMineClaimsInput) (*userClaimsOutput, error) {
@@ -126,7 +127,7 @@ func (s *UserClaimServer) mine(ctx context.Context, in *userMineClaimsInput) (*u
 	}
 	items, total, err := s.claims.ClaimsByActor(ctx, service.UserClaimQuery{
 		ActorUID: uid, Site: site, ClaimStates: claimStates,
-		Before: in.Before, Limit: in.Limit,
+		Before: in.Before, Limit: in.Limit, Kind: in.Kind,
 	})
 	if err != nil {
 		slog.Error("catalog claims mine", "err", err)

--- a/apps/api/internal/platform/catalog/handler/user_claims_face_test.go
+++ b/apps/api/internal/platform/catalog/handler/user_claims_face_test.go
@@ -375,3 +375,59 @@ func TestUserClaims_Mine(t *testing.T) {
 	require.NoError(t, json.Unmarshal(raw, &errBody), string(raw))
 	assert.Equal(t, msgBadClaimState, errBody.Message)
 }
+
+func TestUserClaims_MineSubmittedVsAudited(t *testing.T) {
+	db := openCatalogTestDB(t)
+	resetClaims(t, db)
+	app := userClaimApp(db)
+
+	submit := func(token, name string) int64 {
+		status, raw := userEditReq(t, app, "POST", UserPrefix+"/works/submit", token,
+			fmt.Sprintf(`{"fields":{"catalog.work.display_name":%q}}`, name))
+		require.Equal(t, fiber.StatusOK, status, string(raw))
+		var env struct {
+			Data struct {
+				WorkID int64 `json:"work_id"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &env), string(raw))
+		return env.Data.WorkID
+	}
+
+	submitter := userToken(t, 861, ScopeCatalogEdit, "kungal-client")
+	reviewer := moderatorToken(t, 862)
+
+	workID := submit(submitter, "归属区分测试")
+	status, raw := userEditReq(t, app, "POST", userClaimActionPath(workID, "decline"), reviewer,
+		`{"reason":"区分审核"}`)
+	require.Equal(t, fiber.StatusOK, status, string(raw))
+
+	type minePage struct {
+		Data struct {
+			Items []struct {
+				WorkID int64 `json:"work_id"`
+			} `json:"items"`
+			Total int64 `json:"total"`
+		} `json:"data"`
+	}
+	get := func(query, token string) minePage {
+		status, raw := userEditReq(t, app, "GET", UserPrefix+"/claims/mine"+query, token, "")
+		require.Equal(t, fiber.StatusOK, status, string(raw))
+		var page minePage
+		require.NoError(t, json.Unmarshal(raw, &page), string(raw))
+		return page
+	}
+
+	submitted := get("?kind=submitted", submitter)
+	require.EqualValues(t, 1, submitted.Data.Total, "the submitter owns exactly one work")
+	require.Len(t, submitted.Data.Items, 1)
+	require.Equal(t, workID, submitted.Data.Items[0].WorkID)
+
+	audited := get("?kind=audited", reviewer)
+	require.EqualValues(t, 1, audited.Data.Total, "the reviewer reviewed exactly one work")
+	require.Len(t, audited.Data.Items, 1)
+	require.Equal(t, workID, audited.Data.Items[0].WorkID)
+
+	require.Zero(t, get("?kind=audited", submitter).Data.Total, "the submitter reviewed nothing")
+	require.Zero(t, get("?kind=submitted", reviewer).Data.Total, "the reviewer submitted nothing")
+}

--- a/apps/api/internal/platform/catalog/service/user_claims.go
+++ b/apps/api/internal/platform/catalog/service/user_claims.go
@@ -29,6 +29,11 @@ type UserClaimQuery struct {
 	ClaimStates []string
 	Before      int64
 	Limit       int
+	// Kind narrows which events qualify the actor: "submitted" keeps only the
+	// works the actor owns (their own submissions), "audited" keeps only the
+	// works the actor reviewed but does not own. Empty = every work the actor
+	// touched (the historical behaviour).
+	Kind string
 }
 
 func (s *ClaimLifecycleService) ClaimsByActor(ctx context.Context, q UserClaimQuery) ([]UserClaimItem, int64, error) {
@@ -39,6 +44,16 @@ func (s *ClaimLifecycleService) ClaimsByActor(ctx context.Context, q UserClaimQu
 	stateGate, stateArgs := claimStateWhere(q.ClaimStates)
 	if stateGate != "" {
 		stateGate = " AND " + stateGate
+	}
+	ownerGate := ""
+	var ownerArgs []any
+	switch q.Kind {
+	case "submitted":
+		ownerGate = " AND w.owner_user_id = ?"
+		ownerArgs = []any{q.ActorUID}
+	case "audited":
+		ownerGate = " AND w.owner_user_id IS DISTINCT FROM ?"
+		ownerArgs = []any{q.ActorUID}
 	}
 
 	const from = `
@@ -54,12 +69,13 @@ func (s *ClaimLifecycleService) ClaimsByActor(ctx context.Context, q UserClaimQu
 
 	baseArgs := func() []any {
 		args := []any{q.ActorUID, q.Site, q.Site}
-		return append(args, stateArgs...)
+		args = append(args, stateArgs...)
+		return append(args, ownerArgs...)
 	}
 
 	var total int64
 	if err := s.db.WithContext(ctx).
-		Raw(`SELECT count(*)`+from+` WHERE true`+stateGate, baseArgs()...).
+		Raw(`SELECT count(*)`+from+` WHERE true`+stateGate+ownerGate, baseArgs()...).
 		Scan(&total).Error; err != nil {
 		return nil, 0, err
 	}
@@ -96,7 +112,7 @@ func (s *ClaimLifecycleService) ClaimsByActor(ctx context.Context, q UserClaimQu
 		    ORDER BY le.id DESC
 		    LIMIT 1
 		) le ON true
-		WHERE true`+stateGate+`
+		WHERE true`+stateGate+ownerGate+`
 		  AND (? <= 0 OR le.id < ?)
 		ORDER BY le.id DESC
 		LIMIT ?`, args...).Scan(&rows).Error; err != nil {

--- a/apps/web/shared/types/generated/catalog-api.ts
+++ b/apps/web/shared/types/generated/catalog-api.ts
@@ -2847,6 +2847,8 @@ export interface operations {
                 before?: number;
                 /** @description Page size (default 20, max 100) */
                 limit?: number;
+                /** @description Which events qualify the actor: submitted (works they own) or audited (works they reviewed but do not own). Absent = every work they touched */
+                kind?: string;
             };
             header?: never;
             path?: never;

--- a/docs/catalog/openapi.yaml
+++ b/docs/catalog/openapi.yaml
@@ -3884,6 +3884,13 @@ paths:
             description: Page size (default 20, max 100)
             format: int64
             type: integer
+        - description: "Which events qualify the actor: submitted (works they own) or audited (works they reviewed but do not own). Absent = every work they touched"
+          explode: false
+          in: query
+          name: kind
+          schema:
+            description: "Which events qualify the actor: submitted (works they own) or audited (works they reviewed but do not own). Absent = every work they touched"
+            type: string
       responses:
         "200":
           content:


### PR DESCRIPTION
## 问题

https://www.kungal.com/update/todo 的待办之一：发布 Galgame 的「我的提交」界面，被我拒绝的申请会出现在自己的提交列表里。

根因：`/claims/mine` 返回的是"该用户碰过的所有作品"，既包括自己提交的，也包括作为审核者处理过的（含被拒绝的），两者混在一起。

## 修改

- `UserClaimQuery` 新增 `Kind` 过滤：`submitted` 只保留自己拥有的作品（`owner_user_id = actor`），`audited` 只保留自己审核过但不拥有的作品（`owner_user_id IS DISTINCT FROM actor`）。
- `claims/mine` 接受 `kind` 查询参数并透传给服务层。
- 新增 `TestUserClaims_MineSubmittedVsAudited`，验证提交者 / 审核者各自只看到属于自己的那部分。

## 依赖关系（重要）

本 PR 与「加载更多分页修复」PR（#10）都改动了 `user_claims_face.go` —— `kind` 参数与 `next_before` 逻辑都在同一个 `mine()` 函数里。因此：

- **本 PR 必须在分页 PR #10 合并后再合入**。
- 合入时需在 #10 合并后的 main 上 rebase，以解决 `user_claims_face.go` 的冲突（两者改动互不重叠，rebase 后各自保留即可）。

请先合并 #10，再合并本 PR。