### PR TITLE
fix(catalog): treat = and ＝ as word separators in search indexes

### DIFF
--- a/apps/api/internal/platform/catalog/search/cjk_recall_test.go
+++ b/apps/api/internal/platform/catalog/search/cjk_recall_test.go
@@ -50,6 +50,36 @@ func TestEnsureIndexesResetsWorksLocalePins(t *testing.T) {
 	assert.Empty(t, got, "EnsureIndexes must clear pins it no longer declares")
 }
 
+func TestWorksEqualsDelimiterTitleRecall(t *testing.T) {
+	require.NoError(t, EnsureIndexes(testClient))
+	t.Cleanup(func() { _, _ = testClient.Svc().DeleteIndex(testClient.IndexUID(IndexWorks)) })
+
+	docs := []EntityDoc{
+		{ID: "w1", EntityType: "work", NameJa: "ココロネ＝ペンデュラム！"},
+		{ID: "w2", EntityType: "work", NameJa: "ココロネ=ペンデュラム！"},
+	}
+	task, err := testClient.Index(IndexWorks).AddDocuments(docs, nil)
+	require.NoError(t, err)
+	_, err = testClient.Svc().WaitForTask(task.TaskUID, 0)
+	require.NoError(t, err)
+
+	idx := NewIndexer(testClient)
+	for _, tc := range []struct{ name, q, want string }{
+		{"left of fullwidth equals", "ココロネ", "w1"},
+		{"right of fullwidth equals", "ペンデュラム", "w1"},
+		{"left of ascii equals", "ココロネ", "w2"},
+		{"right of ascii equals", "ペンデュラム", "w2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := idx.SearchWorks(t.Context(), WorksQuery{Q: tc.q, Limit: 12})
+			require.NoError(t, err)
+			id, ok := WorkDocIDToWorkID(tc.want)
+			require.True(t, ok)
+			assert.Contains(t, res.IDs, id, "%q must recall %s", tc.q, tc.want)
+		})
+	}
+}
+
 func TestWorksCJKTitleRecall(t *testing.T) {
 	require.NoError(t, EnsureIndexes(testClient))
 	t.Cleanup(func() { _, _ = testClient.Svc().DeleteIndex(testClient.IndexUID(IndexWorks)) })

--- a/apps/api/internal/platform/catalog/search/index.go
+++ b/apps/api/internal/platform/catalog/search/index.go
@@ -41,6 +41,17 @@ var entityRankingRules = []string{
 	"words", "typo", "proximity", "attribute", "sort", "exactness", "popularity:desc",
 }
 
+// equalsSeparators pins '=' (U+003D) and '＝' (U+FF1D) as word separators.
+// charabia's default separator list covers the whole Sm math-symbol category but
+// skips these two: they live in Basic Latin and Halfwidth/Fullwidth Forms, not
+// the U+2200–U+22FF operators block. Galgame titles use '＝' as the
+// main-title/subtitle delimiter, so without this the split is left to the
+// Japanese segmenter's dictionary version — and on the version that attaches
+// '＝' to the left token, a bare "ココロネ" query missed "ココロネ＝ペンデュラム！"
+// while "ココロネ＝" still matched. Declaring them here makes the boundary
+// deterministic regardless of segmenter version.
+var equalsSeparators = []string{"=", "＝"}
+
 func creditNamesSettings() *meilisearch.Settings {
 	return &meilisearch.Settings{
 		SearchableAttributes: entityNameSearchable(),
@@ -48,6 +59,7 @@ func creditNamesSettings() *meilisearch.Settings {
 		SortableAttributes:   []string{"popularity"},
 		RankingRules:         entityRankingRules,
 		LocalizedAttributes:  localizedAttributes(),
+		SeparatorTokens:      equalsSeparators,
 		TypoTolerance: &meilisearch.TypoTolerance{
 			Enabled:             true,
 			DisableOnAttributes: cjkTypoDisabled(),
@@ -69,6 +81,7 @@ func charactersSettings() *meilisearch.Settings {
 		SortableAttributes:   []string{"popularity"},
 		RankingRules:         entityRankingRules,
 		LocalizedAttributes:  localizedAttributes(),
+		SeparatorTokens:      equalsSeparators,
 		TypoTolerance:        &meilisearch.TypoTolerance{Enabled: true, DisableOnAttributes: cjkTypoDisabled()},
 	}
 }
@@ -80,6 +93,7 @@ func labelsSettings() *meilisearch.Settings {
 		SortableAttributes:   []string{"popularity"},
 		RankingRules:         entityRankingRules,
 		LocalizedAttributes:  localizedAttributes(),
+		SeparatorTokens:      equalsSeparators,
 		TypoTolerance:        &meilisearch.TypoTolerance{Enabled: true, DisableOnAttributes: cjkTypoDisabled()},
 	}
 }
@@ -111,6 +125,7 @@ func worksSettings() *meilisearch.Settings {
 		FilterableAttributes: WorksFilterableAttributes,
 		SortableAttributes:   WorksSortableAttributes,
 		RankingRules:         entityRankingRules,
+		SeparatorTokens:      equalsSeparators,
 		TypoTolerance: &meilisearch.TypoTolerance{
 			Enabled: true, DisableOnAttributes: cjkTypoDisabled(worksIntroSearchable...),
 		},
@@ -125,6 +140,7 @@ func tagsSettings() *meilisearch.Settings {
 		SortableAttributes:   []string{"popularity"},
 		RankingRules:         entityRankingRules,
 		LocalizedAttributes:  localizedAttributes(),
+		SeparatorTokens:      equalsSeparators,
 		TypoTolerance:        &meilisearch.TypoTolerance{Enabled: true, DisableOnAttributes: cjkTypoDisabled()},
 	}
 }

--- a/apps/api/internal/platform/catalog/search/search_test.go
+++ b/apps/api/internal/platform/catalog/search/search_test.go
@@ -68,6 +68,8 @@ func TestEnsureIndexesMatchesMatrix(t *testing.T) {
 		assert.Contains(t, s.TypoTolerance.DisableOnAttributes, "name_zh", uid)
 		assert.NotContains(t, s.TypoTolerance.DisableOnAttributes, "latin", uid)
 
+		assert.Equal(t, []string{"=", "＝"}, s.SeparatorTokens, uid)
+
 		if uid != IndexTags {
 			for _, f := range []string{"aliases_ja", "aliases_zh", "aliases_other"} {
 				assert.Contains(t, s.SearchableAttributes, f, uid)


### PR DESCRIPTION
## Problem

Searching a galgame by the left half of an `=`-delimited title returns nothing.

`ココロネ＝ペンデュラム！` reproduces it:

- `ペンデュラム！` → found
- `ココロネ` → not found
- `ココロネ＝` → found (only with the trailing `=`) 

## Root cause

`=` (U+003D) and `＝` (U+FF1D) are **not** in charabia's default separator
list. That list covers the whole `Sm` math-symbol category, but the two equals
signs live in *Basic Latin* and *Halfwidth/Fullwidth Forms* — not the
U+2200–U+22FF operators block — so they are not recognized as word boundaries.

The split of `ココロネ＝ペンデュラム！` is therefore left entirely to the
Japanese segmenter's dictionary version. On the version that attaches `＝` to
the left token (`ココロネ＝`), a bare `ココロネ` query misses the work while
`ココロネ＝` still matches — exactly the symptom above. (The dev stack's
Meilisearch v1.45 already splits correctly, which is why the bug could not be
reproduced there.)

## Fix

Declare `=` and `＝` as `separator-tokens` on every catalog search index
(`catalog_works`, `catalog_credit_names`, `catalog_characters`,
`catalog_labels`, `catalog_tags`). Separator tokens are applied before
language segmentation, so the boundary becomes deterministic regardless of the
segmenter version.

- `apps/api/internal/platform/catalog/search/index.go`
- tests: `TestWorksEqualsDelimiterTitleRecall` + a `SeparatorTokens` assertion
  in `TestEnsureIndexesMatchesMatrix`

## Where the fix takes effect

The settings are applied by `EnsureIndexes` on service startup, **but
Meilisearch does not re-tokenize existing documents when `separator-tokens`
changes** (the settings update does not trigger a re-index). The fix only bites
after a **manual re-index**:

- Production: run `reindex-catalog` via `infra-tools` after deploy (same as
  migrations — deployment does not run it automatically).
- Local dev: `go run ./cmd/reindex-catalog` (already part of
  `scripts/dev-seed-catchup.sh`).
