### PR TITLE
fix(catalog): gate the human intro lane on provenance

### DIFF
--- a/apps/api/internal/platform/catalog/editspec/curated.go
+++ b/apps/api/internal/platform/catalog/editspec/curated.go
@@ -3,6 +3,8 @@ package editspec
 import (
 	"fmt"
 	"strings"
+
+	catmodel "api/internal/platform/catalog/model"
 )
 
 const curatedSourceID int16 = 12
@@ -22,22 +24,34 @@ func HumanSourceIDs() []int16 { return []int16{userSourceID, curatedSourceID} }
 // editor saved it, read it back, and it never rendered (6 live work rows in
 // 2026-08).
 //
-// It goes AFTER `provenance`, never before it. Every intro the editing engine
-// writes is provenance=0 (IntroProvenanceSource, no exception), so ranking
-// provenance first costs the human lane nothing — it still wins its own tier.
-// Putting this term first instead makes a MACHINE-TRANSLATED curated row beat an
-// upstream ORIGINAL one, which inverts the separate and correct "source outranks
-// machine" axis. The bug was human text hidden by upstream human text; it was
-// never "curated wins everything".
+// The `provenance = 0` gate is the whole point, and it was nearly shipped
+// without: the term applies ONLY inside the source tier, so it can never elect a
+// machine row. Two mistakes were made here in a row.
 //
-// Inside the machine tier the term still applies, and that is deliberate: a
-// curated provenance=1 row is the translation OF the curated original this same
-// fold just picked for its own language, so preferring it keeps the languages
-// telling one story instead of pairing our ja original with a translation of the
-// ja text we rejected. That is also why it precedes the character fold's
-// derived-extraction exception, which ranks machine rows among themselves.
-func HumanLaneFirstSQL(sourceColumn string) string {
-	return fmt.Sprintf("(%s IN (%d, %d)) DESC", sourceColumn, userSourceID, curatedSourceID)
+//  1. Placing the term before `provenance` let a MACHINE-TRANSLATED curated row
+//     beat an upstream ORIGINAL, inverting the separate and correct "source
+//     outranks machine" axis. The bug was human text hidden by upstream human
+//     text; it was never "curated wins everything".
+//  2. Moving it after `provenance` fixed that but still let it decide INSIDE the
+//     machine tier, on the argument that a curated translation belongs with the
+//     curated original it was made from. Production said otherwise. Across the
+//     5,806 works it would have moved, the curated lane holds en/prov0 5,805,
+//     zh-Hans/prov1 5,806, ja/prov0 2 — the zh-Hans machine row is translated
+//     from our `en` row, while 5,804 of those works render bangumi's Japanese
+//     ORIGINAL on the ja face either way. Preferring ours would have paired a
+//     Japanese original with a translation of a different English text: EN→ZH
+//     instead of JA→ZH, and usually a translation of a translation. THE LOCAL
+//     SNAPSHOT SHOWS 4 OF THE 5,806 — this one cannot be judged on a dev copy.
+//
+// The gate also hands the machine tier back to its own rule: `derived` (source
+// 18) is again the only preference among machine rows, per the wave-178 panel.
+//
+// Kept syntactically after `provenance` so the ordering reads tier-then-lane;
+// with the gate the two positions are equivalent.
+func HumanLaneFirstSQL(sourceColumn, provenanceColumn string) string {
+	return fmt.Sprintf("(%s IN (%d, %d) AND %s = %d) DESC",
+		sourceColumn, userSourceID, curatedSourceID,
+		provenanceColumn, catmodel.IntroProvenanceSource)
 }
 
 const (

--- a/apps/api/internal/platform/catalog/service/character_edit_lane_test.go
+++ b/apps/api/internal/platform/catalog/service/character_edit_lane_test.go
@@ -222,3 +222,69 @@ func TestCuratedMachineTranslationDoesNotBeatAnUpstreamOriginal(t *testing.T) {
 	assert.Equal(t, "上流の原文", pub.Intros[0].Intro)
 	assert.Equal(t, "bangumi", pub.Intros[0].Source)
 }
+
+// The machine tier is not the human lane's to decide. This shipped-by-a-hair
+// case is two translations of the same language: preferring ours moved 5,806
+// production works onto a machine translation of our `en` row while their ja
+// face kept rendering bangumi's Japanese original — two languages, two different
+// source materials. The dev snapshot shows 4 such works, so only production
+// could tell.
+func TestCuratedMachineTranslationDoesNotBeatAnUpstreamMachineTranslation(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+	read := NewReadService(testDB)
+	public := NewPublicService(testDB, read, testResolve, "")
+
+	const bangumiSourceID, curatedSourceID = 3, 12
+
+	w := createWork(t, "作品")
+	require.NoError(t, testDB.Create(&[]model.CatalogWorkIntro{
+		{WorkID: w.ID, Lang: "zh-Hans", Intro: "上流の機械翻訳", SourceID: bangumiSourceID, Provenance: model.IntroProvenanceMachine},
+		{WorkID: w.ID, Lang: "zh-Hans", Intro: "curated 車道の機械翻訳", SourceID: curatedSourceID, Provenance: model.IntroProvenanceMachine},
+	}).Error)
+
+	intros := map[int64][]WorkIntroRow{}
+	require.NoError(t, read.nativeWorkIntros(ctx, []int64{w.ID}, intros))
+	require.Len(t, intros[w.ID], 1)
+	assert.Equal(t, "上流の機械翻訳", intros[w.ID][0].Intro)
+	assert.EqualValues(t, bangumiSourceID, intros[w.ID][0].SourceID)
+
+	ch := createCharacter(t, "キャラ")
+	require.NoError(t, testDB.Create(&[]model.CatalogCharacterIntro{
+		{CharacterID: ch.ID, Lang: "zh-Hans", Intro: "上流の機械翻訳", SourceID: bangumiSourceID, Provenance: model.IntroProvenanceMachine},
+		{CharacterID: ch.ID, Lang: "zh-Hans", Intro: "curated 車道の機械翻訳", SourceID: curatedSourceID, Provenance: model.IntroProvenanceMachine},
+	}).Error)
+
+	detail, err := read.CharacterByID(ctx, ch.ID, model.SpoilerSevere)
+	require.NoError(t, err)
+	require.Len(t, detail.Intros, 1)
+	assert.Equal(t, "上流の機械翻訳", detail.Intros[0].Intro)
+
+	pub, ok, err := public.Character(ctx, ch.ID, false, true, model.SpoilerSevere, 10, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, pub.Intros, 1)
+	assert.Equal(t, "bangumi", pub.Intros[0].Source)
+}
+
+// With the human lane gated to provenance=0 the machine tier is ranked by the
+// wave-178 rule alone: a derived extraction (source 18) outranks a translation,
+// including one in the curated lane.
+func TestDerivedStillWinsTheMachineTierOverTheCuratedLane(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+	read := NewReadService(testDB)
+
+	const curatedSourceID = 12
+
+	ch := createCharacter(t, "キャラ")
+	require.NoError(t, testDB.Create(&[]model.CatalogCharacterIntro{
+		{CharacterID: ch.ID, Lang: "zh-Hans", Intro: "curated 車道の機械翻訳", SourceID: curatedSourceID, Provenance: model.IntroProvenanceMachine},
+		{CharacterID: ch.ID, Lang: "zh-Hans", Intro: "derived 抽出", SourceID: sourceDerived, Provenance: model.IntroProvenanceMachine},
+	}).Error)
+
+	detail, err := read.CharacterByID(ctx, ch.ID, model.SpoilerSevere)
+	require.NoError(t, err)
+	require.Len(t, detail.Intros, 1)
+	assert.Equal(t, "derived 抽出", detail.Intros[0].Intro)
+}

--- a/apps/api/internal/platform/catalog/service/public_service.go
+++ b/apps/api/internal/platform/catalog/service/public_service.go
@@ -1303,7 +1303,7 @@ func (s *PublicService) characterIntros(ctx context.Context, characterID int64) 
 	}
 	if err := s.db.WithContext(ctx).Raw(`SELECT lang, intro, source_id, provenance
 		FROM catalog_character_intro WHERE character_id = ?
-		ORDER BY lang, provenance, `+editspec.HumanLaneFirstSQL("source_id")+
+		ORDER BY lang, provenance, `+editspec.HumanLaneFirstSQL("source_id", "provenance")+
 		`, (provenance = 1 AND source_id = ?) DESC, source_id`,
 		characterID, sourceDerived).Scan(&rows).Error; err != nil {
 		return nil, err

--- a/apps/api/internal/platform/catalog/service/read_service.go
+++ b/apps/api/internal/platform/catalog/service/read_service.go
@@ -404,7 +404,7 @@ func (s *ReadService) nativeWorkIntros(ctx context.Context, workIDs []int64, out
 	}
 	if err := db.Raw(`SELECT work_id, lang, intro, source_id, provenance FROM catalog_work_intro
 		WHERE work_id IN ? ORDER BY work_id, lang, provenance, `+
-		editspec.HumanLaneFirstSQL("source_id")+`, source_id`, workIDs).Scan(&rows).Error; err != nil {
+		editspec.HumanLaneFirstSQL("source_id", "provenance")+`, source_id`, workIDs).Scan(&rows).Error; err != nil {
 		return err
 	}
 	seen := make(map[int64]map[string]bool)
@@ -1078,7 +1078,7 @@ func (s *ReadService) CharacterByID(ctx context.Context, characterID int64, maxS
 	}
 	if err := db.Raw(`SELECT lang, intro, source_id, provenance FROM catalog_character_intro
 		WHERE character_id = ? ORDER BY lang, provenance, `+
-		editspec.HumanLaneFirstSQL("source_id")+`,
+		editspec.HumanLaneFirstSQL("source_id", "provenance")+`,
 		(provenance = 1 AND source_id = ?) DESC, source_id`, characterID, sourceDerived).Scan(&introRows).Error; err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
PR #24 之上的修正,**上线前拦下**(生产仍跑旧镜像,未部署过 #24 的版本)。

## 问题

R2a 修的活缺陷是「人工写的简介被同 lang 上游**人写**的简介遮住」。修法是给每 lang 折叠加一个人工车道优先项,但这一项**没有限制在 source 档内**,于是它也会在机器档里做决定:curated 的机翻会压过上游的机翻。

生产实测这一项的真实半径:

| 形态 | 受影响 work 行 |
|---|---|
| 无闸(#24 合入的版本) | **5,812** |
| **加闸(本 PR)** | **6** |

那 5,806 行的构成是决定性的:这些作品的 curated 车道装的是 **`en` 源行(5,805)+ zh-Hans 机翻(5,806)**,`ja` 源行只有 2 条。也就是说改完之后 ja 面 99.97% 仍渲染 bangumi 的**日文原文**,而 zh-Hans 面会切成 curated **英文**的机翻——两个语种讲两份材料,而且 EN→ZH 多半是译文的译文。

**本机快照上这 5,806 行只表现为 4 行**,这个判断在 dev 副本上做不出来。

## 修法

人工车道项加 `AND provenance = 0` 闸(常量取 `catmodel.IntroProvenanceSource`,与写入侧同一处),位置不动。剩下的 6 行正是缺陷本体(ja,`3/0`→`12/0` 四条,`4/0`→`12/0` 两条)。

连带:闸让人工车道项在机器档恒 false,`derived`(source 18)重新成为机器档唯一的排序偏好,与 wave-178 panel 一致。

## 钉死

- `TestCuratedMachineTranslationDoesNotBeatAnUpstreamMachineTranslation`(新)——差点上线的那个东西
- `TestDerivedStillWinsTheMachineTierOverTheCuratedLane`(新)
- 摘掉闸实测两条同时变红,还原后绿

验收亲证:build/vet/gofmt 净,editspec+service **249 顶层 PASS / 0 FAIL**,三份 spec 逐字节相同,生产复算 6 行(与验收者独立量得一致)。