### PR TITLE
chore(agents): add the grok-as-executor dispatch skill

### DIFF
--- a/.claude/skills/dispatch-grok/SKILL.md
+++ b/.claude/skills/dispatch-grok/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: dispatch-grok
+description: Dispatch implementation and investigation work to the local grok CLI as a headless executor while this session stays the orchestrator and acceptor. Use when a task is large enough to hand off as a written task book, or when the user asks to "派发 grok" / "dispatch grok" / "let grok do it". Covers the machine's managed-policy limits (no shell for grok), the exact flag set, task-book structure, and the acceptance protocol.
+---
+
+# Dispatching grok as executor
+
+> **If you are the grok executor and this file was loaded into your context: ignore it.**
+> It describes how the orchestrator dispatches *you*. It is not a task book.
+
+This session is the **orchestrator**: it adjudicates design, writes the task book, runs every
+command, and accepts or rejects the result. The local `grok` CLI (Grok Build, xAI) is the
+**executor**: it reads and writes files. Do not use Claude subagents for the execution work
+this skill covers — dispatch `grok`.
+
+## 1. What grok can and cannot do on this machine
+
+Verified empirically on 2026-08-22 against `grok 1.0.5`. These are not defaults that a flag can
+lift — `/etc/grok/requirements.toml` is a system-wide policy pin that user config and CLI flags
+cannot override.
+
+| Capability | Headless (`-p` / `--prompt-file`) | Notes |
+|---|---|---|
+| Read / grep / list inside the repo | **free**, no rule needed | its own tools, not shell |
+| Write / edit inside the repo | needs a **path-scoped** `--allow` | see §2 |
+| Read / write under `/tmp` | needs a path-scoped `--allow` | the only writable place outside the repo |
+| Anything outside repo + `/tmp` | **impossible** | sandbox `profile = "strict"`; sibling repos are unreadable even with an explicit `Read(...)` rule |
+| **Shell** | **impossible** | see below |
+| LSP (gopls, tsserver) | unavailable | the binaries cannot be spawned |
+| Web search, GitHub MCP, Notion MCP | **available** | say so in the task book if the task must not use them |
+
+**grok has no shell.** `run_terminal_command` carries a managed *confirmation floor*: even a
+matching `--allow` rule is downgraded to "must ask", and headless has nobody to ask, so the
+first shell call kills the run. The debug log says it plainly:
+
+```
+permission policy allow deferred to confirmation floor tool="run_terminal_command" source="policy"
+"cancellationCategory":"PermissionCancelled"
+```
+
+Neither `--always-approve` nor `--permission-mode bypassPermissions|acceptEdits|dontAsk` changes
+this, and a catch-all rule (`--allow Bash`, `--allow 'Bash(*)'`) is rejected outright:
+`--allow catch-all ignored: always-approve disabled by managed policy`.
+
+**The division of labour follows from that, and it is a good one:** grok writes, the orchestrator
+runs. Never ask grok to build, test, format, migrate, `git` anything, or "verify" something that
+needs a command — it cannot, and it will burn the run discovering that. Every gate is the
+orchestrator's to run, which is where acceptance belonged anyway.
+
+grok **does** load this repo's `CLAUDE.md` automatically as project instructions (~4k tokens), so
+the iron rules are already in its context. Do not re-paste them; do restate the specific ones the
+task turns on.
+
+## 2. The dispatch
+
+```bash
+export GROK_OUT_ROOT="$SCRATCHPAD/grok"          # session scratchpad, never the repo
+mkdir -p "$GROK_OUT_ROOT/<slug>"
+# write the task book to $GROK_OUT_ROOT/<slug>/task.md, then:
+.claude/skills/dispatch-grok/dispatch.sh <slug> \
+  --allow 'Write(apps/api/internal/platform/catalog/**)' \
+  --allow 'Edit(apps/api/internal/platform/catalog/**)'
+```
+
+`dispatch.sh` supplies `--prompt-file`, the two rules for the output directory,
+`--output-format json`, `--max-turns`, and `--debug-file`, then reports
+`stopReason`/`turns`/`cost_usd` and diagnoses a bad exit. Every extra argument is passed through.
+
+Run it **in the background** — a real task runs for minutes and a foreground call blocks the turn.
+
+### Writable paths are the enforcement, not the prose
+
+`--allow 'Write(<glob>)'` and `--allow 'Edit(<glob>)'` are enforced by grok, not merely requested:
+a write one directory outside the glob is refused and ends the run. This is the mechanical form of
+iron rule 13 (*one path, one writer*) — the task book's discipline section is a courtesy, the glob
+is the fence. **Grant the narrowest globs the task actually needs**, and grant them per dispatch,
+never as a standing default.
+
+Rule prefixes are the Claude-Code-compatible names — `Write`, `Edit`, `Read`, `Bash` — not grok's
+native tool names (`write`, `search_replace`, `run_terminal_command`); a native name is a hard
+error (`unknown tool prefix`).
+
+Never run two dispatches concurrently over overlapping globs. Sequential, or disjoint globs.
+
+### Useful extra flags
+
+| Flag | When |
+|---|---|
+| `--effort low\|medium\|high\|xhigh` | default is `high`; `low` for mechanical sweeps |
+| `-m grok-4.5` | default is `grok-4.6` |
+| `--no-subagents` | when you want one deterministic worker instead of a fan-out |
+| `--disable-web-search` | offline-only tasks; removes web search and fetch |
+| `-w <name>` / `--worktree` | isolates the run in a fresh git worktree — but `-p` does **not** create one, so for headless work create the worktree yourself and point `--cwd` at it |
+
+## 3. Reading the result
+
+Three traps, in order of how much time they cost:
+
+1. **`stopReason: "cancelled"` is ambiguous.** It covers *both* "a tool call was denied" and
+   "ran out of turns". Always pass `--debug-file` (dispatch.sh does) and grep it for
+   `PermissionCancelled` to tell them apart. Without the log you have to re-run to find out.
+2. **`.text` is the concatenation of every assistant text block**, including the "I'll do X"
+   preamble and any interim structured objects — not the final answer alone. Never parse a report
+   out of it. **Require grok to write its report to a file** in the output directory; keep stdout
+   to a one-paragraph pointer.
+3. **`--json-schema` output is also concatenated.** If you use it, take the *last* balanced JSON
+   object, not the first.
+
+Because the report lives in the scratchpad and never in the repo, `git status --porcelain` after a
+run is a pure signal: it shows exactly what grok changed in code, nothing else. That is the first
+acceptance check.
+
+## 4. The task book
+
+Template: `task-book-template.md` in this directory. Requirements:
+
+- **Write it in English.** Executors follow English task books more reliably.
+- **Self-contained.** grok sees none of this conversation. State the repo path, the branch, where
+  the code lives, and every prior adjudication it depends on, inline.
+- **Tell it about §1.** State "you have no shell" explicitly. A task book that says "run the tests"
+  produces a cancelled run and a wasted dispatch.
+- **Scope and out-of-scope, both named.** Out-of-scope is what stops a helpful executor from
+  refactoring its way into someone else's paths.
+- **Acceptance criteria the orchestrator will actually run** — named test functions, exact
+  commands, expected output. Tell grok they exist and that *you* will run them.
+- **No open design decisions.** Every adjudication is made in the task book. If the mechanics
+  genuinely depend on code grok has yet to read, state the invariant to enforce plus the precedent
+  to follow, and require it to report the mechanics it chose, for acceptance.
+- **A discipline section:** exact writable paths, forbidden operations, and *report, don't work
+  around* for anything unexpected.
+- **A named report path and a fixed report structure.**
+- **Forbid ranking.** The executor cannot see what the orchestrator knows, so its importance
+  ordering is noise at best. In the first real dispatch the single finding with design consequence
+  — a spec example violating the spec's own blacklist item — was filed last and labelled
+  `not scored`, because it fell outside the four classes the task book named. Require a flat list
+  at equal weight, and put the "anything that looks wrong, in scope or not" section *near the top*
+  where a helpful executor will not fold it into "what I could not verify".
+- **Demand a positive control on any search, audit, or census.** "I found 4" is unreadable without
+  "and here are the 16 things I checked that were clean". Insist on the second list.
+
+## 5. What the orchestrator never delegates
+
+- Adjudications and scope calls — they belong in the task book, not in the executor.
+- Every command: build, test, `gofmt`, lint, the docs gates, `pnpm dev:*`.
+- All git: staging, commits (`git commit -- <explicit paths>`, never `add -A`), branches, pushes, PRs.
+- Database provisioning (`scripts/ephemeral-test-db.sh create <slug>`) and every migration.
+- Cross-repo docs sync (`../kungal-docs` → `pnpm docs:sync --write`, `pnpm docs:audit`) — and note
+  grok cannot even *read* a sibling repo.
+- Production operations.
+- **Final acceptance.** After every dispatch: `git status --porcelain` shows only the granted
+  paths; re-run the gates yourself; and spot-check the report's highest-stakes claims against the
+  code. Trust the report's structure, verify its conclusions.
+
+## 6. What is worth dispatching
+
+Dispatching buys **orchestrator context**, not money — the first real run cost $0.19 and burned
+895k tokens of grok's own context to compress 181 KB of source into an 11 KB report. Judge every
+candidate task by how much of the orchestrator's context it removes, and that turns on one
+property: **can the result be compressed into something checkable without re-reading the input?**
+
+| Shape | Verdict |
+|---|---|
+| Broad read → narrow report whose findings are `file:line` + a quoted line | **Dispatch.** ~4–6× context saving; the coordinates are what make verification cheap. Audits, inventories, censuses, cross-reference checks, "find every X across N files". |
+| Wide mechanical edit whose correctness a gate asserts (build, tests, `gofmt`, `docs:verify`) | **Dispatch.** The saving is that the orchestrator reads only what the gate flags, not the diff. |
+| New code carrying design judgement | **Do not dispatch.** Every line must be read to be reviewed, so the orchestrator pays full input for the output *plus* the review, and still runs the gates. Net saving ≈ zero. |
+| Anything whose answer depends on running something | **Impossible** — see §1. |
+
+The structural ceiling: an executor with no shell can prove that documents disagree **with each
+other**, never that they disagree **with reality**. Enumerations, family lists, and field values
+checked only against prose are exactly where the expensive errors live, and dispatching that check
+does not find them — a query does.
+
+## 7. Standing binding documents
+
+When the dispatched work touches the v2 API, `refs/api-v2/` is binding, and the task book must
+name the specific clauses that bind this task — axiom, blacklist item, gate, decision record — by
+identifier, with the file. Do not tell the executor to "follow the spec": the spec is eleven files
+and it will follow the wrong part of it. Name `A<n>` / `B<n>` / `G<n>` / `D<n>` and quote the line.
+
+`refs/` is gitignored, so grok can read the spec but nothing it writes there reaches a commit.

--- a/.claude/skills/dispatch-grok/dispatch.sh
+++ b/.claude/skills/dispatch-grok/dispatch.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Dispatch one grok executor run. See SKILL.md in this directory.
+#
+#   GROK_OUT_ROOT=<dir under /tmp> dispatch.sh <slug> [extra grok args...]
+#
+# Expects <GROK_OUT_ROOT>/<slug>/task.md to exist. Writes run.json, stderr.log and
+# debug.log beside it. Extra arguments are passed straight through to grok — that is
+# where the per-task --allow 'Write(<glob>)' / 'Edit(<glob>)' rules go.
+#
+# Run this in the background: a real dispatch takes minutes.
+set -euo pipefail
+
+slug="${1:?usage: dispatch.sh <slug> [extra grok args...]}"
+shift
+
+root="${GROK_OUT_ROOT:?set GROK_OUT_ROOT to a writable directory under /tmp}"
+out="$root/$slug"
+[ -f "$out/task.md" ] || { echo "dispatch: missing $out/task.md" >&2; exit 2; }
+
+grok --prompt-file "$out/task.md" \
+     --allow "Write($out/**)" \
+     --allow "Read($out/**)" \
+     --output-format json \
+     --max-turns "${GROK_MAX_TURNS:-200}" \
+     --debug-file "$out/debug.log" \
+     "$@" \
+     >"$out/run.json" 2>"$out/stderr.log" || true
+
+if [ ! -s "$out/run.json" ]; then
+  echo "dispatch: grok produced no JSON; see $out/stderr.log" >&2
+  tail -c 2000 "$out/stderr.log" >&2 || true
+  exit 1
+fi
+
+stop=$(jq -r '.stopReason // "?"' "$out/run.json")
+turns=$(jq -r '.num_turns // "?"' "$out/run.json")
+cost=$(jq -r '.total_cost_usd // "?"' "$out/run.json")
+printf 'stopReason=%s turns=%s cost_usd=%s out=%s\n' "$stop" "$turns" "$cost" "$out"
+
+[ -s "$out/stderr.log" ] && { echo '--- stderr ---' >&2; tail -c 2000 "$out/stderr.log" >&2; }
+
+if [ "$stop" != "end_turn" ]; then
+  # stopReason "cancelled" covers both a denied tool call and turn exhaustion.
+  # Only the debug log distinguishes them, which is why it is always written.
+  if rg -q 'PermissionCancelled' "$out/debug.log" 2>/dev/null; then
+    echo 'dispatch: a tool call was DENIED — missing --allow rule, or a managed confirmation floor' >&2
+    rg -o 'confirmation floor tool="[^"]*"' "$out/debug.log" | sort -u >&2 || true
+  elif [ "$turns" -ge "${GROK_MAX_TURNS:-200}" ] 2>/dev/null; then
+    echo 'dispatch: turn budget exhausted — raise GROK_MAX_TURNS or split the task' >&2
+  else
+    echo "dispatch: run ended as '$stop'; inspect $out/debug.log" >&2
+  fi
+  exit 1
+fi

--- a/.claude/skills/dispatch-grok/task-book-template.md
+++ b/.claude/skills/dispatch-grok/task-book-template.md
@@ -1,0 +1,108 @@
+# Task: <one line, imperative, what gets built>
+
+You are the **executor**. The orchestrator wrote this task book; it is self-contained.
+You cannot see the orchestrator's conversation. Everything you need is below.
+
+## Context
+
+Repository: `/home/kun/Desktop/code/website/kun-galgame-infra` (your working directory).
+Branch: `<branch>` at `<short sha>`.
+
+<Where the relevant code lives — exact paths. What it does today. Why it is changing.
+Every prior adjudication this task depends on, stated inline. If the reader would have to
+ask "why this way and not the obvious way", answer it here.>
+
+## Your environment (read this, it is not the usual one)
+
+- **You have no shell.** Any terminal command ends this run immediately. Use only your file
+  tools: read, grep, list_dir, write, edit.
+- You therefore cannot build, test, format, or run anything. **That is expected.** The
+  orchestrator runs every gate after you finish. Write code that compiles; do not try to prove it.
+- Reads inside the repository are free. Everything outside it is unreachable except the one
+  output directory named below. Sibling repositories cannot be read at all.
+- The repository `CLAUDE.md` is already in your context. Its iron rules bind you.
+- <Delete if not applicable:> Do not use web search or any MCP tool for this task.
+
+## Binding constraints for this task
+
+<Name the specific clauses, by identifier, with file and quoted line. Not "follow the spec".>
+
+- `refs/api-v2/01-axioms.md` **A8**: "<quoted line>"
+- `refs/api-v2/07-governance.md` gate **G17**: "<quoted line>"
+- <…>
+
+## Scope
+
+1. <numbered, concrete, each independently checkable>
+2. …
+
+## Out of scope
+
+- <what a helpful executor would otherwise wander into>
+- Renaming, reformatting, or refactoring anything not named in Scope.
+
+## Precedent to follow
+
+<Point at existing code that already does this correctly: file:line. Say what to copy —
+the shape, the error handling, the naming — and what not to.>
+
+## Acceptance criteria
+
+The orchestrator will run these. You cannot. They are listed so you know what your code
+must satisfy:
+
+- `<exact command>` → `<expected output>`
+- Test `<TestName>` in `<file>` must pass.
+- `git status --porcelain` must show **only** the writable paths below.
+
+## Report
+
+Write your report to this exact absolute path:
+
+    <GROK_OUT_ROOT>/<slug>/report.md
+
+Structure:
+
+```
+# Report: <task>
+
+## 1. What I changed
+(file:line per change, one line each, what and why)
+
+## 2. Anything that looks wrong — in scope or not
+(report every one, at the same weight, with file:line and the quoted line. Something outside
+ this task's scope belongs here, not in section 5, and not with a note that it was out of scope.
+ Report it; do not fix it.)
+
+## 3. Mechanics I chose
+(any decision the task book left to the code — what you picked and the precedent you followed)
+
+## 4. Deviations from the task book
+(if none, write "None.")
+
+## 5. What I could not verify
+(everything requiring a command belongs here — be specific about what the orchestrator
+ should check, not just "run the tests")
+```
+
+Your final stdout message: one short paragraph, the report path plus a one-line status.
+Do not paste the report into stdout.
+
+## Discipline
+
+- Writable paths — **exactly** these, nothing else anywhere:
+  - `<glob 1>`
+  - `<glob 2>`
+  - the report path above
+- Forbidden: any shell command; any git operation; any database access; starting any service;
+  editing files outside the writable paths; touching `KunUI` / `@kungal/ui-*` sources.
+- **Report, don't work around.** If something is missing, contradictory, or blocked, stop and
+  write it in section 4 or 5. A blocked task reported accurately is a success; a task completed
+  by inventing around the block is not.
+- **Do not rank, score, or filter your findings.** You cannot see what the orchestrator knows, so
+  you cannot tell which finding matters most. Report every one flat, at equal weight. Never demote
+  something to "minor", "cosmetic", "out of the requested classes", or "not scored" — that
+  judgement is the orchestrator's and yours will be wrong.
+- <Delete unless the task is a search, audit, or census:> **Include a positive control.** A count
+  of what you did *not* find is worthless unless the search is known to work. List what you
+  checked that came back clean, with counts, so the zero can be believed.

--- a/.cursor/rules/grok-executor.mdc
+++ b/.cursor/rules/grok-executor.mdc
@@ -5,32 +5,52 @@ alwaysApply: true
 
 # Grok-as-executor dispatch mode
 
-The agent in this session is the **orchestrator** (task-book author + acceptor). Implementation and investigation work is dispatched to the locally installed `grok` CLI (Grok Build) as the **executor subagent**. Do NOT use Cursor's built-in Task subagents for execution work; use `grok`.
+The agent in this session is the **orchestrator** (task-book author + acceptor). Implementation and investigation work is dispatched to the locally installed `grok` CLI (Grok Build) as the **executor subagent**. Do NOT use built-in Task subagents for execution work; use `grok`.
+
+The full operating manual — verified flag set, dispatch script, task-book template — is `.claude/skills/dispatch-grok/`. Read it before the first dispatch of a session.
+
+## What grok can do here (verified 2026-08-22, grok 1.0.5)
+
+`/etc/grok/requirements.toml` is a system policy pin; no flag lifts it.
+
+- **No shell.** `run_terminal_command` sits behind a managed confirmation floor, and headless has nobody to confirm, so the first shell call ends the run (`stopReason: "cancelled"`). `--always-approve`, `--permission-mode`, and catch-all rules (`--allow Bash`) are all rejected. **grok writes; the orchestrator runs every command.**
+- Reads inside the repo are free. Writes need a **path-scoped** `--allow 'Write(<glob>)'` / `Edit(<glob>)` — enforced, not advisory: a write outside the glob ends the run. That is the mechanical form of "one path, one writer".
+- The sandbox is the repo plus `/tmp`. Sibling repos are unreadable even with an explicit rule.
+- Rule prefixes are Claude-compatible names (`Write`, `Edit`, `Read`), not grok's native tool names.
+- grok loads this repo's `CLAUDE.md` automatically — don't re-paste the iron rules, do restate the ones the task turns on.
 
 ## How to dispatch
 
-1. Write a self-contained task book to `/tmp/<task-slug>.md`, then run from the repo root, in the background:
-
 ```bash
-grok --prompt-file /tmp/<task-slug>.md --output-format plain --max-turns 200 \
-  > /tmp/<task-slug>-report.md 2>/tmp/<task-slug>-stderr.log
+export GROK_OUT_ROOT=/tmp/grok-dispatch          # never the repo
+mkdir -p "$GROK_OUT_ROOT/<slug>"                 # write task.md there, then:
+.claude/skills/dispatch-grok/dispatch.sh <slug> \
+  --allow 'Write(<narrow glob>)' --allow 'Edit(<narrow glob>)'
 ```
 
-2. Headless default permissions allow file reads and read-only shell without approval; write control rides on the task book's discipline section plus your post-run checks. For risky tasks add `--permission-mode` / `--sandbox`.
-3. Never run two grok dispatches concurrently on overlapping paths — one writer per path. Sequential dispatches only.
+Run it in the background. One dispatch at a time over any given path.
 
-## Task book requirements (what makes executors perform well)
+Have grok **write its report to a file** under `$GROK_OUT_ROOT/<slug>/`, never to stdout: `.text` is the concatenation of every assistant text block, not the final answer. Keeping the report out of the repo also makes `git status --porcelain` a pure signal of what grok changed.
+
+`stopReason: "cancelled"` means *either* a denied tool call *or* turn exhaustion — `dispatch.sh` greps the debug log to tell you which.
+
+## Task book requirements
 
 - **Write it in English** — executors follow English task books more reliably.
 - Self-contained: the executor sees nothing of this conversation. State repo path, branch, HEAD, where the code lives, and every relevant prior decision inline.
-- Explicit scope AND out-of-scope lists; named acceptance criteria (test names, commands with expected output); a required report structure.
-- All design adjudications are made by the orchestrator in the task book — never delegate an open design decision to the executor. If mechanics genuinely depend on code details, state the invariant to enforce plus the precedent to follow, and require the executor to report the chosen mechanics for acceptance.
-- A discipline section: writable paths (exact), forbidden operations (git add/commit/checkout/reset/stash, DB access unless a DSN is explicitly provided, starting services), and "report, don't work around" for anything unexpected.
+- State "you have no shell" explicitly. A task book that says "run the tests" wastes the dispatch.
+- Explicit scope AND out-of-scope lists; named acceptance criteria (test names, commands with expected output) that **the orchestrator** will run; a required report structure.
+- All design adjudications are made by the orchestrator in the task book — never delegate an open design decision. If mechanics genuinely depend on code details, state the invariant to enforce plus the precedent to follow, and require the executor to report the chosen mechanics for acceptance.
+- Name binding spec clauses by identifier and quote them (`refs/api-v2/` axiom `A<n>`, blacklist `B<n>`, gate `G<n>`, decision `D<n>`). "Follow the spec" points at eleven files and gets the wrong one followed.
+- A discipline section: writable paths (exact), forbidden operations (git, DB, starting services, KunUI edits), and "report, don't work around" for anything unexpected.
+- **Forbid ranking.** The executor cannot see what the orchestrator knows, so its importance ordering is noise. Require a flat list at equal weight, and put "anything that looks wrong, in scope or not" near the top of the report structure — left at the bottom, the one finding with real consequence gets folded into "could not verify" and labelled `not scored`.
+- On any search, audit, or census, require a **positive control**: alongside "I found N", the list of what was checked and came back clean. A zero from a search nobody proved works is unreadable.
 
 ## What the orchestrator never delegates
 
 - Task-book adjudications and scope calls.
+- Every command — build, test, `gofmt`, lint, docs gates.
 - Git commits (explicit paths only), pushes, PRs, and anything touching shared git state.
-- Database provisioning (`scripts/ephemeral-test-db.sh create <slug>`; pass the DSN into the grok dispatch env; `drop` it when done) and all migrations.
-- Cross-repo docs sync (`../kungal-docs` `docs:sync --write` + `docs:audit`) and production operations.
-- Final acceptance: after every dispatch run `git status --porcelain` (only expected paths changed), spot-check the report's highest-stakes claims against the code, and independently re-run the tests/gates for write tasks. Trust the report's structure, verify its conclusions.
+- Database provisioning (`scripts/ephemeral-test-db.sh create <slug>`) and all migrations.
+- Cross-repo docs sync (`../kungal-docs` `docs:sync --write` + `docs:audit`) and production operations — grok cannot even read a sibling repo.
+- Final acceptance: after every dispatch run `git status --porcelain` (only granted paths changed), spot-check the report's highest-stakes claims against the code, and independently re-run the tests/gates. Trust the report's structure, verify its conclusions.


### PR DESCRIPTION
Records how this machine's `grok` CLI can actually be used as a headless executor, so the next session does not rediscover it.

The binding fact: `/etc/grok/requirements.toml` is a system-wide managed policy with `sandbox.profile = "strict"`, and `run_terminal_command` sits behind a confirmation floor that `--always-approve`, `--permission-mode`, and catch-all `--allow` rules all fail to lift. Headless there is nobody to confirm, so **grok has no shell** — the first command ends the run with a `stopReason: "cancelled"` that is indistinguishable from turn exhaustion without the debug log.

That produces the division of labour the skill is built around: grok reads and writes files, the orchestrator runs every gate, git operation, migration and production action. Writes are fenced by path-scoped `--allow 'Write(<glob>)'` rules that grok enforces mechanically — the machine form of iron rule 13.

Contents:

- `.claude/skills/dispatch-grok/SKILL.md` — capability matrix, dispatch flags, the three traps in reading a run's result, what is worth dispatching and what is not.
- `.claude/skills/dispatch-grok/dispatch.sh` — supplies `--prompt-file`, the output-directory rules, `--output-format json`, `--max-turns`, `--debug-file`, and diagnoses a bad exit.
- `.claude/skills/dispatch-grok/task-book-template.md` — the task-book shape: self-contained, English, binding clauses named by identifier, acceptance criteria the orchestrator runs.
- `.cursor/rules/grok-executor.mdc` — the short version of the same, corrected. The previous text claimed headless grok allowed read-only shell; it does not.

Two requirements come from the first real dispatch (an 11-file cross-reference audit, 9 turns, $0.19, zero false positives): the report must put *anything that looks wrong, in scope or not* near the top and the executor is forbidden to rank its own findings — the one finding with design consequence was filed last and labelled `not scored` because it fell outside the classes the task book named; and any search or census must carry a positive control, because "I found 4" is unreadable without the list of what was checked and came back clean.

Tooling only. No service, schema, or API surface is touched, and no migration is required.