### PR TITLE
fix(web): the client editor and the consent screen share one scope registry

### DIFF
--- a/apps/web/app/components/oauth/authorize/Container.vue
+++ b/apps/web/app/components/oauth/authorize/Container.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { needsStepUp } from '~/constants/roles'
+import { SCOPE_LABELS } from '~~/shared/types/oauth-client'
 
 interface ClientPublicInfo {
   id: string
@@ -60,15 +61,6 @@ const scopeList = computed(() => {
   if (!scope.value) return []
   return scope.value.split(/[\s+]/).filter(Boolean)
 })
-
-const scopeLabels: Record<string, string> = {
-  openid: '身份标识',
-  profile: '用户资料 (昵称、头像)',
-  email: '邮箱地址',
-  'playtime:read': '读取你的游戏时长记录',
-  'playtime:write': '记录你的游戏时长',
-  'catalog:edit': '以你的名义提交目录条目的编辑提案',
-}
 
 const respondWithError = async (errCode: string): Promise<void> => {
   const res = await api.post<{ redirect_url: string }>(
@@ -376,7 +368,7 @@ const handleDeny = async () => {
             class="text-default-500 flex items-center gap-2 text-sm"
           >
             <KunIcon name="lucide:check" class="text-success size-4 shrink-0" />
-            {{ scopeLabels[s] || s }}
+            {{ SCOPE_LABELS[s] || s }}
           </li>
           <li
             v-if="scopeList.length === 0"

--- a/apps/web/shared/types/oauth-client.ts
+++ b/apps/web/shared/types/oauth-client.ts
@@ -50,12 +50,21 @@ export interface EcosystemApp {
 
 export const ALL_GRANTS = ['authorization_code', 'refresh_token'] as const
 
-export const KNOWN_SCOPES = [
-  'openid',
-  'profile',
-  'email',
-  'image:upload',
-  'artifact:upload',
-] as const
+// The client editor's checkboxes and the consent screen's wording are the same
+// registry. When they were two lists, playtime:read/playtime:write existed only
+// in the consent one, so the forum client could not be granted them from the
+// console at all: /oauth/authorize answered 15006 and the feature stayed dark.
+export const SCOPE_LABELS: Record<string, string> = {
+  openid: '身份标识',
+  profile: '用户资料 (昵称、头像)',
+  email: '邮箱地址',
+  'playtime:read': '读取你的游戏时长记录',
+  'playtime:write': '记录你的游戏时长',
+  'catalog:edit': '以你的名义提交目录条目的编辑提案',
+  'image:upload': '以你的名义上传图片',
+  'artifact:upload': '以你的名义上传文件',
+}
+
+export const KNOWN_SCOPES: readonly string[] = Object.keys(SCOPE_LABELS)
 
 export const REN_ONLY_SCOPES: readonly string[] = ['image:upload', 'artifact:upload']


### PR DESCRIPTION
The admin console's scope checkboxes (`KNOWN_SCOPES`) and the consent screen's label map were two separate lists. Only the consent-screen map knew about `playtime:read`, `playtime:write` and `catalog:edit`, so those scopes had no checkbox in the client editor and could not be granted from the console — `/oauth/authorize` then answered `15006` for a client that legitimately needed them.

`KNOWN_SCOPES` now derives from the shared `SCOPE_LABELS` map, so the two faces are one registry by construction: adding a scope to the label map gives it a checkbox automatically, and the two lists cannot drift apart again.

Touches only `apps/web/` (`shared/types/oauth-client.ts`, `app/components/oauth/authorize/Container.vue`). No API change, no schema change, no migration.
