### PR TITLE
fix(tagcanon): match entity names with the space a tagger does not type

### DIFF
--- a/apps/api/internal/jobs/tagcanon/logic_test.go
+++ b/apps/api/internal/jobs/tagcanon/logic_test.go
@@ -21,7 +21,8 @@ func TestBgmJunk(t *testing.T) {
 		blocked: map[string]string{
 			"avantgarde": "label", "ディーゼルマイン": "label",
 			"御苑生メイ": "person", "竹子社": "label_alias",
-			"sim": "label", "巨乳": "person_alias",
+			"鈴木達央": "person",
+			"sim":  "label", "巨乳": "person_alias",
 		},
 		vocab: map[string]struct{}{"巨乳": {}},
 	}
@@ -39,6 +40,7 @@ func TestBgmJunk(t *testing.T) {
 		{"ディーゼルマイン", "label"},
 		{"御苑生メイ", "person"},
 		{"竹子社", "label_alias"},
+		{"鈴木 達央", "person"},
 		{"sim", ""},
 		{"百合", ""},
 		{"r18", ""},

--- a/apps/api/internal/jobs/tagcanon/pool_test.go
+++ b/apps/api/internal/jobs/tagcanon/pool_test.go
@@ -21,11 +21,13 @@ func TestProposePoolDropsEntityNamesAndRejections(t *testing.T) {
 	require.NoError(t, testDB.Create(&label).Error)
 	credit := model.CatalogCreditName{Name: "御苑生メイ"}
 	require.NoError(t, testDB.Create(&credit).Error)
+	spaced := model.CatalogCreditName{Name: "鈴木 達央"}
+	require.NoError(t, testDB.Create(&spaced).Error)
 	elf := model.CatalogLabel{DisplayName: "ELF", Kind: model.LabelKindGameBrand}
 	require.NoError(t, testDB.Create(&elf).Error)
 	t.Cleanup(func() {
 		testDB.Unscoped().Delete(&model.CatalogLabel{}, []int64{label.ID, elf.ID})
-		testDB.Delete(&model.CatalogCreditName{}, credit.ID)
+		testDB.Delete(&model.CatalogCreditName{}, []int64{credit.ID, spaced.ID})
 	})
 
 	// ELF is a brand AND a tag the catalog already answers with: the blocklist
@@ -40,7 +42,7 @@ func TestProposePoolDropsEntityNamesAndRejections(t *testing.T) {
 	mkMap(t, bgm, "百合", mapped.ID)
 
 	w := mkBodylessWork(t, medium)
-	for _, name := range []string{"御苑生メイ", "オトメイト", "ELF", "破鞋", "百合", "银发"} {
+	for _, name := range []string{"御苑生メイ", "オトメイト", "ELF", "破鞋", "百合", "银发", "鈴木達央"} {
 		mkWorkTag(t, w, name, 3, bgm)
 	}
 

--- a/apps/api/internal/jobs/tagcanon/vocab.go
+++ b/apps/api/internal/jobs/tagcanon/vocab.go
@@ -95,8 +95,16 @@ func loadJunkIndex(ctx context.Context, db *gorm.DB) (*junkIndex, error) {
 			return nil, fmt.Errorf("load %s norms: %w", q.reason, err)
 		}
 		for _, n := range names {
-			if k := normalize(n); k != "" {
-				idx.blocked[k] = q.reason
+			k := normalize(n)
+			if k == "" {
+				continue
+			}
+			idx.blocked[k] = q.reason
+			// The catalog stores Japanese personal names with a space
+			// ("鈴木 達央"); a bangumi tagger types them without one. That single
+			// character hid 315 person and company names from this gate.
+			if s := spaceless(k); s != "" && s != k {
+				idx.blocked[s] = q.reason
 			}
 		}
 	}
@@ -127,8 +135,13 @@ func (j *junkIndex) reason(norm string) string {
 	if _, known := j.vocab[norm]; known {
 		return ""
 	}
-	return j.blocked[norm]
+	if r, hit := j.blocked[norm]; hit {
+		return r
+	}
+	return j.blocked[spaceless(norm)]
 }
+
+func spaceless(s string) string { return strings.ReplaceAll(s, " ", "") }
 
 func loadRejectedNames(ctx context.Context, db *gorm.DB) (map[string]struct{}, error) {
 	var rows []struct {


### PR DESCRIPTION
Follow-up to #21, found by the first prod run of the new backlog report: 鈴木達央 (26 works) was still in the unjudged pool because `catalog_credit_name` stores it as `鈴木 達央`.

Indexing the space-stripped form of every entity name catches **315** more names in the bangumi lane (2 of them above the usage-20 floor). The top-30 sample is entirely seiyuu, scenario writers and studios — SpikeChunsoft, SquareEnix, 石田彰, 緑川光, 打越鋼太郎 — i.e. exactly the class wave 208 rejected by hand. The vocabulary and `isMeta` exemptions still override the blocklist.

Test: `internal/jobs/tagcanon` green against `kun_catalog_test`; `TestBgmJunk` gains the spaced/unspaced pair and `TestProposePoolDropsEntityNamesAndRejections` now seeds a spaced credit name.