### PR TITLE
feat(catalog): anchor romaji character names in the en intro-mt lane glossary

### DIFF
--- a/apps/api/internal/jobs/intromt/glossary.go
+++ b/apps/api/internal/jobs/intromt/glossary.go
@@ -102,6 +102,41 @@ var (
 		FROM ros JOIN al ON al.character_id = ros.character_id
 		ORDER BY ros.work_id, ros.character_id`
 
+	// en-lane only. en source texts carry romaji, which the kanji roster keys never
+	// match — work 2775 shipped with "Azabu Masumi" untranslated because its only
+	// roster pair was the identity 麻布 真澄→麻布 真澄. The romaji lives in ASCII
+	// kind 0/1 aliases (both `latin` columns are empty in prod). Never wire this for
+	// SourceJa: it would drift every ja glossary hash and re-trigger the whole lane.
+	workRosterLatinQuery = `
+		WITH ros AS (
+			SELECT wc.work_id, wc.character_id
+			FROM catalog_work_character wc
+			JOIN catalog_character c ON c.id = wc.character_id AND c.deleted_at IS NULL
+			WHERE wc.work_id IN (?)
+			  AND ` + editspec.NotSuppressedRosterSQL("wc") + `
+		),
+		lat AS (
+			SELECT DISTINCT ON (a.character_id) a.character_id, a.name
+			FROM catalog_character_alias a
+			WHERE a.character_id IN (SELECT character_id FROM ros)
+			  AND a.name ~ '^[\x20-\x7e]+$' AND a.name ~ '[A-Za-z]' AND a.kind IN (0,1)
+			  AND ` + editspec.NotSuppressedCharacterAliasSQL("a") + `
+			ORDER BY a.character_id, (a.lang <> 'ja'), a.id
+		),
+		zhn AS (
+			SELECT DISTINCT ON (a.character_id) a.character_id, a.name
+			FROM catalog_character_alias a
+			WHERE a.character_id IN (SELECT character_id FROM ros)
+			  AND a.lang IN ('zh-Hans','zh','zh-Hant') AND a.kind IN (0,1)
+			  AND ` + editspec.NotSuppressedCharacterAliasSQL("a") + `
+			ORDER BY a.character_id, (NOT a.is_primary_for_locale), (a.lang <> 'zh-Hans'), a.id
+		)
+		SELECT ros.work_id AS owner_id, lat.name AS src, zhn.name AS zh
+		FROM ros
+		JOIN lat ON lat.character_id = ros.character_id
+		JOIN zhn ON zhn.character_id = ros.character_id
+		ORDER BY ros.work_id, ros.character_id`
+
 	workLabelQuery = `
 		WITH lab AS (
 			SELECT DISTINCT wl.work_id, wl.label_id, l.display_name
@@ -121,12 +156,12 @@ var (
 		ORDER BY lab.work_id, lab.label_id`
 )
 
-func attachGlossaries(ctx context.Context, db *gorm.DB, cands []candidate) error {
+func attachGlossaries(ctx context.Context, db *gorm.DB, cands []candidate, src SourceLang) error {
 	ids := make([]int64, 0, len(cands))
 	for _, c := range cands {
 		ids = append(ids, c.WorkID)
 	}
-	gs, err := loadGlossaries(ctx, db, ids)
+	gs, err := loadGlossaries(ctx, db, ids, src)
 	if err != nil {
 		return err
 	}
@@ -136,12 +171,16 @@ func attachGlossaries(ctx context.Context, db *gorm.DB, cands []candidate) error
 	return nil
 }
 
-func loadGlossaries(ctx context.Context, db *gorm.DB, workIDs []int64) (map[int64]Glossary, error) {
+func loadGlossaries(ctx context.Context, db *gorm.DB, workIDs []int64, src SourceLang) (map[int64]Glossary, error) {
+	queries := []string{workOwnTitleQuery, workRosterQuery, workLabelQuery}
+	if src == SourceEn {
+		queries = []string{workOwnTitleQuery, workRosterLatinQuery, workRosterQuery, workLabelQuery}
+	}
 	builders := make(map[int64]*glossaryBuilder, len(workIDs))
 	for _, id := range workIDs {
 		builders[id] = &glossaryBuilder{}
 	}
-	for _, q := range []string{workOwnTitleQuery, workRosterQuery, workLabelQuery} {
+	for _, q := range queries {
 		if err := collectGlossary(ctx, db, q, workIDs, builders); err != nil {
 			return nil, err
 		}

--- a/apps/api/internal/jobs/intromt/glossary_test.go
+++ b/apps/api/internal/jobs/intromt/glossary_test.go
@@ -142,7 +142,7 @@ func TestLoadGlossaries(t *testing.T) {
 	bare := mkWork(t, medium, "no-glossary-work", nil)
 	mkTitle(t, bare, "ja", "何もない作品", model.WorkTitleKindOfficial)
 
-	gs, err := loadGlossaries(ctx, testDB, []int64{w, bare})
+	gs, err := loadGlossaries(ctx, testDB, []int64{w, bare}, SourceJa)
 	require.NoError(t, err)
 
 	assert.Equal(t, Glossary{
@@ -153,9 +153,37 @@ func TestLoadGlossaries(t *testing.T) {
 	}, gs[w], "own title, then roster characters by id, then labels")
 	assert.NotContains(t, gs, bare, "a work with no Chinese anywhere gets no glossary")
 
-	again, err := loadGlossaries(ctx, testDB, []int64{w, bare})
+	again, err := loadGlossaries(ctx, testDB, []int64{w, bare}, SourceJa)
 	require.NoError(t, err)
 	assert.Equal(t, gs[w].Canonical(), again[w].Canonical())
+}
+
+func mkCharAlias(t *testing.T, cid int64, name, lang string, kind int16) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&model.CatalogCharacterAlias{
+		CharacterID: cid, Name: name, Lang: lang, Kind: kind,
+	}).Error)
+}
+
+func TestLoadGlossariesEnLatinKeys(t *testing.T) {
+	clean(t)
+	cleanEntities(t)
+	ctx := context.Background()
+	medium, _, _ := reg(t)
+
+	w := mkWork(t, medium, "latin-work", nil)
+	cid := mkRosterCharacter(t, w, "麻布 真澄", "麻布 真澄")
+	mkCharAlias(t, cid, "Azabu Masumi", "ja", model.AliasKindSpellingVariant)
+
+	ja, err := loadGlossaries(ctx, testDB, []int64{w}, SourceJa)
+	require.NoError(t, err)
+	assert.NotContains(t, ja, w,
+		"ja lane must not gain latin keys: the identity kanji pair stays dropped, and ja hashes must not drift")
+
+	en, err := loadGlossaries(ctx, testDB, []int64{w}, SourceEn)
+	require.NoError(t, err)
+	assert.Equal(t, Glossary{{Src: "Azabu Masumi", Zh: "麻布 真澄"}}, en[w],
+		"en lane anchors the romaji spelling to the zh name")
 }
 
 func TestGlossaryReachesPromptAndHash(t *testing.T) {

--- a/apps/api/internal/jobs/intromt/intromt.go
+++ b/apps/api/internal/jobs/intromt/intromt.go
@@ -78,7 +78,7 @@ func Run(ctx context.Context, tr Translator, opts Opts) (*Stats, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load candidates: %w", err)
 	}
-	if err := attachGlossaries(ctx, db, cands); err != nil {
+	if err := attachGlossaries(ctx, db, cands, src); err != nil {
 		return nil, fmt.Errorf("load glossaries: %w", err)
 	}
 	withGloss := 0


### PR DESCRIPTION
W213 close-out fix. The en intro-mt lane's roster glossary keyed on kanji display names, which never appear in en source texts — romaji character names shipped untranslated (user-flagged example: work 2775 kept "Azabu Masumi"), and identity kanji pairs (麻布 真澄→麻布 真澄) were dropped as useless, leaving the glossary empty so the stale v1 row stayed hash-skipped forever.

- Add `workRosterLatinQuery`: latin→zh pairs from ASCII kind 0/1 character aliases (both `latin` columns are empty in prod; romaji lives in kind=1/lang=ja aliases, 124k rows).
- Wired for `SourceEn` only — ja glossary hashes must not drift, or the whole ja lane (17.5k works) would re-queue.
- The en-lane hash drift naturally re-queues affected works for retranslation under the v2 prompt with romaji anchors; no hash-schema change.

Tests: new `TestLoadGlossariesEnLatinKeys` (ja lane sees no latin keys / en lane gets the romaji pair), suite green against an ephemeral DB.