### PR TITLE
fix(catalog): give the remaining three intro folds the human lane

### DIFF
--- a/apps/api/cmd/reindex-catalog/main.go
+++ b/apps/api/cmd/reindex-catalog/main.go
@@ -399,7 +399,9 @@ func loadWorkIntros(db *gorm.DB) (map[int64][]workIntro, error) {
 	if err := db.Raw(`SELECT i.work_id, i.lang, i.intro
 		FROM catalog_work_intro i JOIN catalog_work w ON w.id = i.work_id
 		WHERE ` + population + `
-		ORDER BY i.work_id, i.lang, i.provenance, i.source_id, i.id`).Scan(&native).Error; err != nil {
+		ORDER BY i.work_id, i.lang, i.provenance, ` +
+		editspec.HumanLaneFirstSQL("i.source_id", "i.provenance") +
+		`, i.source_id, i.id`).Scan(&native).Error; err != nil {
 		return nil, err
 	}
 	seen := map[int64]map[string]bool{}

--- a/apps/api/cmd/reindex-catalog/works_intros_test.go
+++ b/apps/api/cmd/reindex-catalog/works_intros_test.go
@@ -94,3 +94,55 @@ func TestLoadWorkIntrosUsesCatalogRowsForEveryWork(t *testing.T) {
 		t.Fatalf("a non-LIVE work contributed intros: %v", got)
 	}
 }
+
+// The search index folds one row per language with its own copy of the ordering,
+// so the human lane has to be spelled out here too. It was not, and for one wave
+// the detail face rendered the curated ja intro while the index still held
+// bangumi's — one field, two consumers, two answers (6 live works).
+func TestLoadWorkIntrosGivesTheSearchIndexTheHumanLane(t *testing.T) {
+	truncateFacetTables(t)
+
+	const (
+		bangumiSource = 3
+		curatedSource = 12
+	)
+
+	contested := mkWork(t, "contested-intro", model.WorkStatusLive, galgameMedium)
+	for _, r := range []struct {
+		lang, intro string
+		source      int16
+		provenance  int16
+	}{
+		{"ja", "上流の紹介", bangumiSource, 0},
+		{"ja", "人手の紹介", curatedSource, 0},
+	} {
+		if err := facetTestDB.Exec(`INSERT INTO catalog_work_intro (work_id, lang, intro, source_id, provenance)
+			VALUES (?, ?, ?, ?, ?)`, contested, r.lang, r.intro, r.source, r.provenance).Error; err != nil {
+			t.Fatalf("seed contested intro: %v", err)
+		}
+	}
+	if got := introsOf(t, contested)["ja"]; got != "人手の紹介" {
+		t.Fatalf("indexed ja intro = %q, want the curated row — the index must agree with the detail face", got)
+	}
+
+	// And no further: inside the machine tier the human lane decides nothing,
+	// or 5,806 works would be indexed under a translation of our `en` row while
+	// their ja face keeps rendering bangumi's Japanese original.
+	machine := mkWork(t, "machine-tier-intro", model.WorkStatusLive, galgameMedium)
+	for _, r := range []struct {
+		lang, intro string
+		source      int16
+		provenance  int16
+	}{
+		{"zh-Hans", "上流の機械翻訳", bangumiSource, 1},
+		{"zh-Hans", "curated 車道の機械翻訳", curatedSource, 1},
+	} {
+		if err := facetTestDB.Exec(`INSERT INTO catalog_work_intro (work_id, lang, intro, source_id, provenance)
+			VALUES (?, ?, ?, ?, ?)`, machine, r.lang, r.intro, r.source, r.provenance).Error; err != nil {
+			t.Fatalf("seed machine-tier intro: %v", err)
+		}
+	}
+	if got := introsOf(t, machine)["zh-Hans"]; got != "上流の機械翻訳" {
+		t.Fatalf("indexed zh-Hans intro = %q, want the upstream machine row", got)
+	}
+}

--- a/apps/api/internal/platform/catalog/editspec/curated.go
+++ b/apps/api/internal/platform/catalog/editspec/curated.go
@@ -54,6 +54,18 @@ func HumanLaneFirstSQL(sourceColumn, provenanceColumn string) string {
 		provenanceColumn, catmodel.IntroProvenanceSource)
 }
 
+// HumanLaneFirstNoProvenanceSQL is HumanLaneFirstSQL for the two intro tables
+// that never grew the 0/1 provenance axis (catalog_tag_intro,
+// catalog_series_intro): every row there is a source row, so the gate has
+// nothing to gate. Using it on a table that HAS the column would resurrect the
+// 5,806-row mistake documented above.
+//
+// The missing column is not an oversight to backfill: neither table has a
+// machine writer today, and R1b's rule is that the axis follows the first one.
+func HumanLaneFirstNoProvenanceSQL(sourceColumn string) string {
+	return fmt.Sprintf("(%s IN (%d, %d)) DESC", sourceColumn, userSourceID, curatedSourceID)
+}
+
 const (
 	maxListElements = 200
 	maxHashRunes    = 128

--- a/apps/api/internal/platform/catalog/service/public_service.go
+++ b/apps/api/internal/platform/catalog/service/public_service.go
@@ -796,7 +796,9 @@ func (s *PublicService) labelIntros(ctx context.Context, labelID int64) ([]dto.P
 	if err := s.db.WithContext(ctx).Raw(`
 		SELECT i.lang, i.intro, src.key AS source, i.provenance
 		FROM catalog_label_intro i JOIN catalog_source src ON src.id = i.source_id
-		WHERE i.label_id = ? ORDER BY i.lang, i.provenance, i.source_id`, labelID).Scan(&rows).Error; err != nil {
+		WHERE i.label_id = ? ORDER BY i.lang, i.provenance, `+
+		editspec.HumanLaneFirstSQL("i.source_id", "i.provenance")+
+		`, i.source_id`, labelID).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	out := make([]dto.PublicLabelIntro, 0, len(rows))

--- a/apps/api/internal/platform/catalog/service/public_tags.go
+++ b/apps/api/internal/platform/catalog/service/public_tags.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"api/internal/platform/catalog/dto"
+	"api/internal/platform/catalog/editspec"
 	"api/internal/platform/catalog/model"
 )
 
@@ -80,7 +81,9 @@ func (s *PublicService) tagIntros(ctx context.Context, tagID int64) ([]dto.Publi
 	}
 	if err := s.db.WithContext(ctx).Raw(`
 		SELECT lang, intro, source_id FROM catalog_tag_intro
-		WHERE tag_id = ? ORDER BY lang, source_id`, tagID).Scan(&rows).Error; err != nil {
+		WHERE tag_id = ? ORDER BY lang, `+
+		editspec.HumanLaneFirstNoProvenanceSQL("source_id")+
+		`, source_id`, tagID).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	out := make([]dto.PublicTagIntro, 0, len(rows))

--- a/apps/api/internal/platform/catalog/service/public_taxonomy_test.go
+++ b/apps/api/internal/platform/catalog/service/public_taxonomy_test.go
@@ -347,13 +347,17 @@ func TestTagDetailIntrosAlwaysPresent(t *testing.T) {
 		t.Fatalf("intros must be an empty slice (serialized []), got %#v", rec.Intros)
 	}
 
-	const srcWiki int16 = 12
+	// Both contenders must be UPSTREAM ids. This used to seed source 12 as
+	// "another source" — it is the curated lane, and the day the human lane
+	// started winning its language the case stopped being about source_id order
+	// at all. TestTagIntroHumanLaneWinsTheLangFold owns that direction now.
+	const srcGetchu int16 = 17
 	for _, in := range []struct {
 		lang, body string
 		src        int16
 	}{
 		{"zh-Hans", "低位来源胜出", srcErogamescape},
-		{"zh-Hans", "另一来源", srcWiki},
+		{"zh-Hans", "另一来源", srcGetchu},
 		{"ja", "日本語", srcVNDB},
 	} {
 		if err := testDB.Create(&model.CatalogTagIntro{

--- a/apps/api/internal/platform/catalog/service/taxonomy_intro_lane_test.go
+++ b/apps/api/internal/platform/catalog/service/taxonomy_intro_lane_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"testing"
+
+	"api/internal/platform/catalog/model"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	bangumiIntroSource = 3
+	curatedIntroSource = 12
+)
+
+// catalog.label.intros is a registered curated lane, and its public face folds
+// one row per language exactly like the work and character faces did — the same
+// defect, found by the completeness sweep rather than by anyone hitting it.
+func TestLabelIntroHumanLaneWinsTheLangFold(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+	svc := newPublicSvc()
+
+	label := createLabel(t, "ブランド", model.LabelKindGameBrand)
+	require.NoError(t, testDB.Create(&[]model.CatalogLabelIntro{
+		{LabelID: label, Lang: "ja", Intro: "上流の紹介", SourceID: bangumiIntroSource, Provenance: model.IntroProvenanceSource},
+		{LabelID: label, Lang: "ja", Intro: "人手の紹介", SourceID: curatedIntroSource, Provenance: model.IntroProvenanceSource},
+	}).Error)
+
+	rec, ok, err := svc.Label(ctx, label, false, true, 10, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, rec.Intros, 1)
+	assert.Equal(t, "人手の紹介", rec.Intros[0].Intro)
+	assert.Equal(t, "curated", rec.Intros[0].Source)
+}
+
+// And no further: catalog_label_intro carries the 0/1 axis, so the machine tier
+// must stay the importers' — the human lane decides only inside provenance=0.
+func TestLabelIntroCuratedMachineRowDoesNotBeatUpstream(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+	svc := newPublicSvc()
+
+	label := createLabel(t, "ブランド", model.LabelKindGameBrand)
+	require.NoError(t, testDB.Create(&[]model.CatalogLabelIntro{
+		{LabelID: label, Lang: "zh-Hans", Intro: "上流の原文", SourceID: bangumiIntroSource, Provenance: model.IntroProvenanceSource},
+		{LabelID: label, Lang: "zh-Hans", Intro: "curated 車道の機械翻訳", SourceID: curatedIntroSource, Provenance: model.IntroProvenanceMachine},
+	}).Error)
+
+	rec, ok, err := svc.Label(ctx, label, false, true, 10, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, rec.Intros, 1)
+	assert.Equal(t, "上流の原文", rec.Intros[0].Intro)
+	assert.False(t, rec.Intros[0].Machine)
+
+	// Two machine rows: the human lane still decides nothing.
+	require.NoError(t, testDB.Exec(
+		`UPDATE catalog_label_intro SET provenance = ? WHERE label_id = ? AND source_id = ?`,
+		model.IntroProvenanceMachine, label, bangumiIntroSource).Error)
+	rec, ok, err = svc.Label(ctx, label, false, true, 10, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, rec.Intros, 1)
+	assert.Equal(t, "上流の原文", rec.Intros[0].Intro)
+}
+
+// catalog_tag_intro has NO provenance column, so this face has no machine tier
+// to protect and only the positive direction can be pinned. The ordering term is
+// HumanLaneFirstNoProvenanceSQL for exactly that reason.
+func TestTagIntroHumanLaneWinsTheLangFold(t *testing.T) {
+	cleanTables(t)
+	cleanTagTables(t)
+	ctx := t.Context()
+	svc := newPublicSvc()
+
+	tag := model.CatalogTag{Name: "純愛", Tier: model.TagTierCore, Kind: model.TagKindContent}
+	require.NoError(t, testDB.Create(&tag).Error)
+	require.NoError(t, testDB.Create(&[]model.CatalogTagIntro{
+		{TagID: tag.ID, Lang: "zh-Hans", Intro: "上游的说明", SourceID: bangumiIntroSource},
+		{TagID: tag.ID, Lang: "zh-Hans", Intro: "人工的说明", SourceID: curatedIntroSource},
+	}).Error)
+
+	rec, ok, err := svc.TagDetail(ctx, tag.ID, false, true, 10, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, rec.Intros, 1)
+	assert.Equal(t, "人工的说明", rec.Intros[0].Intro)
+	assert.Equal(t, "curated", rec.Intros[0].Source)
+}


### PR DESCRIPTION
PR #25 的完备性收尾。**六处**读路径在做「简介每 lang 只留一条」的折叠,#24/#25 只教会了其中三处。

| # | 位置 | 状态 |
|---|---|---|
| 1 | `read_service.go` work 详情 | #24/#25 已修 |
| 2 | `read_service.go` character 详情 | 已修 |
| 3 | `public_service.go` character public | 已修 |
| **4** | `cmd/reindex-catalog` work→Meili | **本 PR** |
| **5** | `public_service.go` label public | **本 PR** |
| **6** | `public_tags.go` tag public | **本 PR** |
| — | `public_series.go` series | **根本不折叠**(每 lang 全量输出),不属本缺陷类,归后续波 |

**为什么不留到 R1c**:这不是新撞点,是同一缺陷的剩余实例。留着的代价是 doc 21 与代码注释会宣称「折叠缺陷已修」而六处里有三处还坏着,下一个人得把 5,806 行那整套分析重推一遍才敢动。

## 生产影响面(只读复算)

- **#4 Meili:6 行**,与详情面**同一批 work_id** —— 不修的话搜索索引会继续给 bangumi 的日文,而详情页已经换成 curated 的,同一字段两个消费者说两句话
- **#5 label / #6 tag:各 0 行** —— curated 行是有的(label 6 / tag 21),只是每条在自己那个 lang 里还没有对手。**0 就是结论**:纯结构性修复,今天没有任何用户看到的东西会变

## `catalog_tag_intro` / `catalog_series_intro` 没有 provenance 列

故给它们单独一个 `HumanLaneFirstNoProvenanceSQL`,而不是给原函数加可空参数——**每一行都是 source 行,闸没有东西可闸**;注释里写明「用在**有**该列的表上会复活 5,806 行那个错误」。补列不做:两张表今日零机器写入方,按 R1b 的规矩,轴跟着第一个机器写入方走。

## 一条既有测试更正(报备)

`TestTagDetailIntrosAlwaysPresent` 原本用 `const srcWiki int16 = 12` 当「另一个上游来源」和 erogamescape(5)对打——**12 就是 curated 车道**(常量名还留着 wave 161 前的旧词),于是这条断言恰好把缺陷本身钉成了契约,是本波唯一一条会红的既有测试。两个竞争者现在都是上游 id(改用 getchu 17),"小 source_id 赢" 与 "渲染公开 source key" 两条断言原样保留;curated 方向由新的 `TestTagIntroHumanLaneWinsTheLangFold` 拥有。**没有削弱断言,只是把两条规则拆到各自的测试里。**

## 验收

build/vet/gofmt 净;**508 顶层 PASS / 0 FAIL**(闸 8 + 主批 346 + handler 154),三份 spec 逐字节相同;五条相关钉死按名核过;三处新钉摘掉对应排序词即变红。**本波无 migration。**

⚠️ #4 是**索引构建输入**的修改,部署不改变 Meili 现有内容,要等 `reindex-catalog` 跑过(日常 06:10 cron)那 6 条才在搜索里对齐。