### PR TITLE
R2a: register catalog.character in the editing engine, fix the intro lang fold

### DIFF
--- a/apps/api/cmd/catalog/main.go
+++ b/apps/api/cmd/catalog/main.go
@@ -128,6 +128,10 @@ func main() {
 		slog.Error("editing: register catalog taxonomy families", "error", err)
 		os.Exit(1)
 	}
+	if err := editspec.RegisterCharacter(editRegistry, catalogDB.DB()); err != nil {
+		slog.Error("editing: register catalog.character", "error", err)
+		os.Exit(1)
+	}
 	editEngine := editing.NewEngine(catalogDB.DB(), editRegistry)
 	catHandler.SetupEdit(s2sAPI, editEngine, catHandler.PermResolvers{
 		"catalog": catalogPerm.Resolver,

--- a/apps/api/cmd/reindex-catalog/characters_aliases_test.go
+++ b/apps/api/cmd/reindex-catalog/characters_aliases_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+
+	"api/internal/platform/catalog/editspec"
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/editing"
+)
+
+func TestSuppressedCharacterAliasLeavesTheSearchDocument(t *testing.T) {
+	for _, tbl := range []string{"catalog_character_alias", "catalog_character", "edit_suppressed_row"} {
+		if err := facetTestDB.Exec("TRUNCATE " + tbl + " RESTART IDENTITY CASCADE").Error; err != nil {
+			t.Fatalf("truncate %s: %v", tbl, err)
+		}
+	}
+
+	ch := model.CatalogCharacter{DisplayName: "主人公"}
+	if err := facetTestDB.Create(&ch).Error; err != nil {
+		t.Fatalf("create character: %v", err)
+	}
+	rows := []model.CatalogCharacterAlias{
+		{CharacterID: ch.ID, Name: "しゅじんこう", Lang: "ja", Kind: model.AliasKindSpellingVariant},
+		{CharacterID: ch.ID, Name: "誤った別名", Lang: "ja", Kind: model.AliasKindSpellingVariant},
+	}
+	if err := facetTestDB.Create(&rows).Error; err != nil {
+		t.Fatalf("create aliases: %v", err)
+	}
+
+	live := editspec.NotSuppressedCharacterAliasSQL("a")
+	before, err := loadAliasTable(facetTestDB, "catalog_character_alias", "character_id", live)
+	if err != nil {
+		t.Fatalf("loadAliasTable: %v", err)
+	}
+	if len(before[ch.ID]) != 2 {
+		t.Fatalf("aliases before suppression = %v", before[ch.ID])
+	}
+
+	if err := facetTestDB.Create(&editing.SuppressedRow{
+		EntityType: editspec.TypeCharacter, EntityID: ch.ID, FieldKey: editspec.FieldCharacterAliases,
+		IdentityKey: editspec.CharacterAliasIdentity(model.AliasKindSpellingVariant, "ja", "誤った別名"),
+	}).Error; err != nil {
+		t.Fatalf("suppress: %v", err)
+	}
+
+	after, err := loadAliasTable(facetTestDB, "catalog_character_alias", "character_id", live)
+	if err != nil {
+		t.Fatalf("loadAliasTable: %v", err)
+	}
+	if len(after[ch.ID]) != 1 || after[ch.ID][0].name != "しゅじんこう" {
+		t.Fatalf("aliases after suppression = %v, want the suppressed one out of the index input", after[ch.ID])
+	}
+}

--- a/apps/api/cmd/reindex-catalog/main.go
+++ b/apps/api/cmd/reindex-catalog/main.go
@@ -64,7 +64,8 @@ func main() {
 			err = reindexCreditNames(ctx, db.DB(), idx, *batch)
 		case catalogSearch.IndexCharacters:
 			err = reindexEntity(ctx, db.DB(), idx, *batch, catalogSearch.IndexCharacters, "catalog_character", "c",
-				model.EntityTypeCharacter, "character_id", "character", "catalog_character_alias", "character_id")
+				model.EntityTypeCharacter, "character_id", "character", "catalog_character_alias", "character_id",
+				editspec.NotSuppressedCharacterAliasSQL("a"))
 		case catalogSearch.IndexLabels:
 			err = reindexLabels(ctx, db.DB(), idx, *batch)
 		case catalogSearch.IndexWorks:
@@ -190,7 +191,7 @@ func reindexLabels(ctx context.Context, db *gorm.DB, idx *catalogSearch.Indexer,
 	if err != nil {
 		return err
 	}
-	aliases, err := loadAliasTable(db, "catalog_label_alias", "label_id")
+	aliases, err := loadAliasTable(db, "catalog_label_alias", "label_id", "")
 	if err != nil {
 		return err
 	}
@@ -237,7 +238,7 @@ func reindexLabels(ctx context.Context, db *gorm.DB, idx *catalogSearch.Indexer,
 	return nil
 }
 
-func reindexEntity(ctx context.Context, db *gorm.DB, idx *catalogSearch.Indexer, batch int, uid, table, prefix string, entityType int16, popCol, etype, aliasTable, aliasCol string) error {
+func reindexEntity(ctx context.Context, db *gorm.DB, idx *catalogSearch.Indexer, batch int, uid, table, prefix string, entityType int16, popCol, etype, aliasTable, aliasCol, aliasLive string) error {
 	pop, err := loadPopularity(db, popCol)
 	if err != nil {
 		return err
@@ -246,7 +247,7 @@ func reindexEntity(ctx context.Context, db *gorm.DB, idx *catalogSearch.Indexer,
 	if err != nil {
 		return err
 	}
-	aliases, err := loadAliasTable(db, aliasTable, aliasCol)
+	aliases, err := loadAliasTable(db, aliasTable, aliasCol, aliasLive)
 	if err != nil {
 		return err
 	}
@@ -293,16 +294,19 @@ func reindexEntity(ctx context.Context, db *gorm.DB, idx *catalogSearch.Indexer,
 type alias struct{ lang, name string }
 
 func loadAliases(db *gorm.DB) (map[int64][]alias, error) {
-	return loadAliasTable(db, "catalog_name_alias", "credit_name_id")
+	return loadAliasTable(db, "catalog_name_alias", "credit_name_id", "")
 }
 
-func loadAliasTable(db *gorm.DB, table, ownerCol string) (map[int64][]alias, error) {
+func loadAliasTable(db *gorm.DB, table, ownerCol, live string) (map[int64][]alias, error) {
 	var rows []struct {
 		OwnerID int64  `gorm:"column:owner_id"`
 		Name    string `gorm:"column:name"`
 		Lang    string `gorm:"column:lang"`
 	}
-	q := fmt.Sprintf(`SELECT %s AS owner_id, name, lang FROM %s`, ownerCol, table)
+	q := fmt.Sprintf(`SELECT a.%s AS owner_id, a.name, a.lang FROM %s a`, ownerCol, table)
+	if live != "" {
+		q += " WHERE " + live
+	}
 	if err := db.Raw(q).Scan(&rows).Error; err != nil {
 		return nil, err
 	}

--- a/apps/api/internal/jobs/charattrs/curated_stamp_test.go
+++ b/apps/api/internal/jobs/charattrs/curated_stamp_test.go
@@ -1,0 +1,44 @@
+package charattrs
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/platform/catalog/editspec"
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/editing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// decide()'s pipelineRank knows only vndb and bangumi, so any other head source
+// — including the curated stamp the editing engine writes — makes the lane skip
+// the column. That is the whole protection catalog.character's scalars get from
+// this job: it needs no change here, and this test is what says so.
+func TestCuratedStampBlocksTheAttributePipeline(t *testing.T) {
+	clean(t)
+	ctx := context.Background()
+	r := reg(t)
+
+	ch := mkChar(t, "engine-edited")
+	mkVNDB(t, "c1", "f", "a", "", 0, 175, 0, 0, 0, nil)
+	mkAnchor(t, ch, r.vndbSource, "c1", "rule:vndb-character-import", model.LinkKindExact)
+
+	registry := editing.NewRegistry()
+	require.NoError(t, editspec.RegisterCharacter(registry, testDB))
+	spec, ok := registry.Type(editspec.TypeCharacter)
+	require.True(t, ok)
+	height, ok := spec.Field(editspec.FieldCharacterHeightCm)
+	require.True(t, ok)
+	require.NoError(t, editing.ApplyField(ctx, testDB, height, ch, float64(163)))
+	require.Equal(t, "curated", provSource(t, ch, "height_cm"))
+
+	_, err := Run(ctx, Opts{DSN: testDSN, Apply: true})
+	require.NoError(t, err)
+
+	after := loadChar(t, ch)
+	assert.Equal(t, int16(163), deref(after.Height), "vndb must not overwrite an engine-edited height")
+	assert.Equal(t, "curated", provSource(t, ch, "height_cm"))
+	assert.Equal(t, model.BloodTypeA, deref(after.Blood), "an unstamped column still fills from vndb")
+}

--- a/apps/api/internal/jobs/entityintromt/glossary.go
+++ b/apps/api/internal/jobs/entityintromt/glossary.go
@@ -63,13 +63,14 @@ type glossRow struct {
 	Zh      string `gorm:"column:zh"`
 }
 
-const (
+var (
 	characterOwnQuery = `
 		SELECT a.character_id AS owner_id, c.display_name AS src, a.name AS zh
 		FROM catalog_character_alias a
 		JOIN catalog_character c ON c.id = a.character_id
 		WHERE a.character_id IN (?)
 		  AND a.lang IN ('zh-Hans','zh','zh-Hant') AND a.kind IN (0,1)
+		  AND ` + editspec.NotSuppressedCharacterAliasSQL("a") + `
 		ORDER BY a.character_id, (NOT a.is_primary_for_locale), (a.lang <> 'zh-Hans'), a.id`
 
 	personOwnQuery = `

--- a/apps/api/internal/jobs/intromt/glossary.go
+++ b/apps/api/internal/jobs/intromt/glossary.go
@@ -94,6 +94,7 @@ var (
 			FROM catalog_character_alias a
 			WHERE a.character_id IN (SELECT character_id FROM ros)
 			  AND a.lang IN ('zh-Hans','zh','zh-Hant') AND a.kind IN (0,1)
+			  AND ` + editspec.NotSuppressedCharacterAliasSQL("a") + `
 			ORDER BY a.character_id, (NOT a.is_primary_for_locale), (a.lang <> 'zh-Hans'), a.id
 		)
 		SELECT ros.work_id AS owner_id, ros.display_name AS src, al.name AS zh

--- a/apps/api/internal/platform/catalog/editspec/character.go
+++ b/apps/api/internal/platform/catalog/editspec/character.go
@@ -1,0 +1,362 @@
+package editspec
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	catmodel "api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/perm"
+	"api/internal/platform/editing"
+
+	"gorm.io/gorm"
+)
+
+const (
+	TypeCharacter = "catalog.character"
+
+	FieldCharacterDisplayName   = "catalog.character.display_name"
+	FieldCharacterLang          = "catalog.character.lang"
+	FieldCharacterLatin         = "catalog.character.latin"
+	FieldCharacterDescription   = "catalog.character.description"
+	FieldCharacterGender        = "catalog.character.gender"
+	FieldCharacterBirthdayMonth = "catalog.character.birthday_month"
+	FieldCharacterBirthdayDay   = "catalog.character.birthday_day"
+	FieldCharacterBloodType     = "catalog.character.blood_type"
+	FieldCharacterHeightCm      = "catalog.character.height_cm"
+	FieldCharacterWeightKg      = "catalog.character.weight_kg"
+	FieldCharacterBustCm        = "catalog.character.bust_cm"
+	FieldCharacterWaistCm       = "catalog.character.waist_cm"
+	FieldCharacterHipCm         = "catalog.character.hip_cm"
+	FieldCharacterCup           = "catalog.character.cup"
+
+	FieldCharacterAliases      = "catalog.character.aliases"
+	FieldCharacterAliasesSuppr = FieldCharacterAliases + editing.SuppressedFieldSuffix
+	FieldCharacterIntros       = "catalog.character.intros"
+)
+
+const maxCupRunes = 8
+
+func RegisterCharacter(reg *editing.Registry, db *gorm.DB) error {
+	fields := characterFieldSpecs()
+
+	// A character is shared by every work it appears in, so kungal keeps
+	// automerge=never here — the blast radius of a direct edit is the taxonomy's,
+	// not a single work's.
+	kungalPolicy := editing.Policy{
+		Propose:   editing.ProposeOpen,
+		Review:    editing.ReviewPerm(string(perm.EditCharacterReview)),
+		Automerge: editing.AutomergeNever,
+	}
+	letmoePolicy := editing.Policy{
+		Propose:   editing.ProposeTrusted,
+		Review:    editing.ReviewPerm(string(perm.EditCharacterReview)),
+		Automerge: editing.AutomergeOwner,
+	}
+	everyField := func(p editing.Policy) map[string]editing.Policy {
+		overlay := make(map[string]editing.Policy, len(fields))
+		for _, f := range fields {
+			overlay[f.Key] = p
+		}
+		return overlay
+	}
+	overlays := make(map[string]map[string]editing.Policy, len(letmoeSites)+1)
+	for _, site := range letmoeSites {
+		overlays[site] = everyField(letmoePolicy)
+	}
+	overlays["kungal"] = everyField(kungalPolicy)
+
+	return reg.Register(editing.EntityTypeSpec{
+		Family:       "catalog",
+		Type:         TypeCharacter,
+		LoadSnapshot: loadCharacterSnapshot(db),
+		Txn:          txnOn(db),
+		// A character belongs to no product site — nothing claims one the way a
+		// site claims a work. The hook exists because editing.Register refuses an
+		// automerge=owner policy without one, and returning nil is what makes the
+		// letmoe overlay's automerge=owner mean "never" for this family.
+		OwnerSite: func(ctx context.Context, entityID int64) (*string, error) {
+			if err := assertCharacterExists(ctx, db, entityID); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		},
+		DefaultPolicy: editing.Policy{
+			Propose:   editing.ProposePerm(string(perm.EditCharacter)),
+			Review:    editing.ReviewPerm(string(perm.EditCharacterReview)),
+			Automerge: editing.AutomergeNever,
+		},
+		SiteOverlays: overlays,
+		Fields:       fields,
+	})
+}
+
+func characterFieldSpecs() []editing.FieldSpec {
+	aliases := editing.FieldSpec{
+		Key: FieldCharacterAliases, Kind: editing.KindList, DiffHint: editing.DiffHintItems,
+		Validate: validateCharacterAliases,
+		Apply:    applyCharacterAliases,
+	}
+	return []editing.FieldSpec{
+		charText(FieldCharacterDisplayName, "display_name", maxNameRunes),
+		charLang(FieldCharacterLang, "lang"),
+		charNullableText(FieldCharacterLatin, "latin", maxNameRunes),
+		charLongText(FieldCharacterDescription, "description"),
+		charEnum(FieldCharacterGender, "gender",
+			catmodel.GenderMale, catmodel.GenderFemale, catmodel.GenderOther),
+		charInt(FieldCharacterBirthdayMonth, "birthday_month", 1, 12),
+		charInt(FieldCharacterBirthdayDay, "birthday_day", 1, 31),
+		charEnum(FieldCharacterBloodType, "blood_type",
+			catmodel.BloodTypeA, catmodel.BloodTypeB, catmodel.BloodTypeAB, catmodel.BloodTypeO),
+		charInt(FieldCharacterHeightCm, "height_cm", 1, 1000),
+		charInt(FieldCharacterWeightKg, "weight_kg", 1, 1000),
+		charInt(FieldCharacterBustCm, "bust_cm", 1, 500),
+		charInt(FieldCharacterWaistCm, "waist_cm", 1, 500),
+		charInt(FieldCharacterHipCm, "hip_cm", 1, 500),
+		charNullableText(FieldCharacterCup, "cup", maxCupRunes),
+		aliases,
+		editing.SuppressedFieldSpec(TypeCharacter, aliases),
+		{
+			Key: FieldCharacterIntros, Kind: editing.KindList, DiffHint: editing.DiffHintLines,
+			Validate: validateIntros,
+			Apply:    applyEntityIntros(introTableCharacter),
+		},
+	}
+}
+
+func characterProvenance(column string) *editing.ProvenanceTarget {
+	return &editing.ProvenanceTarget{Table: catmodel.CatalogCharacter{}.TableName(), Column: column}
+}
+
+func charText(key, column string, maxRunes int) editing.FieldSpec {
+	return editing.FieldSpec{
+		Key: key, Kind: editing.KindText, DiffHint: editing.DiffHintInline,
+		Validate:   func(v any) error { return validateBoundedText(v, maxRunes, false) },
+		Apply:      applyCharacterColumn(column, asString),
+		Provenance: characterProvenance(column),
+	}
+}
+
+func charLongText(key, column string) editing.FieldSpec {
+	return editing.FieldSpec{
+		Key: key, Kind: editing.KindText, DiffHint: editing.DiffHintLines,
+		Validate:   validateIntroText,
+		Apply:      applyCharacterColumn(column, asString),
+		Provenance: characterProvenance(column),
+	}
+}
+
+// charLang is the language column: not null, but the empty string is the
+// recorded "unknown", so it is accepted alongside the allowed language tags.
+func charLang(key, column string) editing.FieldSpec {
+	return editing.FieldSpec{
+		Key: key, Kind: editing.KindEnum, DiffHint: editing.DiffHintInline,
+		Validate: func(v any) error {
+			s, ok := v.(string)
+			if !ok {
+				return fmt.Errorf("must be a string")
+			}
+			if s == "" {
+				return nil
+			}
+			if _, allowed := olangAllowed[s]; !allowed {
+				return fmt.Errorf("%q is not an allowed language", s)
+			}
+			return nil
+		},
+		Apply:      applyCharacterColumn(column, asString),
+		Provenance: characterProvenance(column),
+	}
+}
+
+func charNullableText(key, column string, maxRunes int) editing.FieldSpec {
+	return editing.FieldSpec{
+		Key: key, Kind: editing.KindText, DiffHint: editing.DiffHintInline,
+		Validate: func(v any) error {
+			if v == nil {
+				return nil
+			}
+			return validateBoundedText(v, maxRunes, true)
+		},
+		Apply: applyCharacterColumn(column, func(v any) (any, error) {
+			if v == nil {
+				return nil, nil
+			}
+			return asString(v)
+		}),
+		Provenance: characterProvenance(column),
+	}
+}
+
+func charInt(key, column string, min, max int16) editing.FieldSpec {
+	return editing.FieldSpec{
+		Key: key, Kind: editing.KindInt, DiffHint: editing.DiffHintInline,
+		Validate: func(v any) error {
+			_, err := parseNullableI16(v, min, max)
+			return err
+		},
+		Apply:      applyCharacterColumn(column, nullableI16Converter(min, max)),
+		Provenance: characterProvenance(column),
+	}
+}
+
+func charEnum(key, column string, allowed ...int16) editing.FieldSpec {
+	return editing.FieldSpec{
+		Key: key, Kind: editing.KindEnum, DiffHint: editing.DiffHintInline,
+		Validate: func(v any) error {
+			_, err := parseEnumI16(v, allowed)
+			return err
+		},
+		Apply: applyCharacterColumn(column, func(v any) (any, error) {
+			n, err := parseEnumI16(v, allowed)
+			if err != nil {
+				return nil, err
+			}
+			if n == nil {
+				return nil, nil
+			}
+			return *n, nil
+		}),
+		Provenance: characterProvenance(column),
+	}
+}
+
+func validateBoundedText(v any, maxRunes int, allowEmpty bool) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("must be a string")
+	}
+	if !allowEmpty && strings.TrimSpace(s) == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if len([]rune(s)) > maxRunes {
+		return fmt.Errorf("must be at most %d characters", maxRunes)
+	}
+	return nil
+}
+
+func parseNullableI16(v any, min, max int16) (*int16, error) {
+	if v == nil {
+		return nil, nil
+	}
+	f, ok := v.(float64)
+	if !ok || f != float64(int64(f)) {
+		return nil, fmt.Errorf("must be an integer or null")
+	}
+	n := int64(f)
+	if n < int64(min) || n > int64(max) {
+		return nil, fmt.Errorf("must be between %d and %d", min, max)
+	}
+	out := int16(n)
+	return &out, nil
+}
+
+func nullableI16Converter(min, max int16) func(any) (any, error) {
+	return func(v any) (any, error) {
+		n, err := parseNullableI16(v, min, max)
+		if err != nil {
+			return nil, err
+		}
+		if n == nil {
+			return nil, nil
+		}
+		return *n, nil
+	}
+}
+
+func parseEnumI16(v any, allowed []int16) (*int16, error) {
+	if v == nil {
+		return nil, nil
+	}
+	f, ok := v.(float64)
+	if !ok || f != float64(int64(f)) {
+		return nil, fmt.Errorf("must be an integer or null")
+	}
+	n := int16(int64(f))
+	for _, a := range allowed {
+		if a == n {
+			return &n, nil
+		}
+	}
+	return nil, fmt.Errorf("must be one of %v, or null", allowed)
+}
+
+// applyCharacterColumn writes through a map so that a JSON null reaches the
+// column as NULL: gorm's single-column Update drops a nil value, which would
+// silently turn "clear this attribute" into a no-op.
+func applyCharacterColumn(column string, conv func(any) (any, error)) editing.ApplyFunc {
+	return func(ctx context.Context, tx *gorm.DB, entityID int64, value any) error {
+		v, err := conv(value)
+		if err != nil {
+			return fmt.Errorf("editspec: %s: %w", column, err)
+		}
+		res := tx.WithContext(ctx).Model(&catmodel.CatalogCharacter{}).
+			Where("id = ?", entityID).Updates(map[string]any{column: v})
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return editing.ErrEntityNotFound
+		}
+		return nil
+	}
+}
+
+func assertCharacterExists(ctx context.Context, db *gorm.DB, entityID int64) error {
+	var c catmodel.CatalogCharacter
+	return firstEntity(ctx, db, &c, entityID, "id")
+}
+
+func loadCharacterSnapshot(db *gorm.DB) func(context.Context, int64) (map[string]any, error) {
+	return func(ctx context.Context, entityID int64) (map[string]any, error) {
+		var c catmodel.CatalogCharacter
+		if err := firstEntity(ctx, db, &c, entityID,
+			"id", "display_name", "lang", "latin", "description", "gender",
+			"birthday_month", "birthday_day", "blood_type",
+			"height_cm", "weight_kg", "bust_cm", "waist_cm", "hip_cm", "cup"); err != nil {
+			return nil, err
+		}
+		snapshot := map[string]any{
+			FieldCharacterDisplayName:   c.DisplayName,
+			FieldCharacterLang:          c.Lang,
+			FieldCharacterLatin:         nullableString(c.Latin),
+			FieldCharacterDescription:   c.Description,
+			FieldCharacterGender:        nullableI16(c.Gender),
+			FieldCharacterBirthdayMonth: nullableI16(c.BirthdayMonth),
+			FieldCharacterBirthdayDay:   nullableI16(c.BirthdayDay),
+			FieldCharacterBloodType:     nullableI16(c.BloodType),
+			FieldCharacterHeightCm:      nullableI16(c.HeightCm),
+			FieldCharacterWeightKg:      nullableI16(c.WeightKg),
+			FieldCharacterBustCm:        nullableI16(c.BustCm),
+			FieldCharacterWaistCm:       nullableI16(c.WaistCm),
+			FieldCharacterHipCm:         nullableI16(c.HipCm),
+			FieldCharacterCup:           nullableString(c.Cup),
+		}
+		for key, load := range map[string]func(context.Context, *gorm.DB, int64) ([]any, error){
+			FieldCharacterAliases:      loadCuratedCharacterAliases,
+			FieldCharacterAliasesSuppr: loadSuppressedCharacterAliases,
+			FieldCharacterIntros:       loadCharacterIntros,
+		} {
+			value, err := load(ctx, db, entityID)
+			if err != nil {
+				return nil, err
+			}
+			snapshot[key] = value
+		}
+		return snapshot, nil
+	}
+}
+
+func nullableString(p *string) any {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+func nullableI16(p *int16) any {
+	if p == nil {
+		return nil
+	}
+	return int64(*p)
+}

--- a/apps/api/internal/platform/catalog/editspec/character_aliases.go
+++ b/apps/api/internal/platform/catalog/editspec/character_aliases.go
@@ -1,0 +1,201 @@
+package editspec
+
+import (
+	"context"
+	"fmt"
+
+	catmodel "api/internal/platform/catalog/model"
+	"api/internal/platform/editing"
+
+	"gorm.io/gorm"
+)
+
+type characterAlias struct {
+	Name    string
+	Lang    string
+	Latin   string
+	Kind    int64
+	Primary bool
+}
+
+func parseCharacterAliases(v any) ([]characterAlias, error) {
+	arr, err := asArray(v, "alias objects")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]characterAlias, 0, len(arr))
+	seen := make(map[string]struct{}, len(arr))
+	for i, el := range arr {
+		obj, err := asObject(el, i, "name", "lang", "kind", "latin", "primary")
+		if err != nil {
+			return nil, err
+		}
+		name, err := objString(obj, "name", i, true, maxNameRunes)
+		if err != nil {
+			return nil, err
+		}
+		lang, err := objString(obj, "lang", i, true, 32)
+		if err != nil {
+			return nil, err
+		}
+		if _, allowed := olangAllowed[lang]; !allowed {
+			return nil, fmt.Errorf("element %d: %q is not an allowed language", i, lang)
+		}
+		kind, err := objInt(obj, "kind", i, true)
+		if err != nil {
+			return nil, err
+		}
+		if kind != int64(catmodel.AliasKindTranslation) && kind != int64(catmodel.AliasKindSpellingVariant) {
+			return nil, fmt.Errorf("element %d: kind must be 0 (translation) or 1 (spelling_variant); "+
+				"kind 2 (search hint) is machine-owned and not editable", i)
+		}
+		latin, err := objString(obj, "latin", i, false, maxNameRunes)
+		if err != nil {
+			return nil, err
+		}
+		primary, err := objBool(obj, "primary", i)
+		if err != nil {
+			return nil, err
+		}
+		// The table's unique key is (character_id, name, lang) — kind is not in
+		// it, so two elements differing only by kind would collide on insert.
+		uniq := lang + "\x00" + name
+		if _, dup := seen[uniq]; dup {
+			return nil, fmt.Errorf("element %d: duplicate (name, lang)", i)
+		}
+		seen[uniq] = struct{}{}
+		out = append(out, characterAlias{Name: name, Lang: lang, Latin: latin, Kind: kind, Primary: primary})
+	}
+	return out, nil
+}
+
+func validateCharacterAliases(v any) error {
+	_, err := parseCharacterAliases(v)
+	return err
+}
+
+func applyCharacterAliases(ctx context.Context, tx *gorm.DB, entityID int64, value any) error {
+	aliases, err := parseCharacterAliases(value)
+	if err != nil {
+		return fmt.Errorf("editspec: aliases: %w", err)
+	}
+	if err := assertCharacterExists(ctx, tx, entityID); err != nil {
+		return err
+	}
+	if err := rejectUpstreamAliasCollisions(ctx, tx, entityID, aliases); err != nil {
+		return err
+	}
+	if err := tx.WithContext(ctx).
+		Where("character_id = ? AND source_id = ?", entityID, curatedSourceID).
+		Delete(&catmodel.CatalogCharacterAlias{}).Error; err != nil {
+		return err
+	}
+	if len(aliases) == 0 {
+		return nil
+	}
+	source := curatedSourceID
+	rows := make([]catmodel.CatalogCharacterAlias, 0, len(aliases))
+	for _, a := range aliases {
+		row := catmodel.CatalogCharacterAlias{
+			CharacterID: entityID, Name: a.Name, Lang: a.Lang, Kind: int16(a.Kind),
+			IsPrimaryForLocale: a.Primary,
+			SourceID:           &source, Provenance: catmodel.AliasProvenanceSource,
+		}
+		if a.Latin != "" {
+			latin := a.Latin
+			row.Latin = &latin
+		}
+		rows = append(rows, row)
+	}
+	return tx.WithContext(ctx).Create(&rows).Error
+}
+
+// rejectUpstreamAliasCollisions makes an unwinnable insert an explicit 422.
+// uq_catalog_character_alias_owner_name_lang does not carry source_id, so the
+// curated lane and every importer share one key: a curated row on a (name, lang)
+// an importer already owns can never exist, and the alternatives are a raw 23505
+// out of the merge or the importers' own ON CONFLICT DO NOTHING, which saves the
+// proposal and drops the row.
+func rejectUpstreamAliasCollisions(ctx context.Context, tx *gorm.DB, entityID int64, aliases []characterAlias) error {
+	if len(aliases) == 0 {
+		return nil
+	}
+	pairs := make([][]any, 0, len(aliases))
+	for _, a := range aliases {
+		pairs = append(pairs, []any{a.Name, a.Lang})
+	}
+	var clash []catmodel.CatalogCharacterAlias
+	if err := tx.WithContext(ctx).
+		Select("name", "lang").
+		Where("character_id = ? AND source_id IS DISTINCT FROM ?", entityID, curatedSourceID).
+		Where("(name, lang) IN ?", pairs).
+		Order("lang, name").
+		Find(&clash).Error; err != nil {
+		return err
+	}
+	if len(clash) == 0 {
+		return nil
+	}
+	return &editing.ValidationError{
+		Key: FieldCharacterAliases,
+		Reason: fmt.Sprintf("%q (%s) is already provided upstream for this character; "+
+			"to hide it use %s instead of re-adding it",
+			clash[0].Name, clash[0].Lang, FieldCharacterAliasesSuppr),
+	}
+}
+
+// CharacterAliasIdentity is the frozen row identity of
+// catalog.character.aliases (doc 21 D10: registered means never redefined). It
+// is derived from the row's content and never from catalog_character_alias.id,
+// because the vndb roster importer deletes and re-inserts the same alias, which
+// would expire the suppression exactly when it is needed. Kind is decimal and
+// no lang in the table carries a colon, so the name is the unescaped remainder
+// and needs no quoting. Nothing in the key is an entity id, so a character
+// merge cannot invalidate it.
+func CharacterAliasIdentity(kind int16, lang, name string) string {
+	return fmt.Sprintf("alias:%d:%s:%s", kind, lang, name)
+}
+
+// CharacterAliasIdentitySQL restates CharacterAliasIdentity for a
+// catalog_character_alias alias — the one place the two definitions could drift
+// apart, which is why TestCharacterAliasIdentitySQLMatchesGo recomputes both
+// over real rows.
+func CharacterAliasIdentitySQL(alias string) string {
+	return fmt.Sprintf(`('alias:' || %[1]s.kind || ':' || %[1]s.lang || ':' || %[1]s.name)`, alias)
+}
+
+// NotSuppressedCharacterAliasSQL is the read-path predicate, correlated on a
+// catalog_character_alias alias.
+func NotSuppressedCharacterAliasSQL(alias string) string {
+	return fmt.Sprintf(
+		`NOT EXISTS (SELECT 1 FROM edit_suppressed_row esr
+			WHERE esr.entity_type = '%s' AND esr.field_key = '%s'
+			  AND esr.entity_id = %s.character_id AND esr.identity_key = %s)`,
+		TypeCharacter, FieldCharacterAliases, alias, CharacterAliasIdentitySQL(alias))
+}
+
+func loadSuppressedCharacterAliases(ctx context.Context, db *gorm.DB, characterID int64) ([]any, error) {
+	return editing.LoadSuppressedValue(ctx, db, TypeCharacter, characterID, FieldCharacterAliases)
+}
+
+func loadCuratedCharacterAliases(ctx context.Context, db *gorm.DB, characterID int64) ([]any, error) {
+	var rows []catmodel.CatalogCharacterAlias
+	if err := db.WithContext(ctx).
+		Where("character_id = ? AND source_id = ? AND kind <> ?",
+			characterID, curatedSourceID, catmodel.AliasKindSearchHint).
+		Order("id").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make([]any, 0, len(rows))
+	for _, r := range rows {
+		el := map[string]any{"name": r.Name, "lang": r.Lang, "kind": int64(r.Kind)}
+		if r.Latin != nil && *r.Latin != "" {
+			el["latin"] = *r.Latin
+		}
+		if r.IsPrimaryForLocale {
+			el["primary"] = true
+		}
+		out = append(out, el)
+	}
+	return out, nil
+}

--- a/apps/api/internal/platform/catalog/editspec/character_aliases_test.go
+++ b/apps/api/internal/platform/catalog/editspec/character_aliases_test.go
@@ -1,0 +1,302 @@
+package editspec_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"api/internal/platform/catalog/editspec"
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/editing"
+)
+
+// importCharacterAlias reproduces importer/rostervndb.go's insert verbatim: the
+// row arrives from upstream with a fresh identity column every time, which is
+// why the suppression key may never be derived from it.
+func importCharacterAlias(t *testing.T, characterID int64, name, lang string, kind int16, sourceID int16) int64 {
+	t.Helper()
+	if err := testDB.Exec(
+		`INSERT INTO catalog_character_alias (character_id, name, lang, kind, is_primary_for_locale, source_id, provenance)
+		 VALUES (?, ?, ?, ?, false, ?, 0) ON CONFLICT DO NOTHING`,
+		characterID, name, lang, kind, sourceID).Error; err != nil {
+		t.Fatalf("import alias %q: %v", name, err)
+	}
+	var row model.CatalogCharacterAlias
+	if err := testDB.Where("character_id = ? AND name = ? AND lang = ?", characterID, name, lang).
+		First(&row).Error; err != nil {
+		t.Fatalf("reload alias %q: %v", name, err)
+	}
+	return row.ID
+}
+
+func liveAliasNames(t *testing.T, characterID int64) []string {
+	t.Helper()
+	var names []string
+	if err := testDB.Raw(`SELECT a.name FROM catalog_character_alias a
+		WHERE a.character_id = ? AND `+editspec.NotSuppressedCharacterAliasSQL("a")+`
+		ORDER BY a.id`, characterID).Scan(&names).Error; err != nil {
+		t.Fatalf("apply predicate: %v", err)
+	}
+	return names
+}
+
+func TestCharacterAliasSuppressionEndToEnd(t *testing.T) {
+	e := newCharacterEngine(t)
+	ch := createCharacter(t, "主人公")
+	importCharacterAlias(t, ch.ID, "しゅじんこう", "ja", model.AliasKindSpellingVariant, 2)
+	badID := importCharacterAlias(t, ch.ID, "誤った別名", "ja", model.AliasKindSpellingVariant, 2)
+
+	editor := realActor(100, "admin")
+	reviewer := realActor(200, "ren")
+	badKey := editspec.CharacterAliasIdentity(model.AliasKindSpellingVariant, "ja", "誤った別名")
+
+	prop, rev, err := e.CreateProposal(testCtx, editing.CreateProposalInput{
+		EntityType: editspec.TypeCharacter, EntityID: ch.ID,
+		Patch: map[string]any{editspec.FieldCharacterAliasesSuppr: suppressList(badKey)},
+		Note:  "wrong alias pushed by the vndb roster", Actor: editor,
+	})
+	if err != nil {
+		t.Fatalf("propose suppression: %v", err)
+	}
+	if rev != nil {
+		t.Fatal("catalog.character.aliases.suppressed must inherit automerge=never on nextmoe")
+	}
+	if _, err := e.MergeProposal(testCtx, prop.ID, reviewer, "confirmed"); err != nil {
+		t.Fatalf("merge suppression: %v", err)
+	}
+
+	if got := liveAliasNames(t, ch.ID); len(got) != 1 || got[0] != "しゅじんこう" {
+		t.Fatalf("live aliases after suppression = %v", got)
+	}
+	snap, err := e.CurrentSnapshot(testCtx, editspec.TypeCharacter, ch.ID)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	sameJSON(t, "suppression set", snap[editspec.FieldCharacterAliasesSuppr], []any{badKey})
+
+	// The roster importer owns the row: deleting it locally and re-pushing the
+	// same upstream content must not resurrect it on the read faces.
+	if err := testDB.Exec(`DELETE FROM catalog_character_alias WHERE id = ?`, badID).Error; err != nil {
+		t.Fatal(err)
+	}
+	rePushed := importCharacterAlias(t, ch.ID, "誤った別名", "ja", model.AliasKindSpellingVariant, 2)
+	if rePushed == badID {
+		t.Fatal("the re-push reused the row id; the id-independence of the key is untested")
+	}
+	if got := liveAliasNames(t, ch.ID); len(got) != 1 {
+		t.Fatalf("live aliases after the importer re-push = %v", got)
+	}
+
+	release, _, err := e.CreateProposal(testCtx, editing.CreateProposalInput{
+		EntityType: editspec.TypeCharacter, EntityID: ch.ID,
+		Patch: map[string]any{editspec.FieldCharacterAliasesSuppr: []any{}},
+		Note:  "it was right after all", Actor: editor,
+	})
+	if err != nil {
+		t.Fatalf("propose unsuppression: %v", err)
+	}
+	if _, err := e.MergeProposal(testCtx, release.ID, reviewer, ""); err != nil {
+		t.Fatalf("merge unsuppression: %v", err)
+	}
+	if got := liveAliasNames(t, ch.ID); len(got) != 2 {
+		t.Fatalf("live aliases after release = %v", got)
+	}
+}
+
+func TestCharacterAliasIdentityIsContentDerived(t *testing.T) {
+	cases := []struct {
+		kind       int16
+		lang, name string
+		want       string
+	}{
+		{model.AliasKindTranslation, "zh-Hans", "绪方", "alias:0:zh-Hans:绪方"},
+		{model.AliasKindSpellingVariant, "ja", "おがた", "alias:1:ja:おがた"},
+		{model.AliasKindSpellingVariant, "en", "a:b:c", "alias:1:en:a:b:c"},
+		{model.AliasKindSearchHint, "", "hint", "alias:2::hint"},
+	}
+	for _, c := range cases {
+		if got := editspec.CharacterAliasIdentity(c.kind, c.lang, c.name); got != c.want {
+			t.Fatalf("CharacterAliasIdentity(%d, %q, %q) = %q, want %q", c.kind, c.lang, c.name, got, c.want)
+		}
+	}
+}
+
+func TestCharacterAliasIdentitySQLMatchesGo(t *testing.T) {
+	newCharacterEngine(t)
+	ch := createCharacter(t, "SQL 対 Go")
+	rows := []model.CatalogCharacterAlias{
+		{CharacterID: ch.ID, Name: "しゅじんこう", Lang: "ja", Kind: model.AliasKindSpellingVariant},
+		{CharacterID: ch.ID, Name: "コロン:入り:別名", Lang: "ja", Kind: model.AliasKindTranslation},
+		{CharacterID: ch.ID, Name: "带 空格 的 名字 ", Lang: "zh-Hans", Kind: model.AliasKindTranslation},
+		{CharacterID: ch.ID, Name: `quote'and"back\slash`, Lang: "en", Kind: model.AliasKindSpellingVariant},
+		{CharacterID: ch.ID, Name: "けんさくヒント", Lang: "", Kind: model.AliasKindSearchHint},
+	}
+	if err := testDB.Create(&rows).Error; err != nil {
+		t.Fatalf("create aliases: %v", err)
+	}
+
+	var got []struct {
+		ID   int64  `gorm:"column:id"`
+		Name string `gorm:"column:name"`
+		Lang string `gorm:"column:lang"`
+		Kind int16  `gorm:"column:kind"`
+		Key  string `gorm:"column:key"`
+	}
+	if err := testDB.Raw(`SELECT a.id, a.name, a.lang, a.kind, ` +
+		editspec.CharacterAliasIdentitySQL("a") + ` AS key
+		FROM catalog_character_alias a WHERE a.character_id = ` +
+		fmt.Sprint(ch.ID) + ` ORDER BY a.id`).Scan(&got).Error; err != nil {
+		t.Fatalf("compute keys in SQL: %v", err)
+	}
+	if len(got) != len(rows) {
+		t.Fatalf("rows = %d, want %d", len(got), len(rows))
+	}
+	for _, r := range got {
+		if want := editspec.CharacterAliasIdentity(r.Kind, r.Lang, r.Name); r.Key != want {
+			t.Fatalf("row %d: SQL key %q, Go key %q", r.ID, r.Key, want)
+		}
+	}
+
+	target := got[1]
+	if err := testDB.Create(&editing.SuppressedRow{
+		EntityType: editspec.TypeCharacter, EntityID: ch.ID, FieldKey: editspec.FieldCharacterAliases,
+		IdentityKey: editspec.CharacterAliasIdentity(target.Kind, target.Lang, target.Name),
+	}).Error; err != nil {
+		t.Fatalf("suppress: %v", err)
+	}
+	surviving := liveAliasNames(t, ch.ID)
+	if len(surviving) != len(rows)-1 {
+		t.Fatalf("predicate kept %d rows, want %d", len(surviving), len(rows)-1)
+	}
+	for _, name := range surviving {
+		if name == target.Name {
+			t.Fatalf("row %q is suppressed but survived the predicate", name)
+		}
+	}
+}
+
+func TestCuratedAliasCollidingWithUpstreamIsRejected(t *testing.T) {
+	e := newCharacterEngine(t)
+	ch := createCharacter(t, "衝突テスト")
+	importCharacterAlias(t, ch.ID, "上流の別名", "zh-Hans", model.AliasKindTranslation, 3)
+
+	prop, _, err := e.CreateProposal(testCtx, editing.CreateProposalInput{
+		EntityType: editspec.TypeCharacter, EntityID: ch.ID,
+		Patch: map[string]any{editspec.FieldCharacterAliases: []any{
+			map[string]any{"name": "上流の別名", "lang": "zh-Hans", "kind": float64(model.AliasKindTranslation)},
+		}},
+		Actor: realActor(100, "admin"),
+	})
+	if err != nil {
+		t.Fatalf("propose: %v", err)
+	}
+	_, err = e.MergeProposal(testCtx, prop.ID, realActor(200, "ren"), "")
+	var valErr *editing.ValidationError
+	if !errors.As(err, &valErr) {
+		t.Fatalf("merge a curated alias colliding with an upstream row: %v, want ValidationError (422)", err)
+	}
+	if !strings.Contains(valErr.Error(), editspec.FieldCharacterAliasesSuppr) {
+		t.Fatalf("the 422 must point at the suppression field, got %q", valErr.Error())
+	}
+
+	// The failed merge must not have eaten the upstream row on its way out.
+	var n int64
+	if err := testDB.Model(&model.CatalogCharacterAlias{}).
+		Where("character_id = ?", ch.ID).Count(&n).Error; err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("alias rows after the rejected merge = %d, want the upstream row untouched", n)
+	}
+}
+
+func TestCuratedAliasLaneRoundTrips(t *testing.T) {
+	e := newCharacterEngine(t)
+	ch := createCharacter(t, "别名车道")
+	importCharacterAlias(t, ch.ID, "上流だけの別名", "ja", model.AliasKindSpellingVariant, 2)
+
+	aliases := []any{
+		map[string]any{"name": "人手の別名", "lang": "zh-Hans", "kind": float64(model.AliasKindTranslation), "primary": true},
+		map[string]any{"name": "Human Alias", "lang": "en", "kind": float64(model.AliasKindSpellingVariant), "latin": "Human Alias"},
+	}
+	snap := mergeOn(t, e, editspec.TypeCharacter, ch.ID,
+		map[string]any{editspec.FieldCharacterAliases: aliases})
+	sameJSON(t, "curated aliases", snap[editspec.FieldCharacterAliases], aliases)
+
+	// Only the curated lane is in the snapshot; the upstream row keeps its own
+	// place in the table and is reachable only through .suppressed.
+	var all []model.CatalogCharacterAlias
+	if err := testDB.Where("character_id = ?", ch.ID).Order("id").Find(&all).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("alias rows = %d, want the upstream row plus the two curated ones", len(all))
+	}
+	for _, a := range all {
+		if a.SourceID != nil && *a.SourceID == 12 && a.Provenance != model.AliasProvenanceSource {
+			t.Fatalf("a curated alias must carry provenance=source: %+v", a)
+		}
+	}
+
+	// Removing an element from the list deletes only the curated row.
+	mergeOn(t, e, editspec.TypeCharacter, ch.ID, map[string]any{
+		editspec.FieldCharacterAliases: []any{aliases[0]},
+	})
+	if err := testDB.Where("character_id = ?", ch.ID).Order("id").Find(&all).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("alias rows after the removal = %+v", all)
+	}
+}
+
+func TestCharacterAliasValidation(t *testing.T) {
+	e := newCharacterEngine(t)
+	ch := createCharacter(t, "検証")
+	editor := realActor(100, "admin")
+
+	var valErr *editing.ValidationError
+	cases := []any{
+		"not-a-list",
+		[]any{map[string]any{"lang": "ja", "kind": float64(1)}},
+		[]any{map[string]any{"name": "x", "kind": float64(1)}},
+		[]any{map[string]any{"name": "x", "lang": "", "kind": float64(1)}},
+		[]any{map[string]any{"name": "x", "lang": "xx", "kind": float64(1)}},
+		[]any{map[string]any{"name": "x", "lang": "ja", "kind": float64(model.AliasKindSearchHint)}},
+		[]any{map[string]any{"name": "x", "lang": "ja", "kind": float64(1), "unknown": "y"}},
+		[]any{
+			map[string]any{"name": "x", "lang": "ja", "kind": float64(0)},
+			map[string]any{"name": "x", "lang": "ja", "kind": float64(1)},
+		},
+	}
+	for i, patch := range cases {
+		if _, _, err := e.CreateProposal(testCtx, editing.CreateProposalInput{
+			EntityType: editspec.TypeCharacter, EntityID: ch.ID,
+			Patch: map[string]any{editspec.FieldCharacterAliases: patch}, Actor: editor,
+		}); !errors.As(err, &valErr) {
+			t.Errorf("case %d (%#v): err = %v, want ValidationError", i, patch, err)
+		}
+	}
+}
+
+func TestCharacterAliasSuppressionInheritsParentPolicy(t *testing.T) {
+	reg := editing.NewRegistry()
+	if err := editspec.RegisterCharacter(reg, testDB); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	spec, ok := reg.Type(editspec.TypeCharacter)
+	if !ok {
+		t.Fatal("catalog.character is not registered")
+	}
+	if editspec.FieldCharacterAliasesSuppr != editing.SuppressedFieldKey(editspec.FieldCharacterAliases) {
+		t.Fatalf("companion key %q does not follow the engine's suffix", editspec.FieldCharacterAliasesSuppr)
+	}
+	for _, site := range []string{"nextmoe", "kungal", "letmoe", "letmoe-staging", "letmoe-dev"} {
+		parent := spec.EffectivePolicy(editspec.FieldCharacterAliases, site)
+		companion := spec.EffectivePolicy(editspec.FieldCharacterAliasesSuppr, site)
+		if parent != companion {
+			t.Fatalf("site %q: parent %+v vs companion %+v", site, parent, companion)
+		}
+	}
+}

--- a/apps/api/internal/platform/catalog/editspec/character_intros.go
+++ b/apps/api/internal/platform/catalog/editspec/character_intros.go
@@ -1,0 +1,43 @@
+package editspec
+
+import (
+	"context"
+
+	catmodel "api/internal/platform/catalog/model"
+
+	"gorm.io/gorm"
+)
+
+// The curated lane is the whole editable surface here: an upstream intro row is
+// its importer's, and there is no `.suppressed` companion because the read face
+// renders one row per lang — suppressing one would promote the next upstream row
+// for that lang rather than remove the text. Writing the curated row is enough,
+// because it now wins the fold (HumanLaneFirstSQL).
+var introTableCharacter = introTable{
+	ownerCol:      "character_id",
+	hasProvenance: true,
+	empty:         func() any { return &catmodel.CatalogCharacterIntro{} },
+	newRow: func(id int64, lang, intro string) any {
+		return &catmodel.CatalogCharacterIntro{
+			CharacterID: id, Lang: lang, Intro: intro,
+			SourceID: curatedSourceID, Provenance: catmodel.IntroProvenanceSource,
+		}
+	},
+	read: func(ctx context.Context, db *gorm.DB, ownerID int64) (map[string]string, error) {
+		var rows []catmodel.CatalogCharacterIntro
+		if err := curatedIntroScope(ctx, db, "character_id", ownerID).
+			Where("provenance = ?", catmodel.IntroProvenanceSource).
+			Find(&rows).Error; err != nil {
+			return nil, err
+		}
+		out := make(map[string]string, len(rows))
+		for _, r := range rows {
+			out[r.Lang] = r.Intro
+		}
+		return out, nil
+	},
+}
+
+func loadCharacterIntros(ctx context.Context, db *gorm.DB, characterID int64) ([]any, error) {
+	return loadEntityIntros(ctx, db, introTableCharacter, characterID)
+}

--- a/apps/api/internal/platform/catalog/editspec/character_test.go
+++ b/apps/api/internal/platform/catalog/editspec/character_test.go
@@ -1,0 +1,278 @@
+package editspec_test
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	"api/internal/platform/catalog/editspec"
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/editing"
+	"api/internal/platform/provenance"
+)
+
+func newCharacterEngine(t *testing.T) *editing.Engine {
+	t.Helper()
+	e := newEngine(t)
+	for _, table := range []string{
+		"catalog_character_alias", "catalog_character_intro", "catalog_character",
+	} {
+		if err := testDB.Exec("TRUNCATE " + table + " RESTART IDENTITY CASCADE").Error; err != nil {
+			t.Fatalf("truncate %s: %v", table, err)
+		}
+	}
+	if err := editspec.RegisterCharacter(e.Registry(), testDB); err != nil {
+		t.Fatalf("register catalog.character: %v", err)
+	}
+	return e
+}
+
+func createCharacter(t *testing.T, displayName string) *model.CatalogCharacter {
+	t.Helper()
+	c := &model.CatalogCharacter{DisplayName: displayName}
+	if err := testDB.Create(c).Error; err != nil {
+		t.Fatalf("create character: %v", err)
+	}
+	return c
+}
+
+func reloadCharacter(t *testing.T, id int64) model.CatalogCharacter {
+	t.Helper()
+	var c model.CatalogCharacter
+	if err := testDB.First(&c, id).Error; err != nil {
+		t.Fatalf("reload character %d: %v", id, err)
+	}
+	return c
+}
+
+func TestCharacterScalarEdits(t *testing.T) {
+	e := newCharacterEngine(t)
+	ch := createCharacter(t, "初期名")
+
+	snap := mergeOn(t, e, editspec.TypeCharacter, ch.ID, map[string]any{
+		editspec.FieldCharacterDisplayName: "本名",
+		editspec.FieldCharacterLatin:       "Honmyou",
+		editspec.FieldCharacterLang:        "ja",
+		editspec.FieldCharacterDescription: "人手で書いた説明",
+		editspec.FieldCharacterGender:      float64(model.GenderFemale),
+		editspec.FieldCharacterHeightCm:    float64(158),
+		editspec.FieldCharacterBloodType:   float64(model.BloodTypeAB),
+		editspec.FieldCharacterCup:         "C",
+	})
+	if snap[editspec.FieldCharacterDisplayName] != "本名" {
+		t.Fatalf("snapshot display_name = %#v", snap[editspec.FieldCharacterDisplayName])
+	}
+
+	got := reloadCharacter(t, ch.ID)
+	if got.DisplayName != "本名" || got.Latin == nil || *got.Latin != "Honmyou" ||
+		got.Description != "人手で書いた説明" || got.Gender == nil || *got.Gender != model.GenderFemale ||
+		got.HeightCm == nil || *got.HeightCm != 158 || got.Cup == nil || *got.Cup != "C" {
+		t.Fatalf("character after merge: %+v", got)
+	}
+
+	prov := reloadCharacter(t, ch.ID).FieldProvenance
+	for _, column := range []string{
+		"display_name", "latin", "lang", "description", "gender", "height_cm", "blood_type", "cup",
+	} {
+		if head := provenance.FirstSource(prov, column); head != provenance.SourceCurated {
+			t.Errorf("catalog_character.field_provenance[%s] head = %q, want %q",
+				column, head, provenance.SourceCurated)
+		}
+	}
+
+	// A null must reach the column as NULL: "the editor cleared this attribute"
+	// and "the editor did not touch it" are different edits.
+	mergeOn(t, e, editspec.TypeCharacter, ch.ID, map[string]any{
+		editspec.FieldCharacterHeightCm: nil,
+		editspec.FieldCharacterLatin:    nil,
+	})
+	cleared := reloadCharacter(t, ch.ID)
+	if cleared.HeightCm != nil || cleared.Latin != nil {
+		t.Fatalf("clearing a nullable scalar left %+v", cleared)
+	}
+}
+
+func TestCharacterScalarValidators(t *testing.T) {
+	e := newCharacterEngine(t)
+	ch := createCharacter(t, "validator target")
+	editor := realActor(100, "admin")
+
+	var valErr *editing.ValidationError
+	cases := []map[string]any{
+		{editspec.FieldCharacterDisplayName: ""},
+		{editspec.FieldCharacterDisplayName: "   "},
+		{editspec.FieldCharacterDisplayName: nil},
+		{editspec.FieldCharacterLang: "xx"},
+		{editspec.FieldCharacterGender: float64(9)},
+		{editspec.FieldCharacterGender: "female"},
+		{editspec.FieldCharacterBloodType: float64(5)},
+		{editspec.FieldCharacterBirthdayMonth: float64(13)},
+		{editspec.FieldCharacterBirthdayDay: float64(0)},
+		{editspec.FieldCharacterHeightCm: 158.5},
+		{editspec.FieldCharacterCup: "much too long"},
+	}
+	for i, patch := range cases {
+		if _, _, err := e.CreateProposal(testCtx, editing.CreateProposalInput{
+			EntityType: editspec.TypeCharacter, EntityID: ch.ID, Patch: patch, Actor: editor,
+		}); !errors.As(err, &valErr) {
+			t.Errorf("case %d (%v): want ValidationError, got %v", i, patch, err)
+		}
+	}
+
+	if err := testDB.Delete(&model.CatalogCharacter{}, ch.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := e.CreateProposal(testCtx, editing.CreateProposalInput{
+		EntityType: editspec.TypeCharacter, EntityID: ch.ID,
+		Patch: map[string]any{editspec.FieldCharacterDisplayName: "ghost"}, Actor: editor,
+	}); !errors.Is(err, editing.ErrEntityNotFound) {
+		t.Fatalf("soft-deleted character: %v", err)
+	}
+}
+
+func TestCharacterIntrosAreTheCuratedLane(t *testing.T) {
+	e := newCharacterEngine(t)
+	ch := createCharacter(t, "紹介文の主")
+
+	upstream := model.CatalogCharacterIntro{
+		CharacterID: ch.ID, Lang: "ja", Intro: "バンガミの紹介",
+		SourceID: 3, Provenance: model.IntroProvenanceSource,
+	}
+	if err := testDB.Create(&upstream).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	intros := []any{map[string]any{"lang": "ja", "intro": "人手の紹介"}}
+	snap := mergeOn(t, e, editspec.TypeCharacter, ch.ID,
+		map[string]any{editspec.FieldCharacterIntros: intros})
+	sameJSON(t, "character intros", snap[editspec.FieldCharacterIntros], intros)
+
+	// The upstream row is its importer's and stays put; the curated row is a
+	// second physical row in the same lang, and the read-path fold picks it.
+	var rows []model.CatalogCharacterIntro
+	if err := testDB.Where("character_id = ?", ch.ID).Order("source_id").Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("character intro rows = %+v, want the upstream row kept alongside the curated one", rows)
+	}
+}
+
+func TestCharacterSiteOverlays(t *testing.T) {
+	reg := editing.NewRegistry()
+	if err := editspec.RegisterCharacter(reg, testDB); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	spec, ok := reg.Type(editspec.TypeCharacter)
+	if !ok {
+		t.Fatal("catalog.character is not registered")
+	}
+	for i := range spec.Fields {
+		key := spec.Fields[i].Key
+		kungal := spec.EffectivePolicy(key, "kungal")
+		if kungal.Propose != editing.ProposeOpen || kungal.Automerge != editing.AutomergeNever {
+			t.Fatalf("kungal policy for %s = %+v, want {open, …, never}", key, kungal)
+		}
+		for _, site := range []string{"letmoe", "letmoe-staging", "letmoe-dev"} {
+			letmoe := spec.EffectivePolicy(key, site)
+			if letmoe.Propose != editing.ProposeTrusted || letmoe.Automerge != editing.AutomergeOwner {
+				t.Fatalf("%s policy for %s = %+v, want {trusted, …, owner}", site, key, letmoe)
+			}
+		}
+		nextmoe := spec.EffectivePolicy(key, "nextmoe")
+		if nextmoe.Propose != editing.ProposePerm("edit.catalog.character") ||
+			nextmoe.Automerge != editing.AutomergeNever {
+			t.Fatalf("default policy for %s = %+v", key, nextmoe)
+		}
+	}
+}
+
+// A kungal reviewer holding edit.catalog.character.review still has to merge a
+// proposal by hand: a character fans out to every work it appears in, so it is
+// on the taxonomy side of the automerge line, not the work side.
+func TestKungalCharacterNeverAutomerges(t *testing.T) {
+	e := newCharacterEngine(t)
+	ch := createCharacter(t, "共有キャラ")
+
+	prop, rev, err := e.CreateProposal(testCtx, editing.CreateProposalInput{
+		EntityType: editspec.TypeCharacter, EntityID: ch.ID,
+		Patch: map[string]any{editspec.FieldCharacterDisplayName: "レビュー権付き改名"},
+		Actor: kungalActor(102, "admin"),
+	})
+	if err != nil {
+		t.Fatalf("admin propose on kungal: %v", err)
+	}
+	if rev != nil {
+		t.Fatal("kungal catalog.character must be automerge=never even for a review-perm holder")
+	}
+
+	if _, _, err := e.CreateProposal(testCtx, editing.CreateProposalInput{
+		EntityType: editspec.TypeCharacter, EntityID: ch.ID,
+		Patch: map[string]any{editspec.FieldCharacterCup: "D"},
+		Actor: kungalActor(101),
+	}); err != nil {
+		t.Fatalf("plain kungal user propose: %v", err)
+	}
+
+	var permErr *editing.PermissionError
+	if _, err := e.MergeProposal(testCtx, prop.ID, kungalActor(103, "moderator"), ""); !errors.As(err, &permErr) {
+		t.Fatalf("moderator merge: %v, want PermissionError", err)
+	}
+	if _, err := e.MergeProposal(testCtx, prop.ID, kungalActor(102, "admin"), "ok"); err != nil {
+		t.Fatalf("admin merge: %v", err)
+	}
+	if got := reloadCharacter(t, ch.ID).DisplayName; got != "レビュー権付き改名" {
+		t.Fatalf("display_name after merge = %q", got)
+	}
+}
+
+func TestLetmoeCharacterProposeIsTrusted(t *testing.T) {
+	e := newCharacterEngine(t)
+	ch := createCharacter(t, "letmoe キャラ")
+
+	untrusted := editing.PolicyContext{
+		UserID: 400, Site: "letmoe", TrustTier: 0, HasPerm: func(string) bool { return false },
+	}
+	var permErr *editing.PermissionError
+	if _, _, err := e.CreateProposal(testCtx, editing.CreateProposalInput{
+		EntityType: editspec.TypeCharacter, EntityID: ch.ID,
+		Patch: map[string]any{editspec.FieldCharacterDisplayName: "x"}, Actor: untrusted,
+	}); !errors.As(err, &permErr) {
+		t.Fatalf("untrusted letmoe propose: %v, want PermissionError", err)
+	}
+
+	trusted := untrusted
+	trusted.TrustTier = editing.TrustedTier
+	_, rev, err := e.CreateProposal(testCtx, editing.CreateProposalInput{
+		EntityType: editspec.TypeCharacter, EntityID: ch.ID,
+		Patch: map[string]any{editspec.FieldCharacterDisplayName: "信頼層の提案"}, Actor: trusted,
+	})
+	if err != nil {
+		t.Fatalf("trusted letmoe propose: %v", err)
+	}
+	// automerge=owner with no owner hook value means never — a character belongs
+	// to no site, so the letmoe overlay's shape matches work without granting it.
+	if rev != nil {
+		t.Fatal("a character has no owning site, so automerge=owner must never fire")
+	}
+}
+
+// The two ids the SQL folds order on must be exactly the two source keys
+// provenance calls human; anything else silently promotes or demotes a lane.
+func TestHumanSourceIDsAreTheHumanProvenanceKeys(t *testing.T) {
+	var keys []string
+	if err := testDB.Raw(`SELECT key FROM catalog_source WHERE id IN ? ORDER BY key`,
+		editspec.HumanSourceIDs()).Scan(&keys).Error; err != nil {
+		t.Fatalf("load source keys: %v", err)
+	}
+	want := append([]string(nil), provenance.HumanSources()...)
+	sort.Strings(want)
+	if len(keys) != len(want) {
+		t.Fatalf("catalog_source keys for %v = %v, want %v", editspec.HumanSourceIDs(), keys, want)
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("source key %d = %q, want %q", i, keys[i], want[i])
+		}
+	}
+}

--- a/apps/api/internal/platform/catalog/editspec/curated.go
+++ b/apps/api/internal/platform/catalog/editspec/curated.go
@@ -7,7 +7,38 @@ import (
 
 const curatedSourceID int16 = 12
 
+const userSourceID int16 = 1
+
 const curatedMatchedBy = "curated"
+
+// HumanSourceIDs is provenance.HumanSources() in catalog_source id form;
+// TestHumanSourceIDsAreTheHumanProvenanceKeys pins the two against the seed.
+func HumanSourceIDs() []int16 { return []int16{userSourceID, curatedSourceID} }
+
+// HumanLaneFirstSQL orders the human lane ahead of the importers within one
+// per-lang intro fold. It exists because curated (12) sorts AFTER every upstream
+// importer id: a hand-written ja intro was collated behind the bangumi row for
+// the same language and silently dropped by the one-row-per-lang fold, so the
+// editor saved it, read it back, and it never rendered (6 live work rows in
+// 2026-08).
+//
+// It goes AFTER `provenance`, never before it. Every intro the editing engine
+// writes is provenance=0 (IntroProvenanceSource, no exception), so ranking
+// provenance first costs the human lane nothing — it still wins its own tier.
+// Putting this term first instead makes a MACHINE-TRANSLATED curated row beat an
+// upstream ORIGINAL one, which inverts the separate and correct "source outranks
+// machine" axis. The bug was human text hidden by upstream human text; it was
+// never "curated wins everything".
+//
+// Inside the machine tier the term still applies, and that is deliberate: a
+// curated provenance=1 row is the translation OF the curated original this same
+// fold just picked for its own language, so preferring it keeps the languages
+// telling one story instead of pairing our ja original with a translation of the
+// ja text we rejected. That is also why it precedes the character fold's
+// derived-extraction exception, which ranks machine rows among themselves.
+func HumanLaneFirstSQL(sourceColumn string) string {
+	return fmt.Sprintf("(%s IN (%d, %d)) DESC", sourceColumn, userSourceID, curatedSourceID)
+}
 
 const (
 	maxListElements = 200

--- a/apps/api/internal/platform/catalog/editspec/provenance_test.go
+++ b/apps/api/internal/platform/catalog/editspec/provenance_test.go
@@ -103,10 +103,14 @@ func TestOnlyDeclaredFieldsStampProvenance(t *testing.T) {
 	if err := editspec.RegisterTaxonomy(reg, testDB); err != nil {
 		t.Fatalf("register taxonomy: %v", err)
 	}
+	if err := editspec.RegisterCharacter(reg, testDB); err != nil {
+		t.Fatalf("register catalog.character: %v", err)
+	}
 
 	var got []string
 	for _, entityType := range []string{
 		editspec.TypeWork, editspec.TypeLabel, editspec.TypeTag, editspec.TypeEngine, editspec.TypeSeries,
+		editspec.TypeCharacter,
 	} {
 		spec, ok := reg.Type(entityType)
 		if !ok {
@@ -123,6 +127,20 @@ func TestOnlyDeclaredFieldsStampProvenance(t *testing.T) {
 	sort.Strings(got)
 
 	want := []string{
+		"catalog.character.birthday_day -> catalog_character.birthday_day",
+		"catalog.character.birthday_month -> catalog_character.birthday_month",
+		"catalog.character.blood_type -> catalog_character.blood_type",
+		"catalog.character.bust_cm -> catalog_character.bust_cm",
+		"catalog.character.cup -> catalog_character.cup",
+		"catalog.character.description -> catalog_character.description",
+		"catalog.character.display_name -> catalog_character.display_name",
+		"catalog.character.gender -> catalog_character.gender",
+		"catalog.character.height_cm -> catalog_character.height_cm",
+		"catalog.character.hip_cm -> catalog_character.hip_cm",
+		"catalog.character.lang -> catalog_character.lang",
+		"catalog.character.latin -> catalog_character.latin",
+		"catalog.character.waist_cm -> catalog_character.waist_cm",
+		"catalog.character.weight_kg -> catalog_character.weight_kg",
 		"catalog.label.name -> catalog_label.display_name",
 		"catalog.work.content_rating -> catalog_work.content_rating",
 		"catalog.work.display_name -> catalog_work.display_name",

--- a/apps/api/internal/platform/catalog/importer/rostervndb.go
+++ b/apps/api/internal/platform/catalog/importer/rostervndb.go
@@ -256,6 +256,11 @@ func (im *Importer) loadCharRefsByKind(source, linkKind int16) (map[string]int64
 	return m, nil
 }
 
+// loadVNDBAttachTargets deliberately reads catalog_character_alias WITHOUT the
+// catalog.character.aliases suppression predicate. Suppressing a row means "do
+// not render it", not "this name does not exist": the attach test asks whether
+// this vndb character is already in the roster under any spelling, and hiding a
+// name from it would mint a second character row for the same person.
 func (im *Importer) loadVNDBAttachTargets() (map[string]int64, error) {
 	var rows []struct {
 		CharID     string `gorm:"column:char_id"`

--- a/apps/api/internal/platform/catalog/perm/perm.go
+++ b/apps/api/internal/platform/catalog/perm/perm.go
@@ -16,12 +16,18 @@ const (
 	EditTaxonomyReview authz.Permission = "edit.catalog.taxonomy.review"
 )
 
+const (
+	EditCharacter       authz.Permission = "edit.catalog.character"
+	EditCharacterReview authz.Permission = "edit.catalog.character.review"
+)
+
 const EditTrusted authz.Permission = "catalog.edit.trusted"
 
 var moderatorPerms = []authz.Permission{ClaimReview}
 
 var adminPerms = append(append([]authz.Permission{}, moderatorPerms...),
-	EditWork, EditWorkReview, EditTaxonomy, EditTaxonomyReview, EditTrusted)
+	EditWork, EditWorkReview, EditTaxonomy, EditTaxonomyReview,
+	EditCharacter, EditCharacterReview, EditTrusted)
 
 var renPerms = append(append([]authz.Permission{}, adminPerms...), Review)
 

--- a/apps/api/internal/platform/catalog/perm/perm_test.go
+++ b/apps/api/internal/platform/catalog/perm/perm_test.go
@@ -8,16 +8,45 @@ import (
 )
 
 var goldenGrants = map[authz.Permission][]string{
-	perm.Review:             {"ren"},
-	perm.ClaimReview:        {"moderator", "admin", "ren"},
-	perm.EditWork:           {"admin", "ren"},
-	perm.EditWorkReview:     {"admin", "ren"},
-	perm.EditTaxonomy:       {"admin", "ren"},
-	perm.EditTaxonomyReview: {"admin", "ren"},
-	perm.EditTrusted:        {"admin", "ren"},
+	perm.Review:              {"ren"},
+	perm.ClaimReview:         {"moderator", "admin", "ren"},
+	perm.EditWork:            {"admin", "ren"},
+	perm.EditWorkReview:      {"admin", "ren"},
+	perm.EditTaxonomy:        {"admin", "ren"},
+	perm.EditTaxonomyReview:  {"admin", "ren"},
+	perm.EditCharacter:       {"admin", "ren"},
+	perm.EditCharacterReview: {"admin", "ren"},
+	perm.EditTrusted:         {"admin", "ren"},
 }
 
 var allRoles = []string{"user", "creator", "moderator", "admin", "ren"}
+
+// goldenGrants is the contract, and every other test here only asserts over the
+// keys it already lists — so a key added to a bundle but forgotten here is
+// granted to roles nobody ever checked, silently. This is the assertion that
+// looks at the list itself.
+func TestGoldenCoversEveryBundledPermission(t *testing.T) {
+	for bundle, perms := range perm.Bundles {
+		for _, p := range perms {
+			if _, listed := goldenGrants[p]; !listed {
+				t.Errorf("bundle %q grants %q, which no golden row covers", bundle, p)
+			}
+		}
+	}
+	for p := range goldenGrants {
+		granted := false
+		for _, perms := range perm.Bundles {
+			for _, bundled := range perms {
+				if bundled == p {
+					granted = true
+				}
+			}
+		}
+		if !granted {
+			t.Errorf("golden row %q is in no bundle", p)
+		}
+	}
+}
 
 func TestGoldenBundles(t *testing.T) {
 	for p, granted := range goldenGrants {

--- a/apps/api/internal/platform/catalog/service/character_edit_lane_test.go
+++ b/apps/api/internal/platform/catalog/service/character_edit_lane_test.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"testing"
+
+	"api/internal/platform/catalog/editspec"
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/editing"
+	"api/internal/platform/provenance"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func characterEngine(t *testing.T) *editing.Engine {
+	t.Helper()
+	e := provEngine(t)
+	require.NoError(t, editspec.RegisterCharacter(e.Registry(), testDB))
+	return e
+}
+
+func suppressCharacterAlias(t *testing.T, characterID int64, kind int16, lang, name string) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&editing.SuppressedRow{
+		EntityType:  editspec.TypeCharacter,
+		EntityID:    characterID,
+		FieldKey:    editspec.FieldCharacterAliases,
+		IdentityKey: editspec.CharacterAliasIdentity(kind, lang, name),
+	}).Error)
+}
+
+func TestReadFacesExcludeSuppressedCharacterAliases(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+	read := NewReadService(testDB)
+	public := NewPublicService(testDB, read, testResolve, "")
+
+	ch := createCharacter(t, "主人公")
+	good := createCharacterAlias(t, ch.ID, "しゅじんこう", "ja")
+	bad := createCharacterAlias(t, ch.ID, "誤った別名", "ja")
+	_ = good
+
+	before, err := read.CharacterByID(ctx, ch.ID, model.SpoilerSevere)
+	require.NoError(t, err)
+	require.Len(t, before.Aliases, 2)
+	pubBefore, ok, err := public.Character(ctx, ch.ID, false, true, model.SpoilerSevere, 10, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, pubBefore.Aliases, 2)
+
+	suppressCharacterAlias(t, ch.ID, bad.Kind, bad.Lang, bad.Name)
+
+	after, err := read.CharacterByID(ctx, ch.ID, model.SpoilerSevere)
+	require.NoError(t, err)
+	require.Len(t, after.Aliases, 1)
+	assert.Equal(t, "しゅじんこう", after.Aliases[0].Name)
+
+	pubAfter, ok, err := public.Character(ctx, ch.ID, false, true, model.SpoilerSevere, 10, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, []string{"しゅじんこう"}, pubAfter.Aliases)
+
+	// The suppressed row is still in the table: the roster importer owns it and
+	// the exclusion is a read-path rule, not a delete.
+	var live int64
+	require.NoError(t, testDB.Model(&model.CatalogCharacterAlias{}).
+		Where("character_id = ?", ch.ID).Count(&live).Error)
+	assert.EqualValues(t, 2, live)
+}
+
+func TestMergeCarriesCharacterAliasSuppressions(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+
+	target := createCharacter(t, "同じキャラ")
+	source := createCharacter(t, "同じ キャラ")
+	createCharacterAlias(t, target.ID, "生き残る別名", "ja")
+	srcOnly := createCharacterAlias(t, source.ID, "誤別名", "ja")
+	srcShared := createCharacterAlias(t, source.ID, "共通別名", "ja")
+	dstShared := createCharacterAlias(t, target.ID, "共通別名", "zh-Hans")
+
+	suppressCharacterAlias(t, source.ID, srcOnly.Kind, srcOnly.Lang, srcOnly.Name)
+	suppressCharacterAlias(t, source.ID, srcShared.Kind, srcShared.Lang, srcShared.Name)
+	// The same identity key already sits on the target: the rehang must fold it,
+	// not duplicate it into a unique-constraint violation.
+	suppressCharacterAlias(t, target.ID, srcShared.Kind, srcShared.Lang, srcShared.Name)
+	_ = dstShared
+
+	p, err := testMerge.ProposeMerge(ctx, model.EntityTypeCharacter, source.ID, target.ID, 7, "suppression rehang")
+	require.NoError(t, err)
+	approveAndForceExecutable(t, p.ID)
+	require.NoError(t, testMerge.ExecuteMerge(ctx, p.ID, nil))
+
+	keys, err := editing.LoadSuppressedKeys(ctx, testDB, editspec.TypeCharacter, target.ID, editspec.FieldCharacterAliases)
+	require.NoError(t, err)
+	assert.Len(t, keys, 2, "both suppressions land on the survivor, deduplicated")
+
+	left, err := editing.LoadSuppressedKeys(ctx, testDB, editspec.TypeCharacter, source.ID, editspec.FieldCharacterAliases)
+	require.NoError(t, err)
+	assert.Empty(t, left, "nothing may stay stranded on the merged-away character")
+
+	read := NewReadService(testDB)
+	detail, err := read.CharacterByID(ctx, target.ID, model.SpoilerSevere)
+	require.NoError(t, err)
+	names := make([]string, 0, len(detail.Aliases))
+	for _, a := range detail.Aliases {
+		names = append(names, a.Name)
+	}
+	assert.Equal(t, []string{"生き残る別名", "共通別名"}, names,
+		"the ja 共通別名 rehung from the source stays suppressed; the zh-Hans one is a different key")
+}
+
+func TestMergeKeepsEngineEditedCharacterName(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+	e := characterEngine(t)
+
+	target := createCharacter(t, "上流の暫定名")
+	source := createCharacter(t, "上流の別名")
+	require.NoError(t, testDB.Exec(
+		`UPDATE catalog_character SET field_provenance =
+		 '{"display_name":[{"source":"vndb","at":"2026-01-01T00:00:00Z"}]}' WHERE id = ?`,
+		source.ID).Error)
+
+	humanEdit(t, e, editspec.TypeCharacter, target.ID,
+		map[string]any{editspec.FieldCharacterDisplayName: "人が決めた正式名"})
+
+	p, err := testMerge.ProposeMerge(ctx, model.EntityTypeCharacter, source.ID, target.ID, 7, "dup")
+	require.NoError(t, err)
+	resolveToSource(t, p.ID, "display_name")
+	approveAndForceExecutable(t, p.ID)
+	require.NoError(t, testMerge.ExecuteMerge(ctx, p.ID, nil))
+
+	var merged model.CatalogCharacter
+	require.NoError(t, testDB.First(&merged, target.ID).Error)
+	assert.Equal(t, "人が決めた正式名", merged.DisplayName,
+		"an engine edit must survive a merge that resolves the field to the source")
+	assert.Equal(t, provenance.SourceCurated, firstProvSource(merged.FieldProvenance, "display_name"))
+}
+
+// The curated lane sorts AFTER every importer id (12 > 2/3/4/5), so before this
+// ordering term a hand-written intro was folded away by the one-row-per-lang
+// rule: saved, readable in the editor, and absent from every face.
+func TestHumanIntroWinsTheLangFold(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+	read := NewReadService(testDB)
+	public := NewPublicService(testDB, read, testResolve, "")
+
+	const bangumiSourceID, curatedSourceID = 3, 12
+
+	w := createWork(t, "作品")
+	require.NoError(t, testDB.Create(&[]model.CatalogWorkIntro{
+		{WorkID: w.ID, Lang: "ja", Intro: "上流の紹介", SourceID: bangumiSourceID, Provenance: model.IntroProvenanceSource},
+		{WorkID: w.ID, Lang: "ja", Intro: "人手の紹介", SourceID: curatedSourceID, Provenance: model.IntroProvenanceSource},
+	}).Error)
+
+	intros := map[int64][]WorkIntroRow{}
+	require.NoError(t, read.nativeWorkIntros(ctx, []int64{w.ID}, intros))
+	require.Len(t, intros[w.ID], 1)
+	assert.Equal(t, "人手の紹介", intros[w.ID][0].Intro)
+
+	ch := createCharacter(t, "キャラ")
+	require.NoError(t, testDB.Create(&[]model.CatalogCharacterIntro{
+		{CharacterID: ch.ID, Lang: "ja", Intro: "上流のキャラ紹介", SourceID: bangumiSourceID, Provenance: model.IntroProvenanceSource},
+		{CharacterID: ch.ID, Lang: "ja", Intro: "人手のキャラ紹介", SourceID: curatedSourceID, Provenance: model.IntroProvenanceSource},
+	}).Error)
+
+	detail, err := read.CharacterByID(ctx, ch.ID, model.SpoilerSevere)
+	require.NoError(t, err)
+	require.Len(t, detail.Intros, 1)
+	assert.Equal(t, "人手のキャラ紹介", detail.Intros[0].Intro)
+
+	pub, ok, err := public.Character(ctx, ch.ID, false, true, model.SpoilerSevere, 10, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, pub.Intros, 1)
+	assert.Equal(t, "人手のキャラ紹介", pub.Intros[0].Intro)
+	assert.Equal(t, "curated", pub.Intros[0].Source)
+}
+
+// The other half of the same ordering. The human lane wins its own provenance
+// tier and nothing more: a machine translation that happens to sit in the
+// curated lane (entity-intro-mt writes prov=1 under the ja row's source_id) must
+// still lose to an upstream ORIGINAL, or the fix to the fold would have inverted
+// the source-outranks-machine axis on its way past.
+func TestCuratedMachineTranslationDoesNotBeatAnUpstreamOriginal(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+	read := NewReadService(testDB)
+	public := NewPublicService(testDB, read, testResolve, "")
+
+	const bangumiSourceID, curatedSourceID = 3, 12
+
+	w := createWork(t, "作品")
+	require.NoError(t, testDB.Create(&[]model.CatalogWorkIntro{
+		{WorkID: w.ID, Lang: "zh-Hans", Intro: "上流の原文", SourceID: bangumiSourceID, Provenance: model.IntroProvenanceSource},
+		{WorkID: w.ID, Lang: "zh-Hans", Intro: "curated 車道の機械翻訳", SourceID: curatedSourceID, Provenance: model.IntroProvenanceMachine},
+	}).Error)
+
+	intros := map[int64][]WorkIntroRow{}
+	require.NoError(t, read.nativeWorkIntros(ctx, []int64{w.ID}, intros))
+	require.Len(t, intros[w.ID], 1)
+	assert.Equal(t, "上流の原文", intros[w.ID][0].Intro)
+	assert.False(t, intros[w.ID][0].Machine)
+
+	ch := createCharacter(t, "キャラ")
+	require.NoError(t, testDB.Create(&[]model.CatalogCharacterIntro{
+		{CharacterID: ch.ID, Lang: "zh-Hans", Intro: "上流の原文", SourceID: bangumiSourceID, Provenance: model.IntroProvenanceSource},
+		{CharacterID: ch.ID, Lang: "zh-Hans", Intro: "curated 車道の機械翻訳", SourceID: curatedSourceID, Provenance: model.IntroProvenanceMachine},
+	}).Error)
+
+	detail, err := read.CharacterByID(ctx, ch.ID, model.SpoilerSevere)
+	require.NoError(t, err)
+	require.Len(t, detail.Intros, 1)
+	assert.Equal(t, "上流の原文", detail.Intros[0].Intro)
+
+	pub, ok, err := public.Character(ctx, ch.ID, false, true, model.SpoilerSevere, 10, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, pub.Intros, 1)
+	assert.Equal(t, "上流の原文", pub.Intros[0].Intro)
+	assert.Equal(t, "bangumi", pub.Intros[0].Source)
+}

--- a/apps/api/internal/platform/catalog/service/merge_rehang.go
+++ b/apps/api/internal/platform/catalog/service/merge_rehang.go
@@ -53,7 +53,12 @@ type mergeStmt struct {
 //     engine's history and its open queue, addressed to the id that was
 //     actually edited; same rationale as catalog_revision. edit_suppressed_row
 //     is NOT history — it is live negative knowledge the read paths consult on
-//     every request, so it rehangs with the title rows below.
+//     every request, so it rehangs with the title and alias rows below. One
+//     branch per REGISTERED entity type, not per merge-able type: work
+//     (catalog.work.titles) and character (catalog.character.aliases) each move
+//     their own rows. credit_name registers no field yet, so it has no branch —
+//     R2c must add one the day credits become editable, or every suppression a
+//     reviewer records is silently undone by the next name merge.
 func rehangEntity(tx *gorm.DB, entityType int16, src, dst int64) ([]int64, error) {
 	switch entityType {
 	case model.EntityTypePerson:
@@ -140,6 +145,7 @@ func rehangEntity(tx *gorm.DB, entityType int16, src, dst int64) ([]int64, error
 			{`DELETE FROM catalog_character_trait_link WHERE character_id = ?`, []any{src}, false},
 			{`UPDATE catalog_character SET instance_of = ? WHERE instance_of = ?`, []any{dst, src}, false},
 		}
+		stmts = append(stmts, suppressedRowStmts(editspec.TypeCharacter, src, dst)...)
 		return execAll(tx, append(stmts, entityRelationStmts(entityType, src, dst)...))
 
 	case model.EntityTypeWork:
@@ -162,14 +168,6 @@ func rehangEntity(tx *gorm.DB, entityType int16, src, dst int64) ([]int64, error
 			    AND NOT EXISTS (SELECT 1 FROM catalog_work_title u
 			                     WHERE u.work_id = ? AND u.lang = t.lang AND u.title = t.title AND u.kind = t.kind)`, []any{dst, src, dst}, false},
 			{`DELETE FROM catalog_work_title WHERE work_id = ?`, []any{src}, false},
-			{`UPDATE edit_suppressed_row s SET entity_id = ?
-			    WHERE s.entity_type = ? AND s.entity_id = ?
-			    AND NOT EXISTS (SELECT 1 FROM edit_suppressed_row x
-			                     WHERE x.entity_type = s.entity_type AND x.entity_id = ?
-			                       AND x.field_key = s.field_key AND x.identity_key = s.identity_key)`,
-				[]any{dst, editspec.TypeWork, src, dst}, false},
-			{`DELETE FROM edit_suppressed_row WHERE entity_type = ? AND entity_id = ?`,
-				[]any{editspec.TypeWork, src}, false},
 			{`UPDATE catalog_release SET work_id = ? WHERE work_id = ?`, []any{dst, src}, false},
 			{`UPDATE catalog_credit c SET work_id = ? WHERE c.work_id = ?
 			    AND NOT EXISTS (SELECT 1 FROM catalog_credit d
@@ -178,9 +176,23 @@ func rehangEntity(tx *gorm.DB, entityType int16, src, dst int64) ([]int64, error
 			                       AND COALESCE(d.character_id, 0) = COALESCE(c.character_id, 0))`, []any{dst, src, dst}, false},
 			{`DELETE FROM catalog_credit WHERE work_id = ?`, []any{src}, false},
 		}
+		stmts = append(stmts, suppressedRowStmts(editspec.TypeWork, src, dst)...)
 		return execAll(tx, append(stmts, workFacetStmts(src, dst)...))
 	}
 	return nil, fmt.Errorf("catalog merge: unsupported entity type %d", entityType)
+}
+
+func suppressedRowStmts(entityType string, src, dst int64) []mergeStmt {
+	return []mergeStmt{
+		{`UPDATE edit_suppressed_row s SET entity_id = ?
+		    WHERE s.entity_type = ? AND s.entity_id = ?
+		    AND NOT EXISTS (SELECT 1 FROM edit_suppressed_row x
+		                     WHERE x.entity_type = s.entity_type AND x.entity_id = ?
+		                       AND x.field_key = s.field_key AND x.identity_key = s.identity_key)`,
+			[]any{dst, entityType, src, dst}, false},
+		{`DELETE FROM edit_suppressed_row WHERE entity_type = ? AND entity_id = ?`,
+			[]any{entityType, src}, false},
+	}
 }
 
 func workFacetStmts(src, dst int64) []mergeStmt {

--- a/apps/api/internal/platform/catalog/service/public_names.go
+++ b/apps/api/internal/platform/catalog/service/public_names.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"api/internal/platform/catalog/dto"
+	"api/internal/platform/catalog/editspec"
 	"api/internal/platform/catalog/model"
 )
 
@@ -14,6 +15,9 @@ type aliasSource struct {
 	ownerCol     string
 	ownerTable   string
 	ownerNameCol string
+	// live is the row-level suppression predicate, correlated on alias "a", and
+	// empty for the families whose alias list is not a registered edit field yet.
+	live string
 }
 
 var (
@@ -24,6 +28,7 @@ var (
 	characterAliasSource = aliasSource{
 		table: "catalog_character_alias", ownerCol: "character_id",
 		ownerTable: "catalog_character", ownerNameCol: "display_name",
+		live: editspec.NotSuppressedCharacterAliasSQL("a"),
 	}
 	creditNameAliasSource = aliasSource{
 		table: "catalog_name_alias", ownerCol: "credit_name_id",
@@ -41,15 +46,19 @@ type displayAlias struct {
 }
 
 func (s *PublicService) entityAliases(ctx context.Context, src aliasSource, ownerID int64) ([]displayAlias, error) {
+	live := ""
+	if src.live != "" {
+		live = " AND " + src.live
+	}
 	q := fmt.Sprintf(`
 		SELECT a.name, a.lang, a.kind, a.provenance,
 		       a.is_primary_for_locale AS is_primary,
 		       (a.name = o.%s) AS is_display
 		FROM %s a
 		JOIN %s o ON o.id = a.%s
-		WHERE a.%s = ? AND a.kind <> ?
+		WHERE a.%s = ? AND a.kind <> ?%s
 		ORDER BY a.name, a.id`,
-		src.ownerNameCol, src.table, src.ownerTable, src.ownerCol, src.ownerCol)
+		src.ownerNameCol, src.table, src.ownerTable, src.ownerCol, src.ownerCol, live)
 
 	var rows []displayAlias
 	if err := s.db.WithContext(ctx).Raw(q, ownerID, model.AliasKindSearchHint).Scan(&rows).Error; err != nil {

--- a/apps/api/internal/platform/catalog/service/public_service.go
+++ b/apps/api/internal/platform/catalog/service/public_service.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"api/internal/platform/catalog/dto"
+	"api/internal/platform/catalog/editspec"
 	"api/internal/platform/catalog/model"
 	catsearch "api/internal/platform/catalog/search"
 	"api/pkg/imageclient"
@@ -1302,7 +1303,8 @@ func (s *PublicService) characterIntros(ctx context.Context, characterID int64) 
 	}
 	if err := s.db.WithContext(ctx).Raw(`SELECT lang, intro, source_id, provenance
 		FROM catalog_character_intro WHERE character_id = ?
-		ORDER BY lang, provenance, (provenance = 1 AND source_id = ?) DESC, source_id`,
+		ORDER BY lang, provenance, `+editspec.HumanLaneFirstSQL("source_id")+
+		`, (provenance = 1 AND source_id = ?) DESC, source_id`,
 		characterID, sourceDerived).Scan(&rows).Error; err != nil {
 		return nil, err
 	}

--- a/apps/api/internal/platform/catalog/service/read_service.go
+++ b/apps/api/internal/platform/catalog/service/read_service.go
@@ -403,7 +403,8 @@ func (s *ReadService) nativeWorkIntros(ctx context.Context, workIDs []int64, out
 		Provenance int16  `gorm:"column:provenance"`
 	}
 	if err := db.Raw(`SELECT work_id, lang, intro, source_id, provenance FROM catalog_work_intro
-		WHERE work_id IN ? ORDER BY work_id, lang, provenance, source_id`, workIDs).Scan(&rows).Error; err != nil {
+		WHERE work_id IN ? ORDER BY work_id, lang, provenance, `+
+		editspec.HumanLaneFirstSQL("source_id")+`, source_id`, workIDs).Scan(&rows).Error; err != nil {
 		return err
 	}
 	seen := make(map[int64]map[string]bool)
@@ -1063,8 +1064,10 @@ func (s *ReadService) CharacterByID(ctx context.Context, characterID int64, maxS
 		Extra:       decodeCharExtra(head.Extra),
 		AttrSources: attrSources(head.FieldProvenance),
 	}
-	if err := db.Raw(`SELECT id, name, latin, lang, kind, is_primary_for_locale
-		FROM catalog_character_alias WHERE character_id = ? ORDER BY id`, characterID).Scan(&detail.Aliases).Error; err != nil {
+	if err := db.Raw(`SELECT a.id, a.name, a.latin, a.lang, a.kind, a.is_primary_for_locale
+		FROM catalog_character_alias a WHERE a.character_id = ? AND `+
+		editspec.NotSuppressedCharacterAliasSQL("a")+` ORDER BY a.id`,
+		characterID).Scan(&detail.Aliases).Error; err != nil {
 		return nil, err
 	}
 	var introRows []struct {
@@ -1074,7 +1077,8 @@ func (s *ReadService) CharacterByID(ctx context.Context, characterID int64, maxS
 		Provenance int16  `gorm:"column:provenance"`
 	}
 	if err := db.Raw(`SELECT lang, intro, source_id, provenance FROM catalog_character_intro
-		WHERE character_id = ? ORDER BY lang, provenance,
+		WHERE character_id = ? ORDER BY lang, provenance, `+
+		editspec.HumanLaneFirstSQL("source_id")+`,
 		(provenance = 1 AND source_id = ?) DESC, source_id`, characterID, sourceDerived).Scan(&introRows).Error; err != nil {
 		return nil, err
 	}

--- a/apps/api/internal/platform/catalog/service/snapshot.go
+++ b/apps/api/internal/platform/catalog/service/snapshot.go
@@ -82,6 +82,9 @@ func takeSnapshot(tx *gorm.DB, entityType int16, id int64) (datatypes.JSON, erro
 		if err := tx.First(&c, id).Error; err != nil {
 			return nil, err
 		}
+		// No catalog.character.aliases suppression predicate here on purpose: a
+		// merge snapshot is the record of what physically hung off the retired id,
+		// and an unmerge restores rows, not renderings.
 		var aliases []model.CatalogCharacterAlias
 		if err := tx.Where("character_id = ?", id).Order("id").Find(&aliases).Error; err != nil {
 			return nil, err

--- a/apps/api/internal/platform/permissions/registry.go
+++ b/apps/api/internal/platform/permissions/registry.go
@@ -143,6 +143,8 @@ var live = NewRegistry(
 			{catalogPerm.EditWorkReview, "Adjudicate a catalog.work proposal (amend / merge / decline / revert).", "裁决 catalog.work 提案(修订/合入/驳回/回滚)"},
 			{catalogPerm.EditTaxonomy, "Propose an edit on the shared vocabulary (label / tag / engine / series).", "对共享词表提交编辑提案(label/tag/engine/series)"},
 			{catalogPerm.EditTaxonomyReview, "Adjudicate a vocabulary proposal.", "裁决词表提案"},
+			{catalogPerm.EditCharacter, "Propose an edit on catalog.character through the editing engine.", "对 catalog.character 提交编辑提案"},
+			{catalogPerm.EditCharacterReview, "Adjudicate a catalog.character proposal (amend / merge / decline / revert).", "裁决 catalog.character 提案(修订/合入/驳回/回滚)"},
 			{catalogPerm.EditTrusted, "Write at the trusted tier through the editing engine (site ProposeTrusted lanes accept filings directly).", "以受信任层级走编辑引擎写入(站点 trusted 通道直接接受其提交)"},
 		},
 	},

--- a/docs/auth/04-permission-first-authz.md
+++ b/docs/auth/04-permission-first-authz.md
@@ -110,6 +110,8 @@ type NonDelegable map[Permission]bool      // 叠加层永不可授予的键(§7
 | `edit.catalog.work.review` | admin, ren | 引擎面裁决 `catalog.work` 提案(amend/merge/decline/revert) |
 | `edit.catalog.taxonomy` | admin, ren | 引擎面对 `catalog.{label,tag,engine,series}` 提提案(四族**一把键**=同一权威:注册表共享词表) |
 | `edit.catalog.taxonomy.review` | admin, ren | 引擎面裁决词表提案;**建/删/合并词表条目不在此键**,属注册表策展,仍在 `catalog.review` 之后 |
+| `edit.catalog.character` | admin, ren | 引擎面对 `catalog.character` 提提案(标量属性 + curated 别名车道 + 简介;**建/删/合并角色不在此键**,属注册表策展) |
+| `edit.catalog.character.review` | admin, ren | 引擎面裁决 `catalog.character` 提案(amend/merge/decline/revert);kungal overlay 与词表同档=`automerge=never`,一个角色被多部作品共享 |
 | `catalog.edit.trusted` | admin, ren | 以受信任层级(`TrustTier=2`)走编辑引擎写入:站点 `ProposeTrusted` 通道直接接受其提交(letmoe work overlay)。**与审核轴刻意正交,故不含 moderator**;产品站把它授给自己的角色(如 letmoe `creator`)走 §7 叠加层 |
 | `trust.queue_access` | moderator, admin, ren | T&S 统一审核收件箱队列 |
 | `trust.term_manage` | admin, ren | Tier0 词表增改/退役(站域封禁权,比 queue_access 敏感;**不含 moderator**) |

--- a/docs/catalog/01-service-and-contract.md
+++ b/docs/catalog/01-service-and-contract.md
@@ -299,12 +299,18 @@ catalog 的**第三张脸**,也是「用户写面」的起点。教义一句话:
 
 **行级压制字段 `<field>.suppressed`(wave R1a,2026-08-16 起在产)**:上游 importer 拥有的行不属于编辑面(编辑面只看 curated 车道),但人有时需要让某一行**不再出现在任何读面**。办法不是删它——下一轮导入会把它重新推回来——而是给它记一条负知识。
 
-- **形状**:凡支持此能力的字段 `F`,`getEditSchemaUser` 的 `fields[]` 里**多一个** key `F.suppressed`(`kind=list`、`diff_hint=items`),策略与 `F` 逐字相同(继承父字段的站点 overlay)。首个上线的是 `catalog.work.titles.suppressed`。
-- **值 = 严格升序、去重的字符串数组**(不是集合语义的任意顺序数组)。乱序或重复 → **422**。元素是**内容派生**的行身份键,标题的形状是 `title:<kind>:<lang>:<title>`(`kind` 是数字:0 official / 1 alias / 2 abbreviation)。之所以不用行 id:importer 删了重插同一行会换 id,压制会正好在它该生效的时候失效。
+- **形状**:凡支持此能力的字段 `F`,`getEditSchemaUser` 的 `fields[]` 里**多一个** key `F.suppressed`(`kind=list`、`diff_hint=items`),策略与 `F` 逐字相同(继承父字段的站点 overlay)。目前两个:`catalog.work.titles.suppressed` 与 `catalog.character.aliases.suppressed`。
+- **值 = 严格升序、去重的字符串数组**(不是集合语义的任意顺序数组)。乱序或重复 → **422**。元素是**内容派生**的行身份键:标题是 `title:<kind>:<lang>:<title>`(`kind` 是数字:0 official / 1 alias / 2 abbreviation),角色别名是 `alias:<kind>:<lang>:<name>`。之所以不用行 id:importer 删了重插同一行会换 id,压制会正好在它该生效的时候失效。
 - **悬空键合法**:只校格式,不校该行此刻是否存在——上游今天没推、明天推回来的行,压制照旧等在那里。
 - **被压制的行仍物理留在表里**(importer 仍拥有它),只是**不出任何读面**,标题搜索与 Meili 索引同规排除。父字段 `F` 的编辑快照**照旧包含**这些行(它是全量替换语义,过滤掉会导致下一次保存把它们物理删掉)。
 - 压制与解除各产一条 `entity_revision`,可 diff、可回滚、有归属,与普通编辑同一条审计通道。
 - ⚠️ **通用渲染的 UI 注意**:如果编辑器是「遍历 `fields[]` 逐个渲染」,`F.suppressed` 会作为一个裸字符串数组出现。它要么按压制 UI 渲染(在 `F` 的行旁边给一个「隐藏此行」),要么显式跳过 `.suppressed` 后缀——**不要**当普通文本数组交给用户手打。
+
+**已注册的 entity_type(wave R2a,2026-08-16 起)**:`catalog.work` · `catalog.character` · `catalog.label` / `catalog.tag` / `catalog.engine` / `catalog.series`。编辑面按 `entity_type` 泛化,**新增一个类型不新增任何路由**——`getEditSchemaUser` 换个 `entity_type` 即可,三份 spec 逐字节不变。
+
+- `catalog.character` 开的是**内容**:14 个标量(`display_name` / `lang` / `latin` / `description` / `gender` / 生日月日 / 血型 / 身高体重三围 / cup)+ `aliases`(**只含人工车道行**,上游别名不进字段值,要隐藏走 `aliases.suppressed`)+ `intros`(多语言,人工车道)。**身份不开**:`instance_of`(角色折叠)与外部锚仍归合并机器,永不注册。
+- kungal 租户下 character 的 `automerge` 是 **never**(与词表同档,不与 work 同档):一个角色被它出现过的每一部作品共享,直落的波及面接近词表。有 review 权也只入队。
+- **多语言简介的折叠规则修正(同波)**:作品与角色的简介读面都是「每 lang 只渲染一条」,此前排序让 **curated(source 12)排在所有上游 importer 之后**,于是人工写的同 lang 简介保存成功、回读得到、却永远不出面。现已改为**同 provenance 档内人工车道优先**(顺序:`provenance` → 人工车道 → 其余)。生产上有 10 部作品的简介渲染文本因此改变——**这是修复不是回归**,每一条都是「人保存过的文本终于开始出面」。`provenance` 仍排在最前,所以机翻永远不会盖过原文。
 
 ### 4.3 认领生命周期(投稿 + 八动作 + 我的认领,wave 179)
 

--- a/docs/catalog/01-service-and-contract.md
+++ b/docs/catalog/01-service-and-contract.md
@@ -297,6 +297,15 @@ catalog 的**第三张脸**,也是「用户写面」的起点。教义一句话:
 - ⚠️ **明知的缺口(已在测试里钉住)**:平台自家控制台经 `/auth/login` 登录,其令牌**根本不带 `client_id` claim**(见 `utils.TokenClaims.ClientID`),因此 `AdminGate` 对**空** client id 放行。空 claim 只可能出自本 OP 自己的第一方会话流(即正被放行的那个面),缺口窄;但它只在这一点为真时才窄。待第一方会话流也有自己的注册 client(OIDC 标准化,docs/auth/03)后,应删掉该放行分支,改为像用户面 `UserGate` 一样 fail-closed。
 - **线上形状零变化**:三个 spec(`openapi.yaml` / `admin-openapi.yaml` / `public-openapi.yaml`)逐字节不变——封顶只改谁被拒,不改请求/响应形状。
 
+**行级压制字段 `<field>.suppressed`(wave R1a,2026-08-16 起在产)**:上游 importer 拥有的行不属于编辑面(编辑面只看 curated 车道),但人有时需要让某一行**不再出现在任何读面**。办法不是删它——下一轮导入会把它重新推回来——而是给它记一条负知识。
+
+- **形状**:凡支持此能力的字段 `F`,`getEditSchemaUser` 的 `fields[]` 里**多一个** key `F.suppressed`(`kind=list`、`diff_hint=items`),策略与 `F` 逐字相同(继承父字段的站点 overlay)。首个上线的是 `catalog.work.titles.suppressed`。
+- **值 = 严格升序、去重的字符串数组**(不是集合语义的任意顺序数组)。乱序或重复 → **422**。元素是**内容派生**的行身份键,标题的形状是 `title:<kind>:<lang>:<title>`(`kind` 是数字:0 official / 1 alias / 2 abbreviation)。之所以不用行 id:importer 删了重插同一行会换 id,压制会正好在它该生效的时候失效。
+- **悬空键合法**:只校格式,不校该行此刻是否存在——上游今天没推、明天推回来的行,压制照旧等在那里。
+- **被压制的行仍物理留在表里**(importer 仍拥有它),只是**不出任何读面**,标题搜索与 Meili 索引同规排除。父字段 `F` 的编辑快照**照旧包含**这些行(它是全量替换语义,过滤掉会导致下一次保存把它们物理删掉)。
+- 压制与解除各产一条 `entity_revision`,可 diff、可回滚、有归属,与普通编辑同一条审计通道。
+- ⚠️ **通用渲染的 UI 注意**:如果编辑器是「遍历 `fields[]` 逐个渲染」,`F.suppressed` 会作为一个裸字符串数组出现。它要么按压制 UI 渲染(在 `F` 的行旁边给一个「隐藏此行」),要么显式跳过 `.suppressed` 后缀——**不要**当普通文本数组交给用户手打。
+
 ### 4.3 认领生命周期(投稿 + 八动作 + 我的认领,wave 179)
 
 > ⚠️ **S2S 的两条认领写端点已在 wave 185 删除**:`submitCatalogWork`(`POST /api/v1/catalog/works/submit`)与 `actOnCatalogClaim`(`POST /api/v1/catalog/works/{id}/claim-actions/{action}`)不复存在(404/405,不是 410)。理由同 §4.2——断言式 actor 意味着「后端说是谁就是谁」,一个 BFF 的 bug 或凭据泄漏即可代任意用户投稿、撤回,乃至**裁决**别人的投稿。它们当初留着只为 **kun-galgame-patch(moyu)仍在实调**;moyu 迁 Bearer 之后,跨仓普查与 48 小时生产访问日志确认零调用方,故按 wave 181 的同一套办法删除。孪生即本节的 `submitCatalogWorkUser` / `actOnCatalogClaimUser`——两面**曾共用同一 service、同一状态机、同一 `catalog_claim_event` 账本**,只有身份的来路不同,故删除的是门,不是任何语义。


### PR DESCRIPTION
统一编辑引擎 v3「edit-everything」第四波(doc 21 §8)。前置 R0/R1a/R1b 已在产。

## 内容

**1. `catalog.character` 注册进引擎**(柱 5/6 的第二个消费者)
- 14 个标量,全部声明 `Provenance` → `catalog_character.field_provenance`
- `aliases`:curated 车道 list 字段 + `aliases.suppressed`(身份键 `alias:<kind>:<lang>:<name>`,纯文本零实体 id ⇒ 合并不会让压制过期);唯一索引不含 source,故 curated 撞上游同 `(name,lang)` 显式回 **422** 并指路 `.suppressed`,不静默丢弃
- `intros`:curated 车道,沿 work_intros 既例
- 新权限对 `edit.catalog.character[.review]`(docs/auth/04 §2.5 五步);kungal overlay `automerge=never`(与词表同档——角色被多部作品共享)
- 不注册:`instance_of` / 外部锚 / `extra`(身份归合并机器);暂缓:四个图列、trait links(表无车道列)

**盖戳换来两份免费保护**:`charattrs` 的 `decide()` 遇到不认识的 provenance 头就不写 ⇒ 人工戳后该 job 自动跳过,**job 一行没改**;survivorship 的 human 保护在 character 侧第一次真的能命中。各配一条钉死测试。

**2. 多语言简介折叠修复(线上活缺陷)**
`catalog_source` 里 curated = 12,**大于所有上游 importer**,而简介读面每 lang 只渲染一条 ⇒ 人工写的同 lang 简介保存成功、回读得到、永远不出面。`catalog.work.intros` 一直是注册在产的可编辑字段,所以这不是设计问题。修法:同 provenance 档内人工车道优先(`provenance` → 人工车道 → 其余)。`provenance` 仍在最前,机翻永远不会盖过原文。**生产 10 部作品的简介渲染文本会变——每一条都是「人保存过的文本终于开始出面」。**

**3. merge_rehang 补搬 character 的 `edit_suppressed_row`**(此前只有 work 分支有;character 合并已发生 33,717 次)。

## 验收

- 独立复验:build / vet 净,改动 24 文件 gofmt 净
- **519 顶层 PASS / 0 FAIL**(主批 358 + 闸 7 + handler 154);SKIP 全是 Meili / 专用 DSN 环境闸
- 三份 spec 重新生成后**逐字节相同** —— 新 entity_type 不新增路由,wire 零变化
- 17 条钉死测试逐条按名核过

## 部署

**本波无 migration**,不加表不加列(`edit_suppressed_row` R1a 已在产)。