### PR TITLE
fix(jobs): name the cause when a tag backfill counts write failures

### DIFF
--- a/apps/api/cmd/backfill-bgm-work-meta/main.go
+++ b/apps/api/cmd/backfill-bgm-work-meta/main.go
@@ -59,7 +59,10 @@ func main() {
 		slog.Info("DRY RUN — nothing written; re-run with --apply")
 	}
 	// 2026-08-05: the sibling backfill-work-tags run logged errors=120646 and still exited 0 - nothing fired.
+	// The per-row cause is at WARN under "write meta tag" / "write favorite shelf", neither of which names
+	// this tool, so the weekly log read as a bare errors=N for 15 days. Restate the first one here.
 	if st.Errors > 0 {
+		slog.Error("backfill-bgm-work-meta write failures", "errors", st.Errors, "first_error", st.FirstError)
 		os.Exit(1)
 	}
 }

--- a/apps/api/cmd/backfill-work-tags/main.go
+++ b/apps/api/cmd/backfill-work-tags/main.go
@@ -53,7 +53,11 @@ func main() {
 		slog.Info("DRY RUN — nothing written; re-run with --apply")
 	}
 	// 2026-08-05: 120,646 failed writes exited 0, so neither the cron failure trap nor the watchdog fired.
+	// The cause is also logged per row, but at WARN and under a message that does not name this tool
+	// ("write tag"), so grepping the weekly log for "backfill-work-tags" found 15 days of errors=N and
+	// not one line saying why — it was a NOT NULL column the staged binary predated. Restate it here.
 	if st.Errors > 0 {
+		slog.Error("backfill-work-tags write failures", "errors", st.Errors, "first_error", st.FirstError)
 		os.Exit(1)
 	}
 }

--- a/apps/api/internal/jobs/bgmworkmeta/bgmworkmeta.go
+++ b/apps/api/internal/jobs/bgmworkmeta/bgmworkmeta.go
@@ -61,7 +61,8 @@ type Stats struct {
 	FavWritten    int
 	FavUnchanged  int
 
-	Errors int
+	Errors     int
+	FirstError string
 
 	MetaTopNames []NameFreq
 	MetaSamples  []TagSample

--- a/apps/api/internal/jobs/bgmworkmeta/write.go
+++ b/apps/api/internal/jobs/bgmworkmeta/write.go
@@ -21,6 +21,13 @@ func (w *writer) touch(ctx context.Context) error {
 	return repository.TouchWorks(ctx, w.db, w.touched)
 }
 
+func (w *writer) noteError(err error) {
+	w.stats.Errors++
+	if w.stats.FirstError == "" {
+		w.stats.FirstError = err.Error()
+	}
+}
+
 type tagRow struct {
 	WorkID   int64
 	SourceID int16
@@ -38,7 +45,7 @@ func (w *writer) writeTag(ctx context.Context, p tagRow, apply bool) {
 		WorkID: p.WorkID, Name: p.Name, Count: 0, SourceID: p.SourceID,
 	})
 	if res.Error != nil {
-		w.stats.Errors++
+		w.noteError(res.Error)
 		slog.Warn("write meta tag", "work", p.WorkID, "name", p.Name, "err", res.Error)
 		return
 	}
@@ -70,7 +77,7 @@ func (w *writer) writeFavorite(ctx context.Context, p favRow, apply bool) {
 		WorkID: p.WorkID, SourceID: p.SourceID, Metric: p.Metric, Value: p.Value,
 	})
 	if res.Error != nil {
-		w.stats.Errors++
+		w.noteError(res.Error)
 		slog.Warn("write favorite shelf", "work", p.WorkID, "metric", p.Metric, "err", res.Error)
 		return
 	}

--- a/apps/api/internal/jobs/bgmworkmeta/write_test.go
+++ b/apps/api/internal/jobs/bgmworkmeta/write_test.go
@@ -1,0 +1,19 @@
+package bgmworkmeta
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNoteErrorKeepsTheFirstCause(t *testing.T) {
+	w := &writer{stats: &Stats{}}
+	w.noteError(errors.New(`null value in column "spoiler" violates not-null constraint`))
+	w.noteError(errors.New("a later, less interesting failure"))
+
+	if w.stats.Errors != 2 {
+		t.Errorf("Errors = %d, want 2", w.stats.Errors)
+	}
+	if want := `null value in column "spoiler" violates not-null constraint`; w.stats.FirstError != want {
+		t.Errorf("FirstError = %q, want %q", w.stats.FirstError, want)
+	}
+}

--- a/apps/api/internal/jobs/worktags/worktags.go
+++ b/apps/api/internal/jobs/worktags/worktags.go
@@ -47,6 +47,7 @@ type Stats struct {
 	Written      int
 	Conflict     int
 	Errors       int
+	FirstError   string
 
 	DistinctNames int
 	TopNames      []NameFreq

--- a/apps/api/internal/jobs/worktags/write.go
+++ b/apps/api/internal/jobs/worktags/write.go
@@ -35,7 +35,7 @@ func (w *writer) write(ctx context.Context, p plannedRow, apply bool) {
 		WorkID: p.WorkID, Name: p.Name, Count: p.Count, SourceID: p.SourceID,
 	})
 	if res.Error != nil {
-		w.stats.Errors++
+		w.noteError(res.Error)
 		slog.Warn("write tag", "work", p.WorkID, "name", p.Name, "source", p.SourceID, "err", res.Error)
 		return
 	}
@@ -45,6 +45,13 @@ func (w *writer) write(ctx context.Context, p plannedRow, apply bool) {
 	}
 	w.stats.Written++
 	w.touched = append(w.touched, p.WorkID)
+}
+
+func (w *writer) noteError(err error) {
+	w.stats.Errors++
+	if w.stats.FirstError == "" {
+		w.stats.FirstError = err.Error()
+	}
 }
 
 func (w *writer) touch(ctx context.Context) error {

--- a/apps/api/internal/jobs/worktags/write_test.go
+++ b/apps/api/internal/jobs/worktags/write_test.go
@@ -1,0 +1,19 @@
+package worktags
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNoteErrorKeepsTheFirstCause(t *testing.T) {
+	w := &writer{stats: &Stats{}}
+	w.noteError(errors.New(`null value in column "spoiler" violates not-null constraint`))
+	w.noteError(errors.New("a later, less interesting failure"))
+
+	if w.stats.Errors != 2 {
+		t.Errorf("Errors = %d, want 2", w.stats.Errors)
+	}
+	if want := `null value in column "spoiler" violates not-null constraint`; w.stats.FirstError != want {
+		t.Errorf("FirstError = %q, want %q", w.stats.FirstError, want)
+	}
+}


### PR DESCRIPTION
## What

`backfill-work-tags` and `backfill-bgm-work-meta` wrote **zero rows for 15 days** (2026-07-29 → 2026-08-12) while their summaries read `errors=80507` / `errors=40531`.

The cause was in the log the whole time — but only as a per-row `WARN` under `write tag` / `write meta tag` / `write favorite shelf`, none of which carries the tool name. Grepping the weekly log by tool name therefore found the bare counter and not one line saying why.

```
ERROR: null value in column "spoiler" of relation "catalog_work_tag"
violates not-null constraint (SQLSTATE 23502)
```

The staged binaries predated the migration that added `catalog_work_tag.spoiler` / `.sexual` as `NOT NULL` with no default, so every INSERT omitted both columns and died.

## Fix

That half is **already fixed** by the staged-binary eradication — both tools now run from the digest-pinned `infra-tools` image, so they carry HEAD's model.

This PR closes the remaining hole: keep the first error on `Stats` and restate it at `slog.Error` next to the non-zero exit, so `errors=N` is never again a count without a cause.

## Production verification (today)

Ran both tools against `kun_catalog` from the digest-pinned image:

| tool | before (08-12) | after |
|---|---|---|
| `backfill-work-tags` | `planned=80507 written=0 errors=80507` | `candidates=31153 planned=196470 written=5816 conflict=190654 **errors=0**` |
| `backfill-bgm-work-meta` | `meta_planned=40531 written=0 errors=40531` | `meta_planned=90891 meta_written=65 fav_planned=155765 fav_written=10188 **errors=0**` |

16,069 rows written in total — the feared flood did not materialise; 190,654 tag rows and 145,577 shelf values were already correct and hit the conflict/unchanged paths.