### PR TITLE
fix(dev-snapshot): the news database was never in the snapshot pipeline

### DIFF
--- a/scripts/dev-snapshot/config.sh
+++ b/scripts/dev-snapshot/config.sh
@@ -37,6 +37,7 @@ CORE_DBS=(
   kun_catalog
   kun_images
   kun_artifacts
+  kun_news
 )
 
 # Of the core DBs, these carry a scrub SQL file (scrub/<db>.sql) and are built
@@ -48,6 +49,7 @@ SCRUB_DBS=(
   kungalgame_patch
   kun_community
   kun_images
+  kun_news
 )
 
 # sources = raw public scrape data (zero PII, zero desensitisation, no artifact).

--- a/scripts/dev-snapshot/scrub/kun_news.sql
+++ b/scripts/dev-snapshot/scrub/kun_news.sql
@@ -1,0 +1,16 @@
+-- kun_news scrub — server-side scratch DB only.
+-- The news corpus itself is upstream public reporting and stays verbatim; the
+-- only operator-authored free text is the moderation reason, which gets the
+-- same fidelity downgrade as kun_community's flag notes (裁定 1b).
+--
+-- Expected psql variables: marker  (e.g. -v marker="[dev-scrubbed]")
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+UPDATE news_moderation_decision
+  SET reason = :'marker' || ' synthetic moderation reason.'
+  WHERE reason <> '';
+
+COMMIT;

--- a/scripts/refresh-dev-db.sh
+++ b/scripts/refresh-dev-db.sh
@@ -127,6 +127,8 @@ run_assertions() {
       content_col_synthetic kun_community community_flag note ;;
     kun_images)
       assert_zero "first_uploader_ip cleared" kun_images "SELECT count(*) FROM images WHERE first_uploader_ip IS NOT NULL AND first_uploader_ip <> ''" ;;
+    kun_news)
+      content_col_synthetic kun_news news_moderation_decision reason ;;
     *) echo "   (no PII assertions defined for $db — passthrough)" ;;
   esac
 }


### PR DESCRIPTION
`kun_news` has been live on prod since early August carrying 4,448 news items and 4,434 moderation decisions. Dev never saw any of it: `CORE_DBS` was never extended, so every `refresh-dev-db.sh` run silently skipped the database and the only thing dev had was the empty schema shell `migrate news` leaves behind.

A missing database produces no row count, and a missing row count reads exactly like a quiet domain — which is why this survived a month and several "row counts match prod" refreshes. The counts that matched were the ones the pipeline already knew to compare.

## What changes

- `kun_news` joins `CORE_DBS` so the snapshot builds and restores it.
- It also joins `SCRUB_DBS`: the news corpus is upstream public reporting and passes through verbatim, but `news_moderation_decision.reason` is operator-authored free text, so it gets the same fidelity downgrade `kun_community`'s flag notes already get.
- Matching assertion in `run_assertions`, so the pipeline keeps proving the scrub happened rather than assuming it.

## Verification

Built and restored end to end against artifact `20260816-2347`:

- lane builds (`>> building kun_news`, 1.4M dump)
- assertion passes (`ok [kun_news] news_moderation_decision.reason all synthetic`)
- restored dev database matches prod row for row: `news_item` 4,448 / `news_moderation_decision` 4,434 / `news_source` 2 / `news_item_work` 0
- all 8 core databases restored, 21 assertions green, 0 failures