### PR TITLE
feat(catalog): P3 re-scan — refresh stale derived character intros + batched Cursor lane

### DIFF
--- a/apps/api/cmd/extract-char-intros/cursor.go
+++ b/apps/api/cmd/extract-char-intros/cursor.go
@@ -268,7 +268,9 @@ func (c *cursorClient) extractBatch(ctx context.Context, batch []candidateWork, 
 		}
 		items[i] = cursorExtractItem{I: i, Roster: names, Intro: w.Intro}
 	}
-	rules := extractSystemPrompt + "\n5. `摘录` 的键必须逐字使用「角色名单」里给出的写法(带中文名括注的,只用括注前的名字);没有可摘录的角色介绍时该项输出空对象 {}。"
+	rules := extractSystemPrompt + `
+5. ` + "`摘录`" + ` 的键必须逐字使用「角色名单」里给出的写法(带中文名括注的,只用括注前的名字);没有可摘录的角色介绍时该项输出空对象 {}。
+6. 摘录值必须是从简介正文里**原样复制**的连续文本:一个字都不能改、不能顺句、不能换标点、不能把相隔的句子拼起来。程序会逐字比对,改写过的一律丢弃——与其润色不如原样照抄。`
 	prompt, err := batchPrompt(rules, extractOutShape, items)
 	if err != nil {
 		return failAll(out, err)

--- a/apps/api/cmd/extract-char-intros/cursor.go
+++ b/apps/api/cmd/extract-char-intros/cursor.go
@@ -1,0 +1,378 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Cursor lane. Cursor exposes no chat/completions route — api.cursor.com is
+// Admin/Analytics/Cloud-Agents only — so the one inference face is an agent
+// run: POST /v1/agents, then poll the run until it reaches a terminal status
+// and read its result text. Every run pays ~14k input tokens of fixed
+// overhead, so the BATCH is the economic lever, not the concurrency: wave 210
+// measured $0.00032 per item at batch 200 against $0.0008 at batch 50.
+const cursorBase = "https://api.cursor.com"
+
+type cursorClient struct {
+	base    string
+	token   string
+	model   string
+	effort  string
+	http    *http.Client
+	timeout time.Duration
+	poll    time.Duration
+}
+
+func newCursorClient(token, model, effort string, timeout time.Duration) *cursorClient {
+	return &cursorClient{
+		base:    cursorBase,
+		token:   token,
+		model:   model,
+		effort:  effort,
+		http:    &http.Client{Timeout: 120 * time.Second},
+		timeout: timeout,
+		poll:    5 * time.Second,
+	}
+}
+
+func (c *cursorClient) Configured() bool { return c.token != "" }
+
+// runAgent creates one agent run and blocks until it reports a terminal status.
+func (c *cursorClient) runAgent(ctx context.Context, prompt, label string) (string, error) {
+	body := map[string]any{
+		"prompt": map[string]any{"text": prompt},
+		"model": map[string]any{
+			"id": c.model,
+			"params": []map[string]any{
+				{"id": "effort", "value": c.effort},
+				{"id": "fast", "value": "true"},
+			},
+		},
+		"name": label,
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+	created, err := c.request(ctx, http.MethodPost, "/v1/agents", raw)
+	if err != nil {
+		return "", err
+	}
+	agentID, runID := cursorIDs(created)
+	if agentID == "" || runID == "" {
+		return "", fmt.Errorf("create agent: no run in reply: %s", truncate(string(created), 200))
+	}
+	deadline := time.Now().Add(c.timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case <-time.After(c.poll):
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+		data, err := c.request(ctx, http.MethodGet, "/v1/agents/"+agentID+"/runs/"+runID, nil)
+		if err != nil {
+			return "", err
+		}
+		var r struct {
+			Run *struct {
+				Status string `json:"status"`
+				Result string `json:"result"`
+			} `json:"run"`
+			Status string `json:"status"`
+			Result string `json:"result"`
+		}
+		if err := json.Unmarshal(data, &r); err != nil {
+			return "", fmt.Errorf("decode run: %w", err)
+		}
+		status, result := r.Status, r.Result
+		if r.Run != nil {
+			status, result = r.Run.Status, r.Run.Result
+		}
+		switch status {
+		case "FINISHED":
+			return result, nil
+		case "ERROR", "CANCELLED", "EXPIRED":
+			return "", fmt.Errorf("run %s: %s", status, truncate(result, 200))
+		}
+	}
+	return "", fmt.Errorf("run %s exceeded %s", runID, c.timeout)
+}
+
+func cursorIDs(created []byte) (agentID, runID string) {
+	var resp struct {
+		ID    string `json:"id"`
+		Agent *struct {
+			ID string `json:"id"`
+		} `json:"agent"`
+		Run *struct {
+			ID string `json:"id"`
+		} `json:"run"`
+	}
+	if err := json.Unmarshal(created, &resp); err != nil {
+		return "", ""
+	}
+	agentID = resp.ID
+	if resp.Agent != nil && resp.Agent.ID != "" {
+		agentID = resp.Agent.ID
+	}
+	if resp.Run != nil {
+		runID = resp.Run.ID
+	}
+	return agentID, runID
+}
+
+func (c *cursorClient) request(ctx context.Context, method, path string, body []byte) ([]byte, error) {
+	for attempt := 0; ; attempt++ {
+		data, status, err := c.requestOnce(ctx, method, path, body)
+		if err == nil {
+			return data, nil
+		}
+		retryable := status == 0 || status == http.StatusTooManyRequests ||
+			status == http.StatusRequestTimeout || status >= http.StatusInternalServerError
+		if !retryable || attempt >= len(retryBackoff) {
+			return nil, err
+		}
+		select {
+		case <-time.After(retryBackoff[attempt]):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (c *cursorClient) requestOnce(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.base+path, rdr)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, resp.StatusCode, fmt.Errorf("cursor http %d: %s", resp.StatusCode, truncate(string(data), 300))
+	}
+	return data, resp.StatusCode, nil
+}
+
+const batchEnvelopeRules = `下面是一个 JSON 数组,每项是一个待处理条目,` + "`i`" + ` 是它的序号。
+逐项独立处理,输出 JSON 数组 %s。
+必须满足:输出项数与输入完全一致;每项的 ` + "`i`" + ` 原样回显;顺序与输入一致。
+把 JSON 数组直接作为你的最终回复正文输出:不要解释、不要代码围栏、不要写入任何文件、不要使用任何工具。`
+
+func batchPrompt(rules, outShape string, items any) (string, error) {
+	raw, err := json.Marshal(items)
+	if err != nil {
+		return "", err
+	}
+	return rules + "\n\n" + fmt.Sprintf(batchEnvelopeRules, outShape) + "\n\n" + string(raw), nil
+}
+
+var jsonArrayRe = regexp.MustCompile(`(?s)\[.*\]`)
+
+// parseBatchArray is the integrity gate: the reply must carry exactly one
+// object per wanted index, no more, no fewer. A model that silently drops the
+// tail (observed at batch 1000: 418 of 1000 returned) fails here instead of
+// quietly shifting every downstream passage onto the wrong work.
+func parseBatchArray[T any](text string, want int) ([]T, error) {
+	m := jsonArrayRe.FindString(text)
+	if m == "" {
+		return nil, fmt.Errorf("no JSON array in reply: %s", truncate(strings.TrimSpace(text), 200))
+	}
+	var arr []struct {
+		I *int `json:"i"`
+	}
+	if err := json.Unmarshal([]byte(m), &arr); err != nil {
+		return nil, fmt.Errorf("reply is not a JSON array of objects: %w", err)
+	}
+	if len(arr) != want {
+		return nil, fmt.Errorf("count mismatch: got %d want %d", len(arr), want)
+	}
+	var items []T
+	if err := json.Unmarshal([]byte(m), &items); err != nil {
+		return nil, fmt.Errorf("reply items do not match the requested shape: %w", err)
+	}
+	seen := make(map[int]bool, want)
+	for _, a := range arr {
+		if a.I == nil {
+			return nil, fmt.Errorf("item missing index key")
+		}
+		seen[*a.I] = true
+	}
+	for i := range want {
+		if !seen[i] {
+			return nil, fmt.Errorf("index set mismatch: %d missing", i)
+		}
+	}
+	return items, nil
+}
+
+// --- extraction ---
+
+type cursorExtractItem struct {
+	I      int      `json:"i"`
+	Roster []string `json:"角色名单"`
+	Intro  string   `json:"作品简介"`
+}
+
+type cursorExtractReply struct {
+	I     int               `json:"i"`
+	Found map[string]string `json:"摘录"`
+}
+
+const extractOutShape = `[{"i":0,"摘录":{"角色名":"摘录到的介绍文本"}}]`
+
+// splitRetries is how many times a batch that fails the integrity gate is cut
+// in half and retried. One level is what wave 210 settled on: it rescues the
+// batch that was merely too big without letting a systematically bad item turn
+// one run into a binary search.
+const splitRetries = 1
+
+func (c *cursorClient) ExtractBatch(ctx context.Context, batch []candidateWork) []extraction {
+	return c.extractBatch(ctx, batch, 0)
+}
+
+func (c *cursorClient) extractBatch(ctx context.Context, batch []candidateWork, depth int) []extraction {
+	out := make([]extraction, len(batch))
+	items := make([]cursorExtractItem, len(batch))
+	plain := make([]map[string]string, len(batch))
+	for i, w := range batch {
+		names := make([]string, 0, len(w.Roster))
+		plain[i] = make(map[string]string, len(w.Roster))
+		for _, r := range w.Roster {
+			n := r.Name
+			if r.ZhName != "" && r.ZhName != r.Name {
+				n += "(中文名: " + r.ZhName + ")"
+			}
+			names = append(names, n)
+			plain[i][n] = r.Name
+		}
+		items[i] = cursorExtractItem{I: i, Roster: names, Intro: w.Intro}
+	}
+	rules := extractSystemPrompt + "\n5. `摘录` 的键必须逐字使用「角色名单」里给出的写法(带中文名括注的,只用括注前的名字);没有可摘录的角色介绍时该项输出空对象 {}。"
+	prompt, err := batchPrompt(rules, extractOutShape, items)
+	if err != nil {
+		return failAll(out, err)
+	}
+	text, err := c.runAgent(ctx, prompt, fmt.Sprintf("p3-extract-%d", batch[0].WorkID))
+	if err != nil {
+		return failAll(out, err)
+	}
+	replies, err := parseBatchArray[cursorExtractReply](text, len(batch))
+	if err != nil {
+		if depth < splitRetries && len(batch) > 1 {
+			slog.Warn("extraction batch failed the integrity gate — splitting", "works", len(batch), "err", err)
+			half := len(batch) / 2
+			return append(c.extractBatch(ctx, batch[:half], depth+1), c.extractBatch(ctx, batch[half:], depth+1)...)
+		}
+		return failAll(out, err)
+	}
+	for _, r := range replies {
+		if r.I < 0 || r.I >= len(out) {
+			continue
+		}
+		// The roster is shown as 「名字(中文名: …)」, and a model that echoes the
+		// whole label back would land in the unmatched-name bucket; map it home.
+		found := make(map[string]string, len(r.Found))
+		for name, passage := range r.Found {
+			if p, ok := plain[r.I][strings.TrimSpace(name)]; ok {
+				name = p
+			}
+			found[name] = passage
+		}
+		out[r.I] = extraction{Found: found, Model: c.model}
+	}
+	return out
+}
+
+func failAll(out []extraction, err error) []extraction {
+	for i := range out {
+		out[i] = extraction{Err: err}
+	}
+	return out
+}
+
+// --- panel judging ---
+
+type cursorJudgeItem struct {
+	I    int    `json:"i"`
+	Name string `json:"角色"`
+	A    string `json:"A"`
+	B    string `json:"B"`
+}
+
+type cursorJudgeReply struct {
+	I      int    `json:"i"`
+	Winner string `json:"winner"`
+}
+
+const judgeOutShape = `[{"i":0,"winner":"A"}]`
+
+func (c *cursorClient) CompareBatch(ctx context.Context, batch []comparison) []comparisonResult {
+	return c.compareBatch(ctx, batch, 0)
+}
+
+func (c *cursorClient) compareBatch(ctx context.Context, batch []comparison, depth int) []comparisonResult {
+	out := make([]comparisonResult, len(batch))
+	items := make([]cursorJudgeItem, len(batch))
+	for i, cmp := range batch {
+		first, second := cmp.Incumbent, cmp.Challenger
+		if cmp.ChallengerFirst {
+			first, second = cmp.Challenger, cmp.Incumbent
+		}
+		items[i] = cursorJudgeItem{I: i, Name: cmp.Name, A: first, B: second}
+	}
+	prompt, err := batchPrompt(judgeSystemPrompt, judgeOutShape, items)
+	if err != nil {
+		return failAllVotes(out, err)
+	}
+	text, err := c.runAgent(ctx, prompt, fmt.Sprintf("p3-judge-%d", len(batch)))
+	if err != nil {
+		return failAllVotes(out, err)
+	}
+	replies, err := parseBatchArray[cursorJudgeReply](text, len(batch))
+	if err != nil {
+		if depth < splitRetries && len(batch) > 1 {
+			slog.Warn("judge batch failed the integrity gate — splitting", "votes", len(batch), "err", err)
+			half := len(batch) / 2
+			return append(c.compareBatch(ctx, batch[:half], depth+1), c.compareBatch(ctx, batch[half:], depth+1)...)
+		}
+		return failAllVotes(out, err)
+	}
+	for _, r := range replies {
+		if r.I < 0 || r.I >= len(out) {
+			continue
+		}
+		out[r.I] = comparisonResult{Vote: voteOf(r.Winner, batch[r.I].ChallengerFirst)}
+		if out[r.I].Vote == voteEqual && r.Winner != "equal" {
+			out[r.I] = comparisonResult{Err: fmt.Errorf("judge answered %q", r.Winner)}
+		}
+	}
+	return out
+}
+
+func failAllVotes(out []comparisonResult, err error) []comparisonResult {
+	for i := range out {
+		out[i] = comparisonResult{Err: err}
+	}
+	return out
+}

--- a/apps/api/cmd/extract-char-intros/cursor_test.go
+++ b/apps/api/cmd/extract-char-intros/cursor_test.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCursor serves the two routes the lane uses: create an agent, then poll
+// its run. The first poll of each run answers RUNNING so the wait loop is
+// exercised. answer receives the prompt and the 1-based run number, so a test
+// can make the first (big) batch fail and the split halves succeed.
+type cursorProbe struct {
+	client  *cursorClient
+	prompts []string
+}
+
+func fakeCursor(t *testing.T, answer func(prompt string, run int) string) *cursorProbe {
+	t.Helper()
+	p := &cursorProbe{}
+	results := map[string]string{}
+	polled := map[string]bool{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/agents":
+			assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				Prompt struct {
+					Text string `json:"text"`
+				} `json:"prompt"`
+				Model struct {
+					ID string `json:"id"`
+				} `json:"model"`
+			}
+			require.NoError(t, json.Unmarshal(body, &req))
+			assert.Equal(t, "grok-4.6", req.Model.ID)
+			p.prompts = append(p.prompts, req.Prompt.Text)
+			id := fmt.Sprintf("run_%d", len(p.prompts))
+			results[id] = answer(req.Prompt.Text, len(p.prompts))
+			fmt.Fprintf(w, `{"id":"ag_1","run":{"id":%q,"status":"RUNNING"}}`, id)
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/agents/ag_1/runs/"):
+			id := strings.TrimPrefix(r.URL.Path, "/v1/agents/ag_1/runs/")
+			if !polled[id] {
+				polled[id] = true
+				fmt.Fprintf(w, `{"run":{"id":%q,"status":"RUNNING"}}`, id)
+				return
+			}
+			out, _ := json.Marshal(map[string]any{"run": map[string]any{
+				"id": id, "status": "FINISHED", "result": results[id],
+			}})
+			w.Write(out)
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	p.client = newCursorClient("test-key", "grok-4.6", "low", 20*time.Second)
+	p.client.base = srv.URL
+	p.client.poll = time.Millisecond
+	return p
+}
+
+func always(result string) func(string, int) string {
+	return func(string, int) string { return result }
+}
+
+func twoWorks() []candidateWork {
+	return []candidateWork{
+		{WorkID: 11, Intro: "甲作品简介", Roster: []rosterChar{{CharacterID: 1, Name: "沙耶", ZhName: "沙耶"}}},
+		{WorkID: 22, Intro: "乙作品简介", Roster: []rosterChar{{CharacterID: 2, Name: "玲"}}},
+	}
+}
+
+func TestCursorExtractBatchMapsAnswersBackToTheirWork(t *testing.T) {
+	p := fakeCursor(t, always(`[{"i":0,"摘录":{"沙耶":"甲的介绍"}},{"i":1,"摘录":{}}]`))
+
+	out := p.client.ExtractBatch(context.Background(), twoWorks())
+	require.Len(t, out, 2)
+	require.NoError(t, out[0].Err)
+	assert.Equal(t, map[string]string{"沙耶": "甲的介绍"}, out[0].Found)
+	assert.Equal(t, "grok-4.6", out[0].Model)
+	require.NoError(t, out[1].Err)
+	assert.Empty(t, out[1].Found)
+	require.Len(t, p.prompts, 1, "one batch is one agent run")
+	assert.Contains(t, p.prompts[0], "甲作品简介")
+	assert.Contains(t, p.prompts[0], "乙作品简介")
+}
+
+func TestCursorExtractBatchAcceptsTheAnnotatedRosterLabel(t *testing.T) {
+	p := fakeCursor(t, always(`[{"i":0,"摘录":{"沙耶(中文名: 纱耶)":"甲的介绍"}}]`))
+	batch := []candidateWork{
+		{WorkID: 11, Intro: "甲作品简介", Roster: []rosterChar{{CharacterID: 1, Name: "沙耶", ZhName: "纱耶"}}},
+	}
+
+	out := p.client.ExtractBatch(context.Background(), batch)
+	require.NoError(t, out[0].Err)
+	assert.Equal(t, map[string]string{"沙耶": "甲的介绍"}, out[0].Found,
+		"an echoed label must land on the roster name, not in the unmatched bucket")
+}
+
+// A reply that drops the tail must never be trusted by position — that files
+// every passage onto the wrong work. The batch is cut in half and retried, and
+// only what still fails is reported as failed.
+func TestCursorExtractBatchSplitsAShortReply(t *testing.T) {
+	p := fakeCursor(t, func(_ string, run int) string {
+		if run == 1 {
+			return `[{"i":0,"摘录":{"沙耶":"甲的介绍"}}]` // one item for a batch of two
+		}
+		return `[{"i":0,"摘录":{"沙耶":"甲的介绍"}}]`
+	})
+
+	out := p.client.ExtractBatch(context.Background(), twoWorks())
+	require.Len(t, out, 2)
+	assert.Len(t, p.prompts, 3, "the failed batch plus its two halves")
+	require.NoError(t, out[0].Err)
+	assert.Equal(t, map[string]string{"沙耶": "甲的介绍"}, out[0].Found)
+	require.NoError(t, out[1].Err, "the second half answers for its own single work")
+}
+
+func TestCursorExtractBatchFailsEveryWorkWhenSplittingCannotHelp(t *testing.T) {
+	p := fakeCursor(t, always(`抱歉,我无法完成这个任务。`))
+
+	out := p.client.ExtractBatch(context.Background(), twoWorks())
+	require.Len(t, out, 2)
+	assert.Len(t, p.prompts, 3)
+	for i, e := range out {
+		require.Error(t, e.Err, "item %d", i)
+		assert.Contains(t, e.Err.Error(), "no JSON array")
+	}
+}
+
+func TestParseBatchArrayIntegrityGate(t *testing.T) {
+	type reply struct {
+		I      int    `json:"i"`
+		Winner string `json:"winner"`
+	}
+	cases := []struct {
+		name    string
+		text    string
+		want    int
+		wantErr string
+	}{
+		{"clean", `[{"i":0,"winner":"A"},{"i":1,"winner":"B"}]`, 2, ""},
+		{"tolerates surrounding chatter", "好的:\n[{\"i\":0,\"winner\":\"A\"}]\n", 1, ""},
+		{"dropped tail", `[{"i":0,"winner":"A"}]`, 2, "count mismatch"},
+		{"duplicate index hides a gap", `[{"i":0,"winner":"A"},{"i":0,"winner":"B"}]`, 2, "index set mismatch"},
+		{"missing index key", `[{"winner":"A"},{"i":1,"winner":"B"}]`, 2, "item missing index key"},
+		{"no array at all", `抱歉,我无法完成。`, 1, "no JSON array"},
+	}
+	for _, c := range cases {
+		got, err := parseBatchArray[reply](c.text, c.want)
+		if c.wantErr != "" {
+			require.Error(t, err, c.name)
+			assert.Contains(t, err.Error(), c.wantErr, c.name)
+			continue
+		}
+		require.NoError(t, err, c.name)
+		assert.Len(t, got, c.want, c.name)
+	}
+}
+
+type countingJudge struct{ batches []int }
+
+func (j *countingJudge) CompareBatch(_ context.Context, batch []comparison) []comparisonResult {
+	j.batches = append(j.batches, len(batch))
+	out := make([]comparisonResult, len(batch))
+	for i, c := range batch {
+		out[i] = comparisonResult{Vote: voteOf("A", c.ChallengerFirst)}
+	}
+	return out
+}
+
+func TestVoteDispatchChunksAndKeepsOrder(t *testing.T) {
+	j := &countingJudge{}
+	cmps := make([]comparison, 5)
+	for i := range cmps {
+		cmps[i] = comparison{Name: fmt.Sprint(i), ChallengerFirst: i%2 == 1}
+	}
+
+	out := voteDispatch(j, 2, 1, 0)(context.Background(), cmps)
+	require.Len(t, out, 5)
+	assert.Equal(t, []int{2, 2, 1}, j.batches)
+	for i, r := range out {
+		require.NoError(t, r.Err)
+		want := voteIncumbent
+		if i%2 == 1 {
+			want = voteChallenger
+		}
+		assert.Equal(t, want, r.Vote, "vote %d kept its own position", i)
+	}
+}
+
+type shortJudge struct{}
+
+func (shortJudge) CompareBatch(_ context.Context, _ []comparison) []comparisonResult {
+	return nil
+}
+
+func TestResolvePanelKeepsIncumbentWhenARoundFails(t *testing.T) {
+	w := &writer{st: &stats{}, judge: shortJudge{}}
+	contested := []gated{{WorkID: 1, Target: rosterChar{CharacterID: 1, Name: "沙耶", Incumbent: "既有"}, Passage: "提取"}}
+
+	adopted := w.resolvePanel(context.Background(), contested, voteDispatch(shortJudge{}, 10, 1, 0))
+	assert.Empty(t, adopted)
+	assert.Equal(t, 1, w.st.PanelErrors)
+	assert.Zero(t, w.st.PanelKept, "an unjudged character is not a kept verdict — it is retryable")
+}
+
+func TestCursorModelFallsBackOffTheOpenAIDefault(t *testing.T) {
+	assert.Equal(t, "grok-4.6", cursorModel("glm-5.2"))
+	assert.Equal(t, "grok-4.6", cursorModel(""))
+	assert.Equal(t, "grok-4.7", cursorModel("grok-4.7"))
+}
+
+func TestChunkWorksCoversEveryWorkOnce(t *testing.T) {
+	works := make([]candidateWork, 7)
+	for i := range works {
+		works[i] = candidateWork{WorkID: int64(i)}
+	}
+	var seen []int64
+	for _, c := range chunkWorks(works, 3) {
+		for _, w := range c {
+			seen = append(seen, w.WorkID)
+		}
+	}
+	assert.Equal(t, []int64{0, 1, 2, 3, 4, 5, 6}, seen)
+}
+
+func TestReadCursorKeyRejectsAnEmptyFile(t *testing.T) {
+	t.Setenv("CURSOR_API_KEY", "")
+	path := t.TempDir() + "/key"
+	require.NoError(t, os.WriteFile(path, []byte("  \n"), 0o600))
+	_, err := readCursorKey(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+
+	require.NoError(t, os.WriteFile(path, []byte("crsr_secret\n"), 0o600))
+	key, err := readCursorKey(path)
+	require.NoError(t, err)
+	assert.Equal(t, "crsr_secret", key)
+}
+
+func TestBatchPromptCarriesTheIntegrityRules(t *testing.T) {
+	p, err := batchPrompt("规则", `[{"i":0}]`, []cursorExtractItem{{I: 0, Intro: "简介"}})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(p, "规则"))
+	assert.Contains(t, p, "输出项数与输入完全一致")
+	assert.Contains(t, p, `"作品简介":"简介"`)
+}

--- a/apps/api/cmd/extract-char-intros/extract.go
+++ b/apps/api/cmd/extract-char-intros/extract.go
@@ -29,11 +29,51 @@ type rosterChar struct {
 	Name        string // display name — the key the model must answer with
 	ZhName      string // best zh alias, shown as an aid, may equal Name
 	Incumbent   string // panel bucket only: the elected translated machine intro
+	DerivedID   int64  // refresh bucket only: the stale derived row to rewrite
+	DerivedHash string // refresh bucket only: its src_hash, the update guard
+}
+
+// candidateOpts is the window every bucket's loader applies identically.
+type candidateOpts struct {
+	Limit  int
+	Offset int
+	Since  string // RFC3339; keep only works whose elected zh intro changed since
+}
+
+// sinceClause filters on the ELECTED intro's updated_at — the row the zhi CTE
+// already picked — so it narrows the work list without changing which intro
+// each work contributes.
+func sinceClause(since string) string {
+	if since == "" {
+		return ""
+	}
+	return `
+	  AND zhi.updated_at >= ?`
+}
+
+func sinceArgs(since string) []any {
+	if since == "" {
+		return nil
+	}
+	return []any{since}
+}
+
+func window(works []candidateWork, o candidateOpts) []candidateWork {
+	if o.Offset > 0 {
+		if o.Offset >= len(works) {
+			return nil
+		}
+		works = works[o.Offset:]
+	}
+	if o.Limit > 0 && len(works) > o.Limit {
+		works = works[:o.Limit]
+	}
+	return works
 }
 
 var candidateWorksSQL = `
 	WITH zhi AS (
-		SELECT DISTINCT ON (work_id) work_id, intro
+		SELECT DISTINCT ON (work_id) work_id, intro, updated_at
 		FROM catalog_work_intro
 		WHERE lang = 'zh-Hans' AND length(intro) >= 200
 		ORDER BY work_id, source_id
@@ -53,10 +93,11 @@ var candidateWorksSQL = `
 	  AND ` + editspec.NotSuppressedRosterSQL("wc") + `
 	  AND NOT EXISTS (
 	    SELECT 1 FROM catalog_character_intro ci
-	    WHERE ci.character_id = wc.character_id AND ci.lang = 'zh-Hans')
-	ORDER BY w.id, wc.character_id`
+	    WHERE ci.character_id = wc.character_id AND ci.lang = 'zh-Hans')`
 
-func loadCandidateWorks(ctx context.Context, db *gorm.DB, limit, offset int) ([]candidateWork, error) {
+func loadCandidateWorks(ctx context.Context, db *gorm.DB, o candidateOpts) ([]candidateWork, error) {
+	sql := candidateWorksSQL + sinceClause(o.Since) + `
+	ORDER BY w.id, wc.character_id`
 	var rows []struct {
 		WorkID      int64  `gorm:"column:work_id"`
 		Intro       string `gorm:"column:intro"`
@@ -64,7 +105,7 @@ func loadCandidateWorks(ctx context.Context, db *gorm.DB, limit, offset int) ([]
 		DisplayName string `gorm:"column:display_name"`
 		ZhName      string `gorm:"column:zh_name"`
 	}
-	if err := db.WithContext(ctx).Raw(candidateWorksSQL).Scan(&rows).Error; err != nil {
+	if err := db.WithContext(ctx).Raw(sql, sinceArgs(o.Since)...).Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("load candidate works: %w", err)
 	}
 	var out []candidateWork
@@ -77,16 +118,7 @@ func loadCandidateWorks(ctx context.Context, db *gorm.DB, limit, offset int) ([]
 			CharacterID: r.CharacterID, Name: r.DisplayName, ZhName: r.ZhName,
 		})
 	}
-	if offset > 0 {
-		if offset >= len(out) {
-			return nil, nil
-		}
-		out = out[offset:]
-	}
-	if limit > 0 && len(out) > limit {
-		out = out[:limit]
-	}
-	return out, nil
+	return window(out, o), nil
 }
 
 const extractSystemPrompt = `你从视觉小说(galgame)的作品简介中摘录角色介绍。给你一段简介正文和一份角色名单。
@@ -115,9 +147,29 @@ func extractUserMessage(c candidateWork) string {
 	return sb.String()
 }
 
+// extraction is one work's answer: the model's name→passage map, or the error
+// that kept it from arriving. A failed work writes nothing and stays a
+// candidate, so the next run retries it.
+type extraction struct {
+	Found map[string]string
+	Model string
+	Err   error
+}
+
+// extractor answers a BATCH of works. The OpenAI-compatible gateway has no
+// batch face and its adapter just loops; Cursor's only face is a batch, and
+// there the batch is what makes the lane affordable.
 type extractor interface {
-	// Extract returns the model's name→passage map for one work.
-	Extract(ctx context.Context, c candidateWork) (map[string]string, string, error)
+	ExtractBatch(ctx context.Context, batch []candidateWork) []extraction
+}
+
+func (t *httpExtractor) ExtractBatch(ctx context.Context, batch []candidateWork) []extraction {
+	out := make([]extraction, len(batch))
+	for i, c := range batch {
+		found, model, err := t.Extract(ctx, c)
+		out[i] = extraction{Found: found, Model: model, Err: err}
+	}
+	return out
 }
 
 type httpExtractor struct {

--- a/apps/api/cmd/extract-char-intros/extract_test.go
+++ b/apps/api/cmd/extract-char-intros/extract_test.go
@@ -97,8 +97,12 @@ type fakeExtractor struct {
 	out map[string]string
 }
 
-func (f fakeExtractor) Extract(_ context.Context, _ candidateWork) (map[string]string, string, error) {
-	return f.out, "glm-5.2", nil
+func (f fakeExtractor) ExtractBatch(_ context.Context, batch []candidateWork) []extraction {
+	out := make([]extraction, len(batch))
+	for i := range batch {
+		out[i] = extraction{Found: f.out, Model: "glm-5.2"}
+	}
+	return out
 }
 
 func seedWorkWithIntro(t *testing.T, intro string) int64 {
@@ -139,7 +143,7 @@ func TestRunExtractsOnlyMissingAndVerbatim(t *testing.T) {
 		(character_id, lang, intro, source_id, provenance, created_at, updated_at)
 		VALUES (?, 'zh-Hans', '既有介绍', 3, 1, now(), now())`, rei).Error)
 
-	cands, err := loadCandidateWorks(context.Background(), testDB, 0, 0)
+	cands, err := loadCandidateWorks(context.Background(), testDB, candidateOpts{})
 	require.NoError(t, err)
 	require.Len(t, cands, 1)
 	require.Len(t, cands[0].Roster, 1, "only the intro-less character is a target")
@@ -193,10 +197,13 @@ type fakeJudge struct {
 	calls int
 }
 
-func (f *fakeJudge) Compare(_ context.Context, _, _, _ string, _ bool) (panelVote, error) {
-	v := f.votes[f.calls%len(f.votes)]
-	f.calls++
-	return v, nil
+func (f *fakeJudge) CompareBatch(_ context.Context, batch []comparison) []comparisonResult {
+	out := make([]comparisonResult, len(batch))
+	for i := range batch {
+		out[i] = comparisonResult{Vote: f.votes[f.calls%len(f.votes)]}
+		f.calls++
+	}
+	return out
 }
 
 func seedPanelFixture(t *testing.T) (workID, saya, rei int64) {
@@ -219,7 +226,7 @@ func seedPanelFixture(t *testing.T) (workID, saya, rei int64) {
 func TestRunPanelAdoptsUnanimousChallenger(t *testing.T) {
 	_, saya, _ := seedPanelFixture(t)
 
-	cands, err := loadPanelCandidateWorks(context.Background(), testDB, 0, 0)
+	cands, err := loadPanelCandidateWorks(context.Background(), testDB, candidateOpts{})
 	require.NoError(t, err)
 	require.Len(t, cands, 1)
 	require.Len(t, cands[0].Roster, 1, "only the translated-machine-row holder is a target")
@@ -242,7 +249,7 @@ func TestRunPanelAdoptsUnanimousChallenger(t *testing.T) {
 	assert.EqualValues(t, sourceDerived, rows[1].SourceID)
 	assert.Equal(t, "主人公的青梅竹马,性格开朗,总是照顾身边的每一个人。", rows[1].Intro)
 
-	cands, err = loadPanelCandidateWorks(context.Background(), testDB, 0, 0)
+	cands, err = loadPanelCandidateWorks(context.Background(), testDB, candidateOpts{})
 	require.NoError(t, err)
 	assert.Empty(t, cands, "a written derived row retires the character from the panel")
 }

--- a/apps/api/cmd/extract-char-intros/main.go
+++ b/apps/api/cmd/extract-char-intros/main.go
@@ -1,4 +1,5 @@
-// extract-char-intros — wave 178 P3, the fill bucket only.
+// extract-char-intros — wave 178 P3, extended by wave 214 with the refresh
+// bucket and a batched lane.
 //
 // A work's zh-Hans intro often embeds per-character introductions. For the
 // roster characters that have NO zh-Hans intro row at all, this job asks the
@@ -13,6 +14,12 @@
 // machine rows — never above source rows. When the incumbent is judged better
 // nothing is written, so the verdict is re-checkable on any later run.
 //
+// The refresh bucket (--refresh; wave 214): a derived row is an excerpt, so a
+// retranslated work intro leaves it quoting text that no longer exists — with
+// the character names the retranslation fixed. src_hash names the intro the
+// excerpt came from, and a row matching none of its works' current intros is
+// re-extracted and rewritten in place.
+//
 // Anti-hallucination gate: an extracted passage must reappear verbatim
 // (modulo whitespace and leading list markers) inside the work intro, or it
 // is refused. The model is an index into the text, never an author.
@@ -24,6 +31,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
+	"sync"
 	"time"
 
 	"api/internal/infrastructure/database"
@@ -36,13 +45,22 @@ func main() {
 	dsn := flag.String("dsn", "", "catalog DSN (REQUIRED)")
 	apply := flag.Bool("apply", false, "write the extracted rows (default: dry — extraction runs, nothing written)")
 	panel := flag.Bool("panel", false, "panel bucket: characters whose zh-Hans face is a translated machine row — extract, 3-vote compare, adopt only on a unanimous direction")
+	refresh := flag.Bool("refresh", false, "refresh bucket: derived rows whose src_hash matches none of their works' current zh intros — re-extract from the fresh intro and rewrite in place")
+	since := flag.String("since", "", "only works whose elected zh intro changed at or after this RFC3339 time (a re-scan trigger, not a filter on the rows)")
 	limit := flag.Int("limit", 0, "max WORKS this run (0 = all) — ramp through a small limit first (the rehearsal rule)")
 	offset := flag.Int("offset", 0, "skip the first N candidate works (stable id order)")
+	gateway := flag.String("gateway", "openai", "openai (chat/completions) or cursor (agent runs, batched)")
 	model := flag.String("model", envOr("KUN_INTRO_MT_LLM_MODEL", envOr("KUN_AI_UPSTREAM_MODEL", "glm-5.2")), "served model id")
 	llmBase := flag.String("llm-base", envOr("KUN_INTRO_MT_LLM_BASE", os.Getenv("KUN_AI_UPSTREAM_BASE_URL")), "OpenAI-compatible gateway base URL (…/v1)")
 	llmToken := flag.String("llm-token", envOr("KUN_INTRO_MT_LLM_TOKEN", os.Getenv("KUN_AI_UPSTREAM_TOKEN")), "gateway bearer token")
-	maxTokens := flag.Int("max-tokens", 16384, "max_tokens per extraction call")
-	delayMS := flag.Int("delay-ms", 0, "delay between gateway calls (ms)")
+	cursorKeyFile := flag.String("cursor-key-file", "", "file holding the Cursor API key (or set CURSOR_API_KEY) — never pass a key on the command line")
+	cursorEffort := flag.String("cursor-effort", "low", "Cursor reasoning effort: low | medium | high | xhigh")
+	runTimeout := flag.Duration("run-timeout", 20*time.Minute, "how long one Cursor agent run may take")
+	batch := flag.Int("batch", 0, "works per extraction call (0 = 1 for openai, 20 for cursor)")
+	judgeBatch := flag.Int("judge-batch", 0, "comparisons per judge call (0 = 1 for openai, 40 for cursor)")
+	workers := flag.Int("workers", 0, "concurrent calls in flight (0 = 1 for openai, 6 for cursor)")
+	maxTokens := flag.Int("max-tokens", 16384, "max_tokens per extraction call (openai gateway only)")
+	delayMS := flag.Int("delay-ms", 0, "delay before each gateway call (ms)")
 	samples := flag.Int("samples", 5, "how many extracted samples to print")
 	flag.Parse()
 
@@ -52,22 +70,58 @@ func main() {
 		slog.Error("--dsn is required")
 		os.Exit(2)
 	}
+	if *panel && *refresh {
+		slog.Error("--panel and --refresh are different buckets; pick one")
+		os.Exit(2)
+	}
+	if *since != "" {
+		if _, err := time.Parse(time.RFC3339, *since); err != nil {
+			slog.Error("--since must be RFC3339", "value", *since, "error", err)
+			os.Exit(2)
+		}
+	}
 	db, err := database.OpenJob(*dsn)
 	if err != nil {
 		slog.Error("open database", "error", err)
 		os.Exit(1)
 	}
-	ex := newHTTPExtractor(*llmBase, *llmToken, *model, *maxTokens)
-	if !ex.Configured() {
-		fmt.Println("BLOCKED: LLM gateway not configured (need --llm-base + --llm-token, or KUN_INTRO_MT_LLM_* / KUN_AI_UPSTREAM_*).")
-		os.Exit(3)
-	}
+
+	var ex extractor
 	var judge panelJudge
-	if *panel {
-		judge = ex
+	switch *gateway {
+	case "openai":
+		http := newHTTPExtractor(*llmBase, *llmToken, *model, *maxTokens)
+		if !http.Configured() {
+			fmt.Println("BLOCKED: LLM gateway not configured (need --llm-base + --llm-token, or KUN_INTRO_MT_LLM_* / KUN_AI_UPSTREAM_*).")
+			os.Exit(3)
+		}
+		ex, judge = http, http
+		defaultTo(batch, 1)
+		defaultTo(judgeBatch, 1)
+		defaultTo(workers, 1)
+	case "cursor":
+		key, err := readCursorKey(*cursorKeyFile)
+		if err != nil {
+			fmt.Println("BLOCKED: " + err.Error())
+			os.Exit(3)
+		}
+		cur := newCursorClient(key, cursorModel(*model), *cursorEffort, *runTimeout)
+		ex, judge = cur, cur
+		defaultTo(batch, 20)
+		defaultTo(judgeBatch, 40)
+		defaultTo(workers, 6)
+	default:
+		slog.Error("--gateway must be openai or cursor", "value", *gateway)
+		os.Exit(2)
 	}
+	if !*panel {
+		judge = nil
+	}
+
 	if err := run(context.Background(), db, ex, judge, opts{
-		Apply: *apply, Panel: *panel, Limit: *limit, Offset: *offset,
+		Apply: *apply, Panel: *panel, Refresh: *refresh,
+		Cand:  candidateOpts{Limit: *limit, Offset: *offset, Since: *since},
+		Batch: *batch, JudgeBatch: *judgeBatch, Workers: *workers,
 		Delay: time.Duration(*delayMS) * time.Millisecond, Samples: *samples,
 	}); err != nil {
 		slog.Error("run failed", "error", err)
@@ -76,56 +130,71 @@ func main() {
 }
 
 type opts struct {
-	Apply   bool
-	Panel   bool
-	Limit   int
-	Offset  int
-	Delay   time.Duration
-	Samples int
+	Apply      bool
+	Panel      bool
+	Refresh    bool
+	Cand       candidateOpts
+	Batch      int
+	JudgeBatch int
+	Workers    int
+	Delay      time.Duration
+	Samples    int
 }
 
 func run(ctx context.Context, db *gorm.DB, ex extractor, judge panelJudge, o opts) error {
 	load := loadCandidateWorks
-	if o.Panel {
+	switch {
+	case o.Panel:
 		load = loadPanelCandidateWorks
+	case o.Refresh:
+		load = loadRefreshCandidateWorks
 	}
-	works, err := load(ctx, db, o.Limit, o.Offset)
+	works, err := load(ctx, db, o.Cand)
 	if err != nil {
 		return err
 	}
 	modeStr := mode(o.Apply)
-	if o.Panel {
+	switch {
+	case o.Panel:
 		modeStr = "PANEL " + modeStr
+	case o.Refresh:
+		modeStr = "REFRESH " + modeStr
 	}
 	fmt.Printf("\n=== extract-char-intros (%s) candidate_works=%d ===\n", modeStr, len(works))
 	st := &stats{}
-	w := &writer{db: db, apply: o.Apply, st: st, samples: o.Samples, judge: judge, delay: o.Delay}
-	for i, cand := range works {
-		if ctx.Err() != nil {
-			return ctx.Err()
+	w := &writer{db: db, apply: o.Apply, refresh: o.Refresh, st: st, samples: o.Samples, judge: judge}
+	dispatch := voteDispatch(judge, at(o.JudgeBatch, 1), at(o.Workers, 1), o.Delay)
+
+	done := 0
+	for res := range extractBatches(ctx, ex, chunkWorks(works, at(o.Batch, 1)), at(o.Workers, 1), o.Delay) {
+		var contested []gated
+		for i, cand := range res.works {
+			e := res.out[i]
+			if e.Err != nil {
+				st.CallErrors++
+				slog.Warn("extract failed", "work", cand.WorkID, "err", e.Err)
+				continue
+			}
+			ready, c := w.gate(cand, e.Found, e.Model)
+			for _, g := range ready {
+				w.commit(ctx, g)
+			}
+			contested = append(contested, c...)
 		}
-		if i > 0 && o.Delay > 0 {
-			time.Sleep(o.Delay)
+		for _, g := range w.resolvePanel(ctx, contested, dispatch) {
+			w.commit(ctx, g)
 		}
-		found, model, err := ex.Extract(ctx, cand)
-		if err != nil {
-			st.CallErrors++
-			slog.Warn("extract failed", "work", cand.WorkID, "err", err)
-			continue
-		}
-		w.write(ctx, cand, found, model)
-		if (i+1)%25 == 0 {
-			slog.Info("progress", "works", i+1, "of", len(works), "inserted", st.Inserted,
-				"refused_not_verbatim", st.RefusedNotVerbatim, "call_errors", st.CallErrors)
-		}
+		done += len(res.works)
+		slog.Info("progress", "works", done, "of", len(works), "inserted", st.Inserted, "updated", st.Updated,
+			"refused_not_verbatim", st.RefusedNotVerbatim, "call_errors", st.CallErrors)
 	}
 	if o.Apply {
 		if err := w.flushTouch(ctx); err != nil {
 			return err
 		}
 	}
-	fmt.Printf("\nworks=%d extracted=%d inserted=%d conflict=%d refused_not_verbatim=%d refused_short=%d refused_name_absent=%d unmatched_name=%d call_errors=%d touched_works=%d\n",
-		len(works), st.Extracted, st.Inserted, st.Conflict, st.RefusedNotVerbatim, st.RefusedShort, st.RefusedNameAbsent, st.UnmatchedName, st.CallErrors, st.Touched)
+	fmt.Printf("\nworks=%d extracted=%d inserted=%d updated=%d conflict=%d refused_not_verbatim=%d refused_short=%d refused_name_absent=%d unmatched_name=%d call_errors=%d touched_works=%d\n",
+		len(works), st.Extracted, st.Inserted, st.Updated, st.Conflict, st.RefusedNotVerbatim, st.RefusedShort, st.RefusedNameAbsent, st.UnmatchedName, st.CallErrors, st.Touched)
 	if o.Panel {
 		fmt.Printf("panel: adopted=%d kept_incumbent=%d panel_errors=%d\n", st.PanelAdopted, st.PanelKept, st.PanelErrors)
 	}
@@ -136,6 +205,128 @@ func run(ctx context.Context, db *gorm.DB, ex extractor, judge panelJudge, o opt
 		os.Exit(1)
 	}
 	return nil
+}
+
+type batchResult struct {
+	works []candidateWork
+	out   []extraction
+}
+
+func chunkWorks(works []candidateWork, size int) [][]candidateWork {
+	var out [][]candidateWork
+	for start := 0; start < len(works); start += size {
+		out = append(out, works[start:min(start+size, len(works))])
+	}
+	return out
+}
+
+// extractBatches runs the batches concurrently but delivers them in order, so
+// a rerun with the same window walks the same works in the same sequence and
+// the progress line means what it says.
+func extractBatches(ctx context.Context, ex extractor, batches [][]candidateWork, workers int, delay time.Duration) <-chan batchResult {
+	slots := make([]chan batchResult, len(batches))
+	for i := range slots {
+		slots[i] = make(chan batchResult, 1)
+	}
+	go func() {
+		sem := make(chan struct{}, workers)
+		for i, b := range batches {
+			sem <- struct{}{}
+			go func(i int, b []candidateWork) {
+				defer func() { <-sem }()
+				if delay > 0 {
+					time.Sleep(delay)
+				}
+				slots[i] <- batchResult{works: b, out: ex.ExtractBatch(ctx, b)}
+			}(i, b)
+		}
+	}()
+	out := make(chan batchResult)
+	go func() {
+		defer close(out)
+		for i := range slots {
+			select {
+			case r := <-slots[i]:
+				out <- r
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out
+}
+
+func voteDispatch(judge panelJudge, size, workers int, delay time.Duration) voteDispatcher {
+	return func(ctx context.Context, cmps []comparison) []comparisonResult {
+		out := make([]comparisonResult, len(cmps))
+		sem := make(chan struct{}, workers)
+		var wg sync.WaitGroup
+		for start := 0; start < len(cmps); start += size {
+			end := min(start+size, len(cmps))
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(start, end int) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				if delay > 0 {
+					time.Sleep(delay)
+				}
+				res := judge.CompareBatch(ctx, cmps[start:end])
+				if len(res) != end-start {
+					err := fmt.Errorf("judge answered %d of %d votes", len(res), end-start)
+					for i := start; i < end; i++ {
+						out[i] = comparisonResult{Err: err}
+					}
+					return
+				}
+				copy(out[start:end], res)
+			}(start, end)
+		}
+		wg.Wait()
+		return out
+	}
+}
+
+// readCursorKey keeps the key off the command line: a process list is world
+// readable, an env file and a mode-600 file are not.
+func readCursorKey(path string) (string, error) {
+	if key := strings.TrimSpace(os.Getenv("CURSOR_API_KEY")); key != "" {
+		return key, nil
+	}
+	if path == "" {
+		return "", fmt.Errorf("cursor gateway needs CURSOR_API_KEY or --cursor-key-file")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read cursor key: %w", err)
+	}
+	key := strings.TrimSpace(string(raw))
+	if key == "" {
+		return "", fmt.Errorf("cursor key file %s is empty", path)
+	}
+	return key, nil
+}
+
+// cursorModel keeps --model meaningful for both gateways: the default names a
+// model the OpenAI-compatible gateway serves, which Cursor does not.
+func cursorModel(model string) string {
+	if model == "" || strings.Contains(model, "glm") {
+		return "grok-4.6"
+	}
+	return model
+}
+
+func defaultTo(v *int, n int) {
+	if *v == 0 {
+		*v = n
+	}
+}
+
+func at(v, fallback int) int {
+	if v < 1 {
+		return fallback
+	}
+	return v
 }
 
 func mode(apply bool) string {

--- a/apps/api/cmd/extract-char-intros/panel.go
+++ b/apps/api/cmd/extract-char-intros/panel.go
@@ -17,7 +17,7 @@ import (
 // with source text. An existing derived row means the panel already ran.
 var candidatePanelWorksSQL = `
 	WITH zhi AS (
-		SELECT DISTINCT ON (work_id) work_id, intro
+		SELECT DISTINCT ON (work_id) work_id, intro, updated_at
 		FROM catalog_work_intro
 		WHERE lang = 'zh-Hans' AND length(intro) >= 200
 		ORDER BY work_id, source_id
@@ -47,10 +47,11 @@ var candidatePanelWorksSQL = `
 	    WHERE s.character_id = wc.character_id AND s.lang = 'zh-Hans' AND s.provenance = 0)
 	  AND NOT EXISTS (
 	    SELECT 1 FROM catalog_character_intro d
-	    WHERE d.character_id = wc.character_id AND d.lang = 'zh-Hans' AND d.source_id = 18)
-	ORDER BY w.id, wc.character_id`
+	    WHERE d.character_id = wc.character_id AND d.lang = 'zh-Hans' AND d.source_id = 18)`
 
-func loadPanelCandidateWorks(ctx context.Context, db *gorm.DB, limit, offset int) ([]candidateWork, error) {
+func loadPanelCandidateWorks(ctx context.Context, db *gorm.DB, o candidateOpts) ([]candidateWork, error) {
+	sql := candidatePanelWorksSQL + sinceClause(o.Since) + `
+	ORDER BY w.id, wc.character_id`
 	var rows []struct {
 		WorkID      int64  `gorm:"column:work_id"`
 		Intro       string `gorm:"column:intro"`
@@ -59,7 +60,7 @@ func loadPanelCandidateWorks(ctx context.Context, db *gorm.DB, limit, offset int
 		ZhName      string `gorm:"column:zh_name"`
 		Incumbent   string `gorm:"column:incumbent"`
 	}
-	if err := db.WithContext(ctx).Raw(candidatePanelWorksSQL).Scan(&rows).Error; err != nil {
+	if err := db.WithContext(ctx).Raw(sql, sinceArgs(o.Since)...).Scan(&rows).Error; err != nil {
 		return nil, fmt.Errorf("load panel candidate works: %w", err)
 	}
 	var out []candidateWork
@@ -72,16 +73,7 @@ func loadPanelCandidateWorks(ctx context.Context, db *gorm.DB, limit, offset int
 			CharacterID: r.CharacterID, Name: r.DisplayName, ZhName: r.ZhName, Incumbent: r.Incumbent,
 		})
 	}
-	if offset > 0 {
-		if offset >= len(out) {
-			return nil, nil
-		}
-		out = out[offset:]
-	}
-	if limit > 0 && len(out) > limit {
-		out = out[:limit]
-	}
-	return out, nil
+	return window(out, o), nil
 }
 
 type panelVote int
@@ -92,10 +84,33 @@ const (
 	voteEqual
 )
 
+// comparison is one vote to cast: which passage serves better as this
+// character's introduction. ChallengerFirst decides which one is shown as A,
+// so a position bias cannot decide the verdict.
+type comparison struct {
+	Name            string
+	Incumbent       string
+	Challenger      string
+	ChallengerFirst bool
+}
+
+type comparisonResult struct {
+	Vote panelVote
+	Err  error
+}
+
 type panelJudge interface {
-	// Compare returns which of the two zh passages serves better as the
-	// character's introduction.
-	Compare(ctx context.Context, name, incumbent, challenger string, challengerFirst bool) (panelVote, error)
+	// CompareBatch answers one vote per comparison, in order.
+	CompareBatch(ctx context.Context, batch []comparison) []comparisonResult
+}
+
+func (t *httpExtractor) CompareBatch(ctx context.Context, batch []comparison) []comparisonResult {
+	out := make([]comparisonResult, len(batch))
+	for i, c := range batch {
+		v, err := t.Compare(ctx, c.Name, c.Incumbent, c.Challenger, c.ChallengerFirst)
+		out[i] = comparisonResult{Vote: v, Err: err}
+	}
+	return out
 }
 
 const panelVotes = 3
@@ -173,21 +188,25 @@ func (t *httpExtractor) Compare(ctx context.Context, name, incumbent, challenger
 	if err != nil {
 		return voteEqual, err
 	}
+	return voteOf(winner, challengerFirst), nil
+}
+
+// voteOf maps the judge's answer back onto the two passages. parseJudgeWinner
+// (and the batch lane's own check) already rejected anything but A/B/equal.
+func voteOf(winner string, challengerFirst bool) panelVote {
 	switch winner {
-	case "equal":
-		return voteEqual, nil
 	case "A":
 		if challengerFirst {
-			return voteChallenger, nil
+			return voteChallenger
 		}
-		return voteIncumbent, nil
+		return voteIncumbent
 	case "B":
 		if challengerFirst {
-			return voteIncumbent, nil
+			return voteIncumbent
 		}
-		return voteChallenger, nil
+		return voteChallenger
 	}
-	return voteEqual, fmt.Errorf("judge answered %q", winner)
+	return voteEqual
 }
 
 func parseJudgeWinner(s string) (string, error) {

--- a/apps/api/cmd/extract-char-intros/refresh.go
+++ b/apps/api/cmd/extract-char-intros/refresh.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"api/internal/platform/catalog/editspec"
+
+	"gorm.io/gorm"
+)
+
+// Refresh bucket: a derived row is an EXCERPT of the work intro it was taken
+// from, so when that intro is retranslated the excerpt keeps the old wording —
+// including the character names the retranslation fixed. src_hash records the
+// intro the passage came from; a row whose hash matches none of its works'
+// current zh intros is quoting text that no longer exists.
+//
+// Neither other bucket can reach these rows (fill skips any character that has
+// a zh row, panel skips any character that has a derived row), so without this
+// query a derived row is written once and never revisited.
+var candidateRefreshWorksSQL = `
+	WITH zhi AS (
+		SELECT DISTINCT ON (work_id) work_id, intro, updated_at
+		FROM catalog_work_intro
+		WHERE lang = 'zh-Hans' AND length(intro) >= 200
+		ORDER BY work_id, source_id
+	), der AS (
+		SELECT id, character_id, src_hash
+		FROM catalog_character_intro
+		WHERE lang = 'zh-Hans' AND source_id = 18
+	)
+	SELECT w.id AS work_id, zhi.intro,
+	       wc.character_id, c.display_name,
+	       COALESCE((
+	         SELECT a.name FROM catalog_character_alias a
+	         WHERE a.character_id = c.id AND a.lang IN ('zh-Hans','zh','zh-Hant') AND a.kind IN (0,1)
+	         ORDER BY (NOT a.is_primary_for_locale), (a.lang <> 'zh-Hans'), a.id LIMIT 1
+	       ), '') AS zh_name,
+	       der.id AS derived_id, der.src_hash AS derived_hash
+	FROM catalog_work w
+	JOIN zhi ON zhi.work_id = w.id
+	JOIN catalog_work_character wc ON wc.work_id = w.id
+	JOIN catalog_character c ON c.id = wc.character_id AND c.deleted_at IS NULL
+	JOIN der ON der.character_id = wc.character_id
+	WHERE w.deleted_at IS NULL
+	  AND ` + editspec.NotSuppressedRosterSQL("wc") + `
+	  AND NOT EXISTS (
+	    SELECT 1 FROM catalog_work_character wc2
+	    JOIN catalog_work_intro wi2 ON wi2.work_id = wc2.work_id AND wi2.lang = 'zh-Hans'
+	    WHERE wc2.character_id = wc.character_id
+	      AND encode(sha256(convert_to(wi2.intro,'UTF8')),'hex') = der.src_hash)`
+
+func loadRefreshCandidateWorks(ctx context.Context, db *gorm.DB, o candidateOpts) ([]candidateWork, error) {
+	sql := candidateRefreshWorksSQL + sinceClause(o.Since) + `
+	ORDER BY w.id, wc.character_id`
+	var rows []struct {
+		WorkID      int64  `gorm:"column:work_id"`
+		Intro       string `gorm:"column:intro"`
+		CharacterID int64  `gorm:"column:character_id"`
+		DisplayName string `gorm:"column:display_name"`
+		ZhName      string `gorm:"column:zh_name"`
+		DerivedID   int64  `gorm:"column:derived_id"`
+		DerivedHash string `gorm:"column:derived_hash"`
+	}
+	if err := db.WithContext(ctx).Raw(sql, sinceArgs(o.Since)...).Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("load refresh candidate works: %w", err)
+	}
+	var out []candidateWork
+	for _, r := range rows {
+		if len(out) == 0 || out[len(out)-1].WorkID != r.WorkID {
+			out = append(out, candidateWork{WorkID: r.WorkID, Intro: r.Intro})
+		}
+		cur := &out[len(out)-1]
+		cur.Roster = append(cur.Roster, rosterChar{
+			CharacterID: r.CharacterID, Name: r.DisplayName, ZhName: r.ZhName,
+			DerivedID: r.DerivedID, DerivedHash: r.DerivedHash,
+		})
+	}
+	return window(out, o), nil
+}

--- a/apps/api/cmd/extract-char-intros/refresh_test.go
+++ b/apps/api/cmd/extract-char-intros/refresh_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sayaPassage = "主人公的青梅竹马,性格开朗,总是照顾身边的每一个人。"
+
+func seedDerivedRow(t *testing.T, characterID int64, intro, srcHash string) {
+	t.Helper()
+	require.NoError(t, testDB.Exec(`INSERT INTO catalog_character_intro
+		(character_id, lang, intro, source_id, provenance, src_hash, mt_model, created_at, updated_at)
+		VALUES (?, 'zh-Hans', ?, 18, 1, ?, 'glm-5.2', now(), now())`,
+		characterID, intro, srcHash).Error)
+}
+
+func TestRefreshBucketHoldsOnlyStaleRows(t *testing.T) {
+	require.NoError(t, testDB.Exec(`TRUNCATE catalog_work, catalog_character RESTART IDENTITY CASCADE`).Error)
+	workID := seedWorkWithIntro(t, longIntro)
+	fresh := seedRosterChar(t, workID, "沙耶")
+	stale := seedRosterChar(t, workID, "玲")
+	seedDerivedRow(t, fresh, sayaPassage, hashText(longIntro))
+	seedDerivedRow(t, stale, "转校生,沉默寡言。", hashText("这是被替换掉的旧简介。"))
+
+	cands, err := loadRefreshCandidateWorks(context.Background(), testDB, candidateOpts{})
+	require.NoError(t, err)
+	require.Len(t, cands, 1)
+	require.Len(t, cands[0].Roster, 1, "a row whose hash still matches the current intro is not stale")
+	assert.Equal(t, stale, cands[0].Roster[0].CharacterID)
+	assert.Equal(t, hashText("这是被替换掉的旧简介。"), cands[0].Roster[0].DerivedHash)
+}
+
+// A character on two works is stale only when NO work of theirs still carries
+// the intro the excerpt came from — otherwise the row is live and the other
+// work would rewrite it with a passage from a different game.
+func TestRefreshBucketSkipsRowsLiveOnAnotherWork(t *testing.T) {
+	require.NoError(t, testDB.Exec(`TRUNCATE catalog_work, catalog_character RESTART IDENTITY CASCADE`).Error)
+	other := "另一部作品的简介。" + longIntro
+	workA := seedWorkWithIntro(t, longIntro)
+	workB := seedWorkWithIntro(t, other)
+	saya := seedRosterChar(t, workA, "沙耶")
+	require.NoError(t, testDB.Exec(`INSERT INTO catalog_work_character
+		(work_id, character_id, kind, spoiler, matched_by, created_at, updated_at)
+		VALUES (?, ?, 0, 0, 'test', now(), now())`, workB, saya).Error)
+	seedDerivedRow(t, saya, sayaPassage, hashText(other))
+
+	cands, err := loadRefreshCandidateWorks(context.Background(), testDB, candidateOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, cands)
+}
+
+func TestRunRefreshRewritesInPlace(t *testing.T) {
+	require.NoError(t, testDB.Exec(`TRUNCATE catalog_work, catalog_character RESTART IDENTITY CASCADE`).Error)
+	workID := seedWorkWithIntro(t, longIntro)
+	saya := seedRosterChar(t, workID, "沙耶")
+	seedDerivedRow(t, saya, "主人公的青梅竹马、Saya。", hashText("旧简介"))
+
+	ex := fakeExtractor{out: map[string]string{"沙耶": sayaPassage}}
+	require.NoError(t, run(context.Background(), testDB, ex, nil, opts{Apply: true, Refresh: true}))
+
+	var rows []struct {
+		Intro   string `gorm:"column:intro"`
+		SrcHash string `gorm:"column:src_hash"`
+	}
+	require.NoError(t, testDB.Raw(`SELECT intro, src_hash FROM catalog_character_intro
+		WHERE character_id = ?`, saya).Scan(&rows).Error)
+	require.Len(t, rows, 1, "the stale row is rewritten, not duplicated")
+	assert.Equal(t, sayaPassage, rows[0].Intro)
+	assert.Equal(t, hashText(longIntro), rows[0].SrcHash)
+
+	cands, err := loadRefreshCandidateWorks(context.Background(), testDB, candidateOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, cands, "the refreshed row leaves the bucket")
+}
+
+func TestRunRefreshKeepsTheRowWhenNothingIsExtractable(t *testing.T) {
+	require.NoError(t, testDB.Exec(`TRUNCATE catalog_work, catalog_character RESTART IDENTITY CASCADE`).Error)
+	workID := seedWorkWithIntro(t, longIntro)
+	saya := seedRosterChar(t, workID, "沙耶")
+	seedDerivedRow(t, saya, "旧的摘录。", hashText("旧简介"))
+
+	// Nothing extractable, and an invented passage: neither may erase the row.
+	invented := "其实是来自未来的魔法使,为了拯救这座城市而隐藏身份潜入学园。"
+	for _, out := range []map[string]string{{}, {"沙耶": invented}} {
+		require.NoError(t, run(context.Background(), testDB, fakeExtractor{out: out}, nil,
+			opts{Apply: true, Refresh: true}))
+		var intro string
+		require.NoError(t, testDB.Raw(`SELECT intro FROM catalog_character_intro
+			WHERE character_id = ?`, saya).Scan(&intro).Error)
+		assert.Equal(t, "旧的摘录。", intro, "a character never loses its intro to a failed refresh")
+	}
+}
+
+func TestSinceFiltersOnTheElectedIntro(t *testing.T) {
+	require.NoError(t, testDB.Exec(`TRUNCATE catalog_work, catalog_character RESTART IDENTITY CASCADE`).Error)
+	workID := seedWorkWithIntro(t, longIntro)
+	seedRosterChar(t, workID, "沙耶")
+	require.NoError(t, testDB.Exec(`UPDATE catalog_work_intro SET updated_at = '2026-01-02T03:04:05Z'
+		WHERE work_id = ?`, workID).Error)
+
+	cands, err := loadCandidateWorks(context.Background(), testDB, candidateOpts{Since: "2026-01-01T00:00:00Z"})
+	require.NoError(t, err)
+	assert.Len(t, cands, 1)
+
+	cands, err = loadCandidateWorks(context.Background(), testDB, candidateOpts{Since: "2026-02-01T00:00:00Z"})
+	require.NoError(t, err)
+	assert.Empty(t, cands, "an intro that has not changed since the cutoff is not re-scanned")
+}

--- a/apps/api/cmd/extract-char-intros/write.go
+++ b/apps/api/cmd/extract-char-intros/write.go
@@ -25,6 +25,7 @@ const minIntroRunes = 20
 type stats struct {
 	Extracted          int
 	Inserted           int
+	Updated            int
 	Conflict           int
 	RefusedNotVerbatim int
 	RefusedShort       int
@@ -40,6 +41,7 @@ type stats struct {
 type writer struct {
 	db      *gorm.DB
 	apply   bool
+	refresh bool
 	st      *stats
 	samples int
 	shown   int
@@ -48,15 +50,27 @@ type writer struct {
 	delay   time.Duration
 }
 
-// write files one work's extraction results. Every passage passes the verbatim
-// gate against the work intro before anything else is considered.
-func (w *writer) write(ctx context.Context, cand candidateWork, found map[string]string, mtModel string) {
+// gated is one passage that survived every deterministic gate, ready to be
+// written — or, when the character holds an incumbent, to be put to the panel.
+type gated struct {
+	WorkID  int64
+	Target  rosterChar
+	Passage string
+	SrcHash string
+	MTModel string
+}
+
+// gate runs one work's extraction results through the deterministic gates.
+// Every passage passes the verbatim gate against the work intro before
+// anything else is considered. Judging is NOT done here: the panel votes are
+// batched across works, so gate only sorts the survivors into those that can
+// be written straight away and those that need a verdict first.
+func (w *writer) gate(cand candidateWork, found map[string]string, mtModel string) (ready, contested []gated) {
 	byName := make(map[string]rosterChar, len(cand.Roster))
 	for _, r := range cand.Roster {
 		byName[r.Name] = r
 	}
 	srcHash := hashText(cand.Intro)
-	wrote := false
 	for name, passage := range found {
 		w.st.Extracted++
 		target, ok := byName[strings.TrimSpace(name)]
@@ -81,79 +95,153 @@ func (w *writer) write(ctx context.Context, cand candidateWork, found map[string
 				"character", target.CharacterID, "name", name)
 			continue
 		}
+		g := gated{WorkID: cand.WorkID, Target: target, Passage: passage, SrcHash: srcHash, MTModel: mtModel}
 		if target.Incumbent != "" && w.judge != nil {
-			adopted, err := w.runPanel(ctx, cand.WorkID, target, passage)
-			if err != nil {
-				w.st.PanelErrors++
-				slog.Warn("panel failed — incumbent stays, retryable", "work", cand.WorkID,
-					"character", target.CharacterID, "err", err)
-				continue
-			}
-			if !adopted {
-				w.st.PanelKept++
-				continue
-			}
-			w.st.PanelAdopted++
+			contested = append(contested, g)
+			continue
 		}
 		if w.shown < w.samples {
 			fmt.Printf("  sample: work=%d %s → %s\n", cand.WorkID, name, truncate(passage, 80))
 			w.shown++
 		}
-		if !w.apply {
-			continue
-		}
-		res := w.db.WithContext(ctx).Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "character_id"}, {Name: "lang"}, {Name: "source_id"}},
-			DoNothing: true,
-		}).Create(&model.CatalogCharacterIntro{
-			CharacterID: target.CharacterID,
-			Lang:        "zh-Hans",
-			Intro:       passage,
-			SourceID:    sourceDerived,
-			Provenance:  model.IntroProvenanceMachine,
-			SrcHash:     srcHash,
-			MTModel:     mtModel,
-		})
-		if res.Error != nil {
-			w.st.CallErrors++
-			slog.Warn("insert extracted intro", "work", cand.WorkID, "character", target.CharacterID, "err", res.Error)
-			continue
-		}
-		if res.RowsAffected == 0 {
-			w.st.Conflict++
-			continue
-		}
-		w.st.Inserted++
-		wrote = true
+		ready = append(ready, g)
 	}
-	if wrote {
-		w.touched = append(w.touched, cand.WorkID)
-	}
+	return ready, contested
 }
 
-// runPanel takes one gated extraction through three judge votes, alternating
-// which passage is shown first so a position bias cannot decide the verdict.
-func (w *writer) runPanel(ctx context.Context, workID int64, target rosterChar, challenger string) (bool, error) {
-	votes := make([]panelVote, 0, panelVotes)
-	for i := range panelVotes {
-		if i > 0 && w.delay > 0 {
-			time.Sleep(w.delay)
-		}
-		v, err := w.judge.Compare(ctx, target.Name, target.Incumbent, challenger, i%2 == 1)
-		if err != nil {
-			return false, err
-		}
-		votes = append(votes, v)
+// commit writes one gated passage: a fresh derived row, or a rewrite of the
+// stale one in the refresh bucket.
+func (w *writer) commit(ctx context.Context, g gated) {
+	if !w.apply {
+		return
 	}
-	adopted := panelVerdict(votes)
-	slog.Info("panel verdict", "work", workID, "character", target.CharacterID,
-		"name", target.Name, "adopted", adopted, "votes", fmt.Sprintf("%v", votes))
-	if w.shown < w.samples {
-		fmt.Printf("  panel: work=%d %s adopted=%v\n    A(现有): %s\n    B(提取): %s\n",
-			workID, target.Name, adopted, truncate(target.Incumbent, 70), truncate(challenger, 70))
-		w.shown++
+	if w.refresh {
+		if w.rewrite(ctx, g.WorkID, g.Target, g.Passage, g.SrcHash, g.MTModel) {
+			w.touched = append(w.touched, g.WorkID)
+		}
+		return
 	}
-	return adopted, nil
+	res := w.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "character_id"}, {Name: "lang"}, {Name: "source_id"}},
+		DoNothing: true,
+	}).Create(&model.CatalogCharacterIntro{
+		CharacterID: g.Target.CharacterID,
+		Lang:        "zh-Hans",
+		Intro:       g.Passage,
+		SourceID:    sourceDerived,
+		Provenance:  model.IntroProvenanceMachine,
+		SrcHash:     g.SrcHash,
+		MTModel:     g.MTModel,
+	})
+	if res.Error != nil {
+		w.st.CallErrors++
+		slog.Warn("insert extracted intro", "work", g.WorkID, "character", g.Target.CharacterID, "err", res.Error)
+		return
+	}
+	if res.RowsAffected == 0 {
+		w.st.Conflict++
+		return
+	}
+	w.st.Inserted++
+	w.touched = append(w.touched, g.WorkID)
+}
+
+// rewrite replaces a stale derived row in place. The src_hash it was loaded
+// with is the update guard: a character on two candidate works is offered once
+// per work, and the first refresh moves the hash, so the second work's write
+// becomes a no-op instead of overwriting it with a different work's passage.
+// Nothing is deleted when the fresh intro yields no passage — the old excerpt
+// stays until a later run can replace it, so no character loses its intro.
+func (w *writer) rewrite(ctx context.Context, workID int64, target rosterChar, passage, srcHash, mtModel string) bool {
+	res := w.db.WithContext(ctx).Model(&model.CatalogCharacterIntro{}).
+		Where("id = ? AND src_hash = ?", target.DerivedID, target.DerivedHash).
+		Updates(map[string]any{"intro": passage, "src_hash": srcHash, "mt_model": mtModel})
+	if res.Error != nil {
+		w.st.CallErrors++
+		slog.Warn("refresh derived intro", "work", workID, "character", target.CharacterID, "err", res.Error)
+		return false
+	}
+	if res.RowsAffected == 0 {
+		w.st.Conflict++
+		return false
+	}
+	w.st.Updated++
+	return true
+}
+
+// voteDispatcher casts one round of votes and answers in the same order. It
+// owns the batching and the concurrency; resolvePanel owns the semantics.
+type voteDispatcher func(ctx context.Context, cmps []comparison) []comparisonResult
+
+// resolvePanel takes every contested passage through three votes, one round at
+// a time so a whole round can travel as one batch. Which passage is shown
+// first alternates by round, so a position bias cannot decide the verdict. A
+// vote that errors drops that character out of the round: the incumbent stays
+// and the character remains a candidate, so a later run re-judges it.
+func (w *writer) resolvePanel(ctx context.Context, contested []gated, dispatch voteDispatcher) []gated {
+	if len(contested) == 0 {
+		return nil
+	}
+	votes := make([][]panelVote, len(contested))
+	failed := make([]bool, len(contested))
+	for round := range panelVotes {
+		cmps := make([]comparison, 0, len(contested))
+		idx := make([]int, 0, len(contested))
+		for i, g := range contested {
+			if failed[i] {
+				continue
+			}
+			cmps = append(cmps, comparison{
+				Name: g.Target.Name, Incumbent: g.Target.Incumbent,
+				Challenger: g.Passage, ChallengerFirst: round%2 == 1,
+			})
+			idx = append(idx, i)
+		}
+		if len(cmps) == 0 {
+			break
+		}
+		res := dispatch(ctx, cmps)
+		if len(res) != len(cmps) {
+			for _, i := range idx {
+				failed[i] = true
+				w.st.PanelErrors++
+			}
+			slog.Warn("panel round answered the wrong number of votes", "want", len(cmps), "got", len(res))
+			continue
+		}
+		for j, r := range res {
+			i := idx[j]
+			if r.Err != nil {
+				failed[i] = true
+				w.st.PanelErrors++
+				slog.Warn("panel failed — incumbent stays, retryable", "work", contested[i].WorkID,
+					"character", contested[i].Target.CharacterID, "err", r.Err)
+				continue
+			}
+			votes[i] = append(votes[i], r.Vote)
+		}
+	}
+	var adopted []gated
+	for i, g := range contested {
+		if failed[i] {
+			continue
+		}
+		ok := panelVerdict(votes[i])
+		slog.Info("panel verdict", "work", g.WorkID, "character", g.Target.CharacterID,
+			"name", g.Target.Name, "adopted", ok, "votes", fmt.Sprintf("%v", votes[i]))
+		if w.shown < w.samples {
+			fmt.Printf("  panel: work=%d %s adopted=%v\n    A(现有): %s\n    B(提取): %s\n",
+				g.WorkID, g.Target.Name, ok, truncate(g.Target.Incumbent, 70), truncate(g.Passage, 70))
+			w.shown++
+		}
+		if !ok {
+			w.st.PanelKept++
+			continue
+		}
+		w.st.PanelAdopted++
+		adopted = append(adopted, g)
+	}
+	return adopted
 }
 
 func (w *writer) flushTouch(ctx context.Context) error {


### PR DESCRIPTION
## Why

Wave 213 retranslated 27,476 work intros. A derived character intro (`source_id=18`) is an **excerpt** of the work intro it was taken from, so those rewrites left the excerpts behind: **1,333 of the 1,690 derived rows (79%)** now carry a `src_hash` that matches none of their works' current zh intros, and a fair containment probe finds only 278 of them still present in the live text. They keep the exact defect 213 fixed — character 80333 (中文名 麻鸟时雨) still reads 「トモエ的侧近侍从…シグレ也做好了…」.

Neither existing bucket can reach them: fill skips any character that has a zh row, panel skips any character that has a derived row. The tool has always **written** `src_hash` and never **read** it; this PR closes that loop.

## What

- **`--refresh`** — third bucket: derived rows stale against every one of their works' current intros. Re-extract from the fresh intro, pass the same verbatim / name-appears gates, and rewrite in place guarded on the `src_hash` that was loaded (a character on two candidate works cannot be clobbered by the second). **Nothing is deleted when no passage comes back** — no character loses its intro to a failed run.
- **`--since`** — narrows fill and panel to works whose *elected* zh intro changed at or after a cutoff, so a re-scan does not blindly re-judge the 864 / 1,804 works wave 178 already judged.
- **`--gateway cursor`** — Cursor Cloud Agents lane. Cursor has no chat/completions route, so one agent run carries a whole batch; each run pays ~14k input tokens of fixed overhead, which makes the batch (not the concurrency) the economic lever. Batch integrity gate + one halve-and-retry ported from wave 210: a reply that drops the tail fails whole instead of filing every passage onto the wrong work.
- Extraction and judging now run concurrently and are delivered in order; the panel votes travel one round per batch instead of three calls per character.
- The deterministic gates and the write path stay exactly where they were. The lane is a transport, not a second implementation.

## Measured

| | works | wall clock | call errors |
|---|---|---|---|
| Cursor, batch 25 × 4 workers | 100 | 70s | 0 |
| Cursor, batch 25 × 8 workers | 200 | ~85s | 0 |
| CF fleet (wave 178, for scale) | 8,344 | 23.5h / 8 shards | 702 |

~86 works/min against ~12 for the CF fleet, and it does not share prod's inference quota — wave 178's fleet pushed prod's moderation gate to a 2.2% fail-open rate.

Prompt calibration on a fixed window: telling the model that rewriting is discarded took verbatim refusals from 8/22 to 0/18 (second window 6/42) and lifted accepted passages per 100 works from 7 to ~10.5. `effort=medium` on the same window changed nothing (9 refusals vs 8) for 46% more wall clock → the lane stays on `low`.

## Tests

22 green (`kun_ephem_20260822_w214p3`), 12 new: refresh bucket membership incl. the multi-work live case, in-place rewrite, the row surviving a failed refresh, `--since`, the Cursor run lifecycle over httptest, the integrity gate's five failure shapes, halve-and-retry both ways, dispatcher chunking and ordering, and a failed panel round leaving the incumbent.

No schema change, no migration.