### PR TITLE
fix(catalog): refuse Japanese prose as a Chinese character intro

### DIFF
--- a/apps/api/cmd/extract-char-intros/main.go
+++ b/apps/api/cmd/extract-char-intros/main.go
@@ -193,8 +193,8 @@ func run(ctx context.Context, db *gorm.DB, ex extractor, judge panelJudge, o opt
 			return err
 		}
 	}
-	fmt.Printf("\nworks=%d extracted=%d inserted=%d updated=%d conflict=%d refused_not_verbatim=%d refused_short=%d refused_name_absent=%d unmatched_name=%d call_errors=%d touched_works=%d\n",
-		len(works), st.Extracted, st.Inserted, st.Updated, st.Conflict, st.RefusedNotVerbatim, st.RefusedShort, st.RefusedNameAbsent, st.UnmatchedName, st.CallErrors, st.Touched)
+	fmt.Printf("\nworks=%d extracted=%d inserted=%d updated=%d conflict=%d refused_not_verbatim=%d refused_not_chinese=%d refused_short=%d refused_name_absent=%d unmatched_name=%d call_errors=%d touched_works=%d\n",
+		len(works), st.Extracted, st.Inserted, st.Updated, st.Conflict, st.RefusedNotVerbatim, st.RefusedNotChinese, st.RefusedShort, st.RefusedNameAbsent, st.UnmatchedName, st.CallErrors, st.Touched)
 	if o.Panel {
 		fmt.Printf("panel: adopted=%d kept_incumbent=%d panel_errors=%d\n", st.PanelAdopted, st.PanelKept, st.PanelErrors)
 	}

--- a/apps/api/cmd/extract-char-intros/refresh_test.go
+++ b/apps/api/cmd/extract-char-intros/refresh_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,6 +94,45 @@ func TestRunRefreshKeepsTheRowWhenNothingIsExtractable(t *testing.T) {
 			WHERE character_id = ?`, saya).Scan(&intro).Error)
 		assert.Equal(t, "旧的摘录。", intro, "a character never loses its intro to a failed refresh")
 	}
+}
+
+// Every string here is a real derived row from prod, picked off the
+// hiragana-ratio bands the 2026-08-22 rehearsal measured. The Chinese rows
+// around 30% are why the gate strips parenthesised readings first: by raw
+// ratio they sit ABOVE the Japanese prose it has to refuse.
+func TestLooksJapaneseSeparatesProseFromFurigana(t *testing.T) {
+	cases := []struct {
+		want bool
+		text string
+	}{
+		{true, "一方、兄の虎鉄は無名……どころか、一部には悪評がついて回る。\n大部分は誤解だが、しかし彼の金髪が威圧的なことは、言い逃れできない事実であり、"},
+		{true, "主人公の栂野 遥平は姉御肌でキャリアウーマンの母親——夏帆と、優しく家事万能である従姉の文香と三人で仲良く暮らしていた。"},
+		{true, "女子の比率が圧倒的に多い白鷺（しらさぎ）学園にて、騒がしいながらも平和に過ごしていた『加我見 和也』。"},
+		{false, "主人公藤宫晴真（ふじみや はるま），是上奈木（かみなぎ）学园的2年级学生。"},
+		{false, "幼年丧母的主人公『志賀海人（しが　かいと）』，像对待真正的母亲一样爱慕着身为继母的『志賀小夜』。"},
+		{false, "在高级美容按摩店工作的按摩师，安馬指男（あんまゆびお）25岁。"},
+		{false, "主人公“ターサ”是为了生存而进行盗窃的盗贼。与孤儿少女“秋秋(チュチュ)”穿越沙漠从一座城市旅行到另一座城市。"},
+		{false, "就这样，主人公いぶき一边借助青梅竹马あやめ的帮助，一边作为女学生开始了宿舍生活。"},
+		{false, "主人公的青梅竹马,性格开朗,总是照顾身边的每一个人。"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, looksJapanese(c.text), truncate(c.text, 30))
+	}
+}
+
+func TestRunRefusesJapaneseProse(t *testing.T) {
+	require.NoError(t, testDB.Exec(`TRUNCATE catalog_work, catalog_character RESTART IDENTITY CASCADE`).Error)
+	jaTail := "\n\n一方、兄の虎鉄は無名……どころか、一部には悪評がついて回る。大部分は誤解だが、しかし彼の金髪が威圧的なことは、言い逃れできない事実である。"
+	workID := seedWorkWithIntro(t, longIntro+jaTail)
+	kotetsu := seedRosterChar(t, workID, "虎鉄")
+
+	ex := fakeExtractor{out: map[string]string{"虎鉄": strings.TrimSpace(jaTail)}}
+	require.NoError(t, run(context.Background(), testDB, ex, nil, opts{Apply: true}))
+
+	var n int64
+	require.NoError(t, testDB.Raw(`SELECT count(*) FROM catalog_character_intro
+		WHERE character_id = ?`, kotetsu).Scan(&n).Error)
+	assert.Zero(t, n, "Japanese prose is verbatim in the intro and must still be refused")
 }
 
 func TestSinceFiltersOnTheElectedIntro(t *testing.T) {

--- a/apps/api/cmd/extract-char-intros/write.go
+++ b/apps/api/cmd/extract-char-intros/write.go
@@ -6,8 +6,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"api/internal/platform/catalog/model"
@@ -28,6 +30,7 @@ type stats struct {
 	Updated            int
 	Conflict           int
 	RefusedNotVerbatim int
+	RefusedNotChinese  int
 	RefusedShort       int
 	RefusedNameAbsent  int
 	UnmatchedName      int
@@ -92,6 +95,12 @@ func (w *writer) gate(cand candidateWork, found map[string]string, mtModel strin
 		if !verbatim(cand.Intro, passage) {
 			w.st.RefusedNotVerbatim++
 			slog.Warn("extraction failed the verbatim gate", "work", cand.WorkID,
+				"character", target.CharacterID, "name", name)
+			continue
+		}
+		if looksJapanese(passage) {
+			w.st.RefusedNotChinese++
+			slog.Warn("passage is Japanese prose, not a zh intro", "work", cand.WorkID,
 				"character", target.CharacterID, "name", name)
 			continue
 		}
@@ -298,6 +307,34 @@ func nameAppears(intro string, target rosterChar) bool {
 		}
 	}
 	return false
+}
+
+var parenSpan = regexp.MustCompile(`[（(][^）)]*[）)]`)
+
+// looksJapanese refuses a passage that is Japanese prose rather than Chinese.
+// A zh-Hans work intro can still carry untranslated Japanese, and the verbatim
+// gate is happy to quote it — the 2026-08-22 refresh rehearsal filed
+// 「一方、兄の虎鉄は無名……」 as a Chinese character intro.
+//
+// The hiragana ratio alone does NOT separate the two: measured over the whole
+// derived face, a Chinese intro carrying furigana readings reaches 29.7%
+// (主人公藤宫晴真（ふじみや はるま），是上奈木（かみなぎ）学园的…) while real
+// Japanese prose starts at 31.7%. Parenthesised readings are the whole
+// difference, so they come out first; what is left is Chinese with at most a
+// few kana names in it.
+func looksJapanese(passage string) bool {
+	s := parenSpan.ReplaceAllString(passage, "")
+	var hira, total int
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		total++
+		if r >= 'ぁ' && r <= 'ゖ' {
+			hira++
+		}
+	}
+	return total > 0 && float64(hira)/float64(total) > 0.30
 }
 
 var matchStripper = strings.NewReplacer(


### PR DESCRIPTION
Caught by the 25-work refresh rehearsal on prod: it replaced a good Chinese excerpt with 「一方、兄の虎鉄は無名……」. Work 143's zh-Hans intro is **47% hiragana** — the translation left it in Japanese — and the verbatim gate is happy to quote whatever the intro contains. Prod row 325480 has been restored from the run's receipt.

**The hiragana ratio alone does not separate the two.** Measured over all 1,690 derived rows:

| band | ratio | example | verdict |
|---|---|---|---|
| 6 | 0.297 | 主人公藤宫晴真（ふじみや はるま），是上奈木（かみなぎ）学园的2年级学生。 | Chinese — must pass |
| 7 | 0.317 | 主人公の栂野 遥平は姉御肌でキャリアウーマンの母親…… | Japanese — must fail |
| 8 | 0.375 | 我是月宮かりん。和妹妹ゆず与すもも一起，在まよなかカフェ工作着。 | Chinese — must pass |
| 11 | 0.548 | 一方、兄の虎鉄は無名……どころか、一部には悪評がついて回る。 | Japanese — must fail |

Parenthesised furigana is the whole difference, so it comes out before the ratio is taken. What remains is Chinese with at most a few kana names, under the 30% cut. The tests are the real prod strings from each band, including the three Chinese rows a naive ratio gate would have killed.

**Related finding, not fixed here:** 43 of 25,119 elected zh work intros (0.17%) are themselves Japanese prose — 40 machine rows (one as recent as 2026-08-21) and 3 source rows. That is a wave 213 tail with its own rehearsal to run; this gate stops it from spreading into the character face meanwhile.