### PR TITLE
fix: class-level search delimiter tokens + dev OAuth URL override removal

### DIFF
--- a/apps/api/internal/platform/catalog/search/cjk_recall_test.go
+++ b/apps/api/internal/platform/catalog/search/cjk_recall_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,6 +79,59 @@ func TestWorksCJKTitleRecall(t *testing.T) {
 			id, ok := WorkDocIDToWorkID(tc.want)
 			require.True(t, ok)
 			assert.Contains(t, res.IDs, id, "%q must recall %s", tc.q, tc.want)
+		})
+	}
+}
+
+func TestWorksTitleDelimiterRecall(t *testing.T) {
+	require.NoError(t, EnsureIndexes(testClient))
+	t.Cleanup(func() { _, _ = testClient.Svc().DeleteIndex(testClient.IndexUID(IndexWorks)) })
+
+	// Dropping SeparatorTokens from worksSettings turns the same 7 of 14
+	// (=☆★✕♪♭♯) red on dev Meili v1.45 — but each lane loses a different half:
+	// ja loses the LEFT one (`ココロネ`, the PR #12 symptom) while latin loses the
+	// RIGHT one (`Kokorone` still matches the merged token as a prefix). One lane,
+	// or one half, would have looked green while the bug was live.
+	lanes := []struct {
+		name, left, right, suffix string
+		base                      int64
+		ja                        bool
+	}{
+		{name: "ja", left: "ココロネ", right: "ペンデュラム", suffix: "！", base: 1, ja: true},
+		{name: "latin", left: "Kokorone", right: "Pendulum", base: 101},
+	}
+
+	docs := make([]EntityDoc, 0, len(lanes)*len(titleDelimiterSeparators))
+	for _, lane := range lanes {
+		for i, sep := range titleDelimiterSeparators {
+			d := EntityDoc{ID: WorkDocID(lane.base + int64(i)), EntityType: "work"}
+			if lane.ja {
+				d.NameJa = lane.left + sep + lane.right + lane.suffix
+			} else {
+				d.Latin = lane.left + sep + lane.right + lane.suffix
+			}
+			docs = append(docs, d)
+		}
+	}
+	task, err := testClient.Index(IndexWorks).AddDocuments(docs, nil)
+	require.NoError(t, err)
+	_, err = testClient.Svc().WaitForTask(task.TaskUID, 0)
+	require.NoError(t, err)
+
+	idx := NewIndexer(testClient)
+	for _, lane := range lanes {
+		t.Run(lane.name, func(t *testing.T) {
+			for i, sep := range titleDelimiterSeparators {
+				want := lane.base + int64(i)
+				t.Run(fmt.Sprintf("%s_U+%04X", sep, []rune(sep)[0]), func(t *testing.T) {
+					for _, half := range []string{lane.left, lane.right} {
+						res, err := idx.SearchWorks(t.Context(), WorksQuery{Q: half, Limit: 50})
+						require.NoError(t, err)
+						assert.Contains(t, res.IDs, want, "%q must recall %s",
+							half, lane.left+sep+lane.right+lane.suffix)
+					}
+				})
+			}
 		})
 	}
 }

--- a/apps/api/internal/platform/catalog/search/index.go
+++ b/apps/api/internal/platform/catalog/search/index.go
@@ -41,6 +41,16 @@ var entityRankingRules = []string{
 	"words", "typo", "proximity", "attribute", "sort", "exactness", "popularity:desc",
 }
 
+// PR #12: searching `ココロネ` alone recalled nothing for `ココロネ＝ペンデュラム！` in prod.
+// charabia's default separators are the Unicode punctuation/space categories plus the
+// U+2200-U+22FF operators block, so `=`, `＝`, `～` and every So char (☆★✕♪♭♯) sit outside
+// it and the boundary falls to the segmenter's dictionary — dev Meili v1.45 splits `＝`,
+// prod's version does not. This list is a census of the 447k-title prod corpus; declaring
+// every delimiter class explicitly is what stops tokenization from being version-dependent.
+var titleDelimiterSeparators = []string{
+	"=", "＝", "☆", "★", "×", "✕", "～", "〜", "・", "♪", "♭", "♯", "†", "‡",
+}
+
 func creditNamesSettings() *meilisearch.Settings {
 	return &meilisearch.Settings{
 		SearchableAttributes: entityNameSearchable(),
@@ -48,6 +58,7 @@ func creditNamesSettings() *meilisearch.Settings {
 		SortableAttributes:   []string{"popularity"},
 		RankingRules:         entityRankingRules,
 		LocalizedAttributes:  localizedAttributes(),
+		SeparatorTokens:      titleDelimiterSeparators,
 		TypoTolerance: &meilisearch.TypoTolerance{
 			Enabled:             true,
 			DisableOnAttributes: cjkTypoDisabled(),
@@ -69,6 +80,7 @@ func charactersSettings() *meilisearch.Settings {
 		SortableAttributes:   []string{"popularity"},
 		RankingRules:         entityRankingRules,
 		LocalizedAttributes:  localizedAttributes(),
+		SeparatorTokens:      titleDelimiterSeparators,
 		TypoTolerance:        &meilisearch.TypoTolerance{Enabled: true, DisableOnAttributes: cjkTypoDisabled()},
 	}
 }
@@ -80,6 +92,7 @@ func labelsSettings() *meilisearch.Settings {
 		SortableAttributes:   []string{"popularity"},
 		RankingRules:         entityRankingRules,
 		LocalizedAttributes:  localizedAttributes(),
+		SeparatorTokens:      titleDelimiterSeparators,
 		TypoTolerance:        &meilisearch.TypoTolerance{Enabled: true, DisableOnAttributes: cjkTypoDisabled()},
 	}
 }
@@ -111,6 +124,7 @@ func worksSettings() *meilisearch.Settings {
 		FilterableAttributes: WorksFilterableAttributes,
 		SortableAttributes:   WorksSortableAttributes,
 		RankingRules:         entityRankingRules,
+		SeparatorTokens:      titleDelimiterSeparators,
 		TypoTolerance: &meilisearch.TypoTolerance{
 			Enabled: true, DisableOnAttributes: cjkTypoDisabled(worksIntroSearchable...),
 		},
@@ -125,6 +139,7 @@ func tagsSettings() *meilisearch.Settings {
 		SortableAttributes:   []string{"popularity"},
 		RankingRules:         entityRankingRules,
 		LocalizedAttributes:  localizedAttributes(),
+		SeparatorTokens:      titleDelimiterSeparators,
 		TypoTolerance:        &meilisearch.TypoTolerance{Enabled: true, DisableOnAttributes: cjkTypoDisabled()},
 	}
 }

--- a/apps/api/internal/platform/catalog/search/search_test.go
+++ b/apps/api/internal/platform/catalog/search/search_test.go
@@ -63,6 +63,8 @@ func TestEnsureIndexesMatchesMatrix(t *testing.T) {
 			assert.Equal(t, []string{"cmn"}, locales["*_zh"], uid)
 		}
 
+		assert.ElementsMatch(t, titleDelimiterSeparators, s.SeparatorTokens, uid)
+
 		require.NotNil(t, s.TypoTolerance, uid)
 		assert.Contains(t, s.TypoTolerance.DisableOnAttributes, "name_ja", uid)
 		assert.Contains(t, s.TypoTolerance.DisableOnAttributes, "name_zh", uid)

--- a/apps/web/shared/types/generated/catalog-api.ts
+++ b/apps/web/shared/types/generated/catalog-api.ts
@@ -1953,7 +1953,7 @@ export interface components {
             value: number;
         };
         WorkRating: {
-            /** @description vote histogram on the source-native scale, ascending, sparse (an absent bucket has no votes); detail face only. Published by bangumi (1-10) and dlsite (1-5); absent for vndb and erogamescape, which publish no histogram */
+            /** @description vote histogram on the source-native scale, ascending, sparse (an absent bucket has no votes); detail face only. All four sources publish it: bangumi 1-10, dlsite 1-5, vndb 1-10, erogamescape 0-100 in decile steps (0, 10, ... 100). The bars do not share one denominator: bangumi and dlsite publish the histogram together with the aggregate, so their bars sum to vote_count; erogamescape bars are computed from the reviews mirror, which syncs on a cursor independent of the row score and vote_count come from, so sum-of-bars is the histogram's own denominator and need not equal vote_count; vndb bars come from the public votes dump, which omits votes on private lists, so they sum to at most vote_count */
             distribution?: components["schemas"]["RatingBucket"][] | null;
             /**
              * Format: int64
@@ -1967,10 +1967,10 @@ export interface components {
             score: number;
             /**
              * Format: int32
-             * @description catalog_source id (provenance + scale selector): vndb = 1-10 mean, bangumi = 0-10 mean, dlsite = 0-5 star mean, erogamescape = 0-100 median
+             * @description catalog_source id (provenance + scale selector): vndb = 1-10 bayesian-smoothed rating, bangumi = 0-10 mean, dlsite = 0-5 star mean, erogamescape = 0-100 median
              */
             source_id: number;
-            /** @description spread of the same vote population as score; detail face only. Carried by erogamescape alone, which publishes these instead of a histogram */
+            /** @description spread of the same vote population as score; detail face only. Carried by erogamescape (average, stdev, min and max, on its 0-100 scale) and by vndb (average only — the plain mean beside the bayesian-smoothed rating that score holds). bangumi and dlsite carry no stats */
             stats?: components["schemas"]["RatingStats"];
             /**
              * Format: int64

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -89,7 +89,6 @@ x-dev-env: &dev-env
   KUN_FRONTEND_CORS_ORIGIN: http://localhost:3000,http://127.0.0.1:3000,http://localhost:3001,http://127.0.0.1:3001,http://localhost:2333,http://127.0.0.1:2333,http://localhost:6969,http://127.0.0.1:6969,http://localhost:9420,http://127.0.0.1:9420,http://localhost:5364,http://127.0.0.1:5364,http://localhost:15008,http://127.0.0.1:15008,http://localhost:15009,http://127.0.0.1:15009,http://localhost:15011,http://127.0.0.1:15011,http://localhost:15013,http://127.0.0.1:15013
   # oauth identity URLs — the local oauth service
   KUN_SITE_URL: http://127.0.0.1:9277
-  KUN_FRONTEND_URL: http://127.0.0.1:9277
   # image_service S3 → local MinIO (path-style). Dev key = the MinIO root user.
   # The image service os.Exit(1)s on empty key/secret/bucket, so these are set.
   KUN_IMAGE_S3_ENDPOINT: http://127.0.0.1:9000

--- a/docs/catalog/openapi.yaml
+++ b/docs/catalog/openapi.yaml
@@ -2724,7 +2724,7 @@ components:
       additionalProperties: false
       properties:
         distribution:
-          description: vote histogram on the source-native scale, ascending, sparse (an absent bucket has no votes); detail face only. Published by bangumi (1-10) and dlsite (1-5); absent for vndb and erogamescape, which publish no histogram
+          description: "vote histogram on the source-native scale, ascending, sparse (an absent bucket has no votes); detail face only. All four sources publish it: bangumi 1-10, dlsite 1-5, vndb 1-10, erogamescape 0-100 in decile steps (0, 10, ... 100). The bars do not share one denominator: bangumi and dlsite publish the histogram together with the aggregate, so their bars sum to vote_count; erogamescape bars are computed from the reviews mirror, which syncs on a cursor independent of the row score and vote_count come from, so sum-of-bars is the histogram's own denominator and need not equal vote_count; vndb bars come from the public votes dump, which omits votes on private lists, so they sum to at most vote_count"
           items:
             $ref: "#/components/schemas/RatingBucket"
           type:
@@ -2739,12 +2739,12 @@ components:
           format: double
           type: number
         source_id:
-          description: "catalog_source id (provenance + scale selector): vndb = 1-10 mean, bangumi = 0-10 mean, dlsite = 0-5 star mean, erogamescape = 0-100 median"
+          description: "catalog_source id (provenance + scale selector): vndb = 1-10 bayesian-smoothed rating, bangumi = 0-10 mean, dlsite = 0-5 star mean, erogamescape = 0-100 median"
           format: int32
           type: integer
         stats:
           $ref: "#/components/schemas/RatingStats"
-          description: spread of the same vote population as score; detail face only. Carried by erogamescape alone, which publishes these instead of a histogram
+          description: spread of the same vote population as score; detail face only. Carried by erogamescape (average, stdev, min and max, on its 0-100 scale) and by vndb (average only — the plain mean beside the bayesian-smoothed rating that score holds). bangumi and dlsite carry no stats
         vote_count:
           description: number of ratings backing the score
           format: int64


### PR DESCRIPTION
Supersedes community PRs #12 and #6 (closed with commit references; contributors credited via `Co-authored-by`).

## 9469b2ae — fix(catalog): title delimiters as separator tokens (co-authored with @GBLELDER)

#12 correctly root-caused the `ココロネ＝ペンデュラム！` recall failure (charabia's default separators don't cover `=`/`＝`; the boundary falls to the segmenter's dictionary version, and prod/dev Meili versions diverge) but fixed only the reproduced char pair — 256 titles in the prod corpus. A census of the 447k-title prod corpus found the sibling delimiter classes are 20–250× larger (`～〜` 63,726 / `・` 12,412 / `♪♭♯` 10,806 / `×✕` 10,168 / `☆★` 4,656 / `†‡` 188), so this declares every class explicitly on all five catalog indexes:

```
= ＝ ☆ ★ × ✕ ～ 〜 ・ ♪ ♭ ♯ † ‡
```

Verified against charabia's actual `separators.rs`: `× 〜 ・ † ‡` are already defaults (harmless no-ops declared for version-independence); `= ＝ ☆ ★ ✕ ～ ♪ ♭ ♯` are not.

Tests: `TestWorksTitleDelimiterRecall` — ja + latin lanes × 14 chars × both halves (28 subtests), negative-control-verified (dropping the setting turns 14 subtests red; the two lanes fail on *opposite* halves, so either lane alone would have been a false green). `TestEnsureIndexesMatchesMatrix` asserts the list on all five indexes.

**Ops correction to #12's body**: Meilisearch *does* re-tokenize existing documents when `separator-tokens` changes (empirically verified: a pre-change miss flips to a hit after only the settings PUT, documents untouched). A normal catalog redeploy applies the fix via `EnsureIndexes` — no manual `reindex-catalog` pass required. The settings task will re-tokenize ~102k affected titles; spot-check recall after it completes.

## a2b999c5 — fix(dev): drop the stale KUN_FRONTEND_URL override (co-authored with @Satou456)

#6 correctly diagnosed that the dev compose pinned `KUN_FRONTEND_URL` to `:9277` (the OAuth API itself), stranding full-profile OAuth logins on the backend port. The code default in `pkg/config` is already the correct `http://127.0.0.1:9420` — the compose line was a duplicate of that default, and the duplicate is what drifted. Deleting it (rather than correcting it) removes the drift surface; every remaining `KUN_FRONTEND_URL` reference repo-wide was audited (code default / `.env.example` / prod compose / legacy full-docker templates — all correct for their contexts).

No migration required. No schema change.

## ac7d11ff — fix(catalog): re-emit the S2S spec the rating description wave missed

Pre-existing main breakage this PR inherited (unit gate red on main since the rating-description wave merged): that wave re-emitted the public and admin catalog specs but not `docs/catalog/openapi.yaml`, so the S2S face still carried the pre-wave text and the spec-sync gate — and `build-and-push` with it — failed on main. Regenerated with the exact CI command set (only this file drifted), plus the paired `apps/web` generated TS types whose JSDoc carries the same three description strings (the `openapi-types` gate would have gone red next without them).
