### PR TITLE
fix(catalog): match an extraction key with its spaces taken out

### DIFF
--- a/apps/api/cmd/extract-char-intros/batch.go
+++ b/apps/api/cmd/extract-char-intros/batch.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+)
+
+// The batched lane, shared by both gateways. On Cursor every agent run re-reads
+// ~14k tokens of fixed preamble; on the OpenAI-compatible gateway the account
+// serialises requests (2026-08-22: four concurrent judge calls came back as a
+// perfect serial staircase 6.8/13.9/20.0/27.1s, eight returned a 429
+// "Concurrency limit exceeded for account"). So on BOTH gateways the batch is
+// the throughput lever and concurrency is not: batching the judge measured
+// 0.147 -> 3.09 comparisons per second.
+type batchCall struct {
+	Rules string // system half: the task rules plus the envelope contract
+	Items string // user half: a JSON array, one object per item
+	Label string // names the Cursor agent run; unused by the chat face
+}
+
+type promptCaller interface {
+	// callBatch answers one batched prompt with the reply text and the model
+	// that actually served it.
+	callBatch(ctx context.Context, c batchCall) (text, model string, err error)
+}
+
+// errBatchOversize marks a reply the gateway cut short. It is the one call
+// failure that halving the batch can fix, so it reaches the split retry
+// instead of failing every item outright.
+var errBatchOversize = errors.New("reply truncated before it finished")
+
+const batchEnvelopeRules = `下面是一个 JSON 数组,每项是一个待处理条目,` + "`i`" + ` 是它的序号。
+逐项独立处理,输出 JSON 数组 %s。
+必须满足:输出项数与输入完全一致;每项的 ` + "`i`" + ` 原样回显;顺序与输入一致。
+把 JSON 数组直接作为你的最终回复正文输出:不要解释、不要代码围栏、不要写入任何文件、不要使用任何工具。`
+
+func batchCallOf(rules, outShape, label string, items any) (batchCall, error) {
+	raw, err := json.Marshal(items)
+	if err != nil {
+		return batchCall{}, err
+	}
+	return batchCall{
+		Rules: rules + "\n\n" + fmt.Sprintf(batchEnvelopeRules, outShape),
+		Items: string(raw),
+		Label: label,
+	}, nil
+}
+
+var jsonArrayRe = regexp.MustCompile(`(?s)\[.*\]`)
+
+// parseBatchArray is the integrity gate: the reply must carry exactly one
+// object per wanted index, no more, no fewer. A model that silently drops the
+// tail (observed at batch 1000: 418 of 1000 returned) fails here instead of
+// quietly shifting every downstream passage onto the wrong work.
+func parseBatchArray[T any](text string, want int) ([]T, error) {
+	m := jsonArrayRe.FindString(text)
+	if m == "" {
+		return nil, fmt.Errorf("no JSON array in reply: %s", truncate(strings.TrimSpace(text), 200))
+	}
+	var arr []struct {
+		I *int `json:"i"`
+	}
+	if err := json.Unmarshal([]byte(m), &arr); err != nil {
+		return nil, fmt.Errorf("reply is not a JSON array of objects: %w", err)
+	}
+	if len(arr) != want {
+		return nil, fmt.Errorf("count mismatch: got %d want %d", len(arr), want)
+	}
+	var items []T
+	if err := json.Unmarshal([]byte(m), &items); err != nil {
+		return nil, fmt.Errorf("reply items do not match the requested shape: %w", err)
+	}
+	seen := make(map[int]bool, want)
+	for _, a := range arr {
+		if a.I == nil {
+			return nil, fmt.Errorf("item missing index key")
+		}
+		seen[*a.I] = true
+	}
+	for i := range want {
+		if !seen[i] {
+			return nil, fmt.Errorf("index set mismatch: %d missing", i)
+		}
+	}
+	return items, nil
+}
+
+// splitRetries is how many times a batch that fails the integrity gate is cut
+// in half and retried. One level is what wave 210 settled on: it rescues the
+// batch that was merely too big without letting a systematically bad item turn
+// one run into a binary search.
+const splitRetries = 1
+
+func splittable(depth, size int) bool { return depth < splitRetries && size > 1 }
+
+// --- extraction ---
+
+type batchExtractItem struct {
+	I      int      `json:"i"`
+	Roster []string `json:"角色名单"`
+	Intro  string   `json:"作品简介"`
+}
+
+type batchExtractReply struct {
+	I     int               `json:"i"`
+	Found map[string]string `json:"摘录"`
+}
+
+const extractOutShape = `[{"i":0,"摘录":{"角色名":"摘录到的介绍文本"}}]`
+
+const extractBatchRules = extractSystemPrompt + `
+5. ` + "`摘录`" + ` 的键必须逐字使用「角色名单」里给出的写法(带中文名括注的,只用括注前的名字);没有可摘录的角色介绍时该项输出空对象 {}。
+6. 摘录值必须是从简介正文里**原样复制**的连续文本:一个字都不能改、不能顺句、不能换标点、不能把相隔的句子拼起来。程序会逐字比对,改写过的一律丢弃——与其润色不如原样照抄。`
+
+func extractBatchVia(ctx context.Context, c promptCaller, batch []candidateWork, depth int) []extraction {
+	out := make([]extraction, len(batch))
+	items := make([]batchExtractItem, len(batch))
+	plain := make([]map[string]string, len(batch))
+	for i, w := range batch {
+		names := make([]string, 0, len(w.Roster))
+		plain[i] = make(map[string]string, len(w.Roster))
+		for _, r := range w.Roster {
+			n := r.Name
+			if r.ZhName != "" && r.ZhName != r.Name {
+				n += "(中文名: " + r.ZhName + ")"
+			}
+			names = append(names, n)
+			plain[i][n] = r.Name
+		}
+		items[i] = batchExtractItem{I: i, Roster: names, Intro: w.Intro}
+	}
+	call, err := batchCallOf(extractBatchRules, extractOutShape, fmt.Sprintf("p3-extract-%d", batch[0].WorkID), items)
+	if err != nil {
+		return failAll(out, err)
+	}
+	text, model, err := c.callBatch(ctx, call)
+	if err != nil && !errors.Is(err, errBatchOversize) {
+		return failAll(out, err)
+	}
+	replies, gateErr := parseBatchArray[batchExtractReply](text, len(batch))
+	if gateErr == nil {
+		for _, r := range replies {
+			if r.I < 0 || r.I >= len(out) {
+				continue
+			}
+			// The roster is shown as 「名字(中文名: …)」, and a model that echoes the
+			// whole label back would land in the unmatched-name bucket; map it home.
+			found := make(map[string]string, len(r.Found))
+			for name, passage := range r.Found {
+				if p, ok := plain[r.I][strings.TrimSpace(name)]; ok {
+					name = p
+				}
+				found[name] = passage
+			}
+			out[r.I] = extraction{Found: found, Model: model}
+		}
+		return out
+	}
+	if err == nil {
+		err = gateErr
+	}
+	if splittable(depth, len(batch)) {
+		slog.Warn("extraction batch failed the integrity gate — splitting", "works", len(batch), "err", err)
+		half := len(batch) / 2
+		return append(extractBatchVia(ctx, c, batch[:half], depth+1), extractBatchVia(ctx, c, batch[half:], depth+1)...)
+	}
+	return failAll(out, err)
+}
+
+func failAll(out []extraction, err error) []extraction {
+	for i := range out {
+		out[i] = extraction{Err: err}
+	}
+	return out
+}
+
+// --- panel judging ---
+
+type batchJudgeItem struct {
+	I    int    `json:"i"`
+	Name string `json:"角色"`
+	A    string `json:"A"`
+	B    string `json:"B"`
+}
+
+type batchJudgeReply struct {
+	I      int    `json:"i"`
+	Winner string `json:"winner"`
+}
+
+const judgeOutShape = `[{"i":0,"winner":"A"}]`
+
+func compareBatchVia(ctx context.Context, c promptCaller, batch []comparison, depth int) []comparisonResult {
+	out := make([]comparisonResult, len(batch))
+	items := make([]batchJudgeItem, len(batch))
+	for i, cmp := range batch {
+		first, second := cmp.Incumbent, cmp.Challenger
+		if cmp.ChallengerFirst {
+			first, second = cmp.Challenger, cmp.Incumbent
+		}
+		items[i] = batchJudgeItem{I: i, Name: cmp.Name, A: first, B: second}
+	}
+	call, err := batchCallOf(judgeSystemPrompt, judgeOutShape, fmt.Sprintf("p3-judge-%d", len(batch)), items)
+	if err != nil {
+		return failAllVotes(out, err)
+	}
+	text, _, err := c.callBatch(ctx, call)
+	if err != nil && !errors.Is(err, errBatchOversize) {
+		return failAllVotes(out, err)
+	}
+	replies, gateErr := parseBatchArray[batchJudgeReply](text, len(batch))
+	if gateErr == nil {
+		for _, r := range replies {
+			if r.I < 0 || r.I >= len(out) {
+				continue
+			}
+			out[r.I] = comparisonResult{Vote: voteOf(r.Winner, batch[r.I].ChallengerFirst)}
+			if out[r.I].Vote == voteEqual && r.Winner != "equal" {
+				out[r.I] = comparisonResult{Err: fmt.Errorf("judge answered %q", r.Winner)}
+			}
+		}
+		return out
+	}
+	if err == nil {
+		err = gateErr
+	}
+	if splittable(depth, len(batch)) {
+		slog.Warn("judge batch failed the integrity gate — splitting", "votes", len(batch), "err", err)
+		half := len(batch) / 2
+		return append(compareBatchVia(ctx, c, batch[:half], depth+1), compareBatchVia(ctx, c, batch[half:], depth+1)...)
+	}
+	return failAllVotes(out, err)
+}
+
+func failAllVotes(out []comparisonResult, err error) []comparisonResult {
+	for i := range out {
+		out[i] = comparisonResult{Err: err}
+	}
+	return out
+}

--- a/apps/api/cmd/extract-char-intros/batch_test.go
+++ b/apps/api/cmd/extract-char-intros/batch_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBatchArrayIntegrityGate(t *testing.T) {
+	type reply struct {
+		I      int    `json:"i"`
+		Winner string `json:"winner"`
+	}
+	cases := []struct {
+		name    string
+		text    string
+		want    int
+		wantErr string
+	}{
+		{"clean", `[{"i":0,"winner":"A"},{"i":1,"winner":"B"}]`, 2, ""},
+		{"tolerates surrounding chatter", "好的:\n[{\"i\":0,\"winner\":\"A\"}]\n", 1, ""},
+		{"dropped tail", `[{"i":0,"winner":"A"}]`, 2, "count mismatch"},
+		{"duplicate index hides a gap", `[{"i":0,"winner":"A"},{"i":0,"winner":"B"}]`, 2, "index set mismatch"},
+		{"missing index key", `[{"winner":"A"},{"i":1,"winner":"B"}]`, 2, "item missing index key"},
+		{"no array at all", `抱歉,我无法完成。`, 1, "no JSON array"},
+	}
+	for _, c := range cases {
+		got, err := parseBatchArray[reply](c.text, c.want)
+		if c.wantErr != "" {
+			require.Error(t, err, c.name)
+			assert.Contains(t, err.Error(), c.wantErr, c.name)
+			continue
+		}
+		require.NoError(t, err, c.name)
+		assert.Len(t, got, c.want, c.name)
+	}
+}
+
+func TestBatchCallCarriesTheIntegrityRules(t *testing.T) {
+	c, err := batchCallOf("规则", `[{"i":0}]`, "label", []batchExtractItem{{I: 0, Intro: "简介"}})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(c.Rules, "规则"))
+	assert.Contains(t, c.Rules, "输出项数与输入完全一致")
+	assert.Contains(t, c.Items, `"作品简介":"简介"`)
+	assert.Equal(t, "label", c.Label)
+}
+
+// chatReq is the request shape the batched lane must send: the rules as the
+// system message, the JSON array as the user message.
+type chatReq struct {
+	Model           string `json:"model"`
+	MaxTokens       int    `json:"max_tokens"`
+	ReasoningEffort string `json:"reasoning_effort"`
+	Messages        []struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	} `json:"messages"`
+}
+
+type chatProbe struct {
+	ex   *httpExtractor
+	reqs []chatReq
+}
+
+func fakeChat(t *testing.T, answer func(req chatReq, n int) (content, finish string)) *chatProbe {
+	t.Helper()
+	p := &chatProbe{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+		body, _ := io.ReadAll(r.Body)
+		var req chatReq
+		require.NoError(t, json.Unmarshal(body, &req))
+		p.reqs = append(p.reqs, req)
+		content, finish := answer(req, len(p.reqs))
+		out, _ := json.Marshal(map[string]any{
+			"model": "grok-4.6",
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": content}, "finish_reason": finish},
+			},
+		})
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(out)
+	}))
+	t.Cleanup(srv.Close)
+	p.ex = newHTTPExtractor(srv.URL+"/v1", "test-key", "grok-4.6", "low", 4096)
+	return p
+}
+
+func TestHTTPCompareBatchSendsOneCallAndKeepsEachSide(t *testing.T) {
+	p := fakeChat(t, func(chatReq, int) (string, string) {
+		return `[{"i":0,"winner":"B"},{"i":1,"winner":"A"}]`, "stop"
+	})
+	batch := []comparison{
+		{Name: "沙耶", Incumbent: "既有甲", Challenger: "提取甲", ChallengerFirst: false},
+		{Name: "玲", Incumbent: "既有乙", Challenger: "提取乙", ChallengerFirst: true},
+	}
+
+	out := p.ex.CompareBatch(context.Background(), batch)
+	require.Len(t, out, 2)
+	require.Len(t, p.reqs, 1, "a batch of two comparisons is one call")
+	for i, r := range out {
+		require.NoError(t, r.Err, "vote %d", i)
+		assert.Equal(t, voteChallenger, r.Vote, "vote %d answered for the challenger whichever side it sat on", i)
+	}
+	msgs := p.reqs[0].Messages
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "system", msgs[0].Role)
+	assert.Contains(t, msgs[0].Content, "输出项数与输入完全一致")
+	assert.Equal(t, "user", msgs[1].Role)
+	assert.Contains(t, msgs[1].Content, `"角色":"沙耶"`)
+	assert.Equal(t, "low", p.reqs[0].ReasoningEffort)
+}
+
+func TestHTTPExtractBatchMapsAnswersBackToTheirWork(t *testing.T) {
+	p := fakeChat(t, func(chatReq, int) (string, string) {
+		return `[{"i":0,"摘录":{"沙耶":"甲的介绍"}},{"i":1,"摘录":{}}]`, "stop"
+	})
+
+	out := p.ex.ExtractBatch(context.Background(), twoWorks())
+	require.Len(t, out, 2)
+	require.NoError(t, out[0].Err)
+	assert.Equal(t, map[string]string{"沙耶": "甲的介绍"}, out[0].Found)
+	assert.Equal(t, "grok-4.6", out[0].Model, "the served model is recorded, not the requested one")
+	require.NoError(t, out[1].Err)
+	assert.Empty(t, out[1].Found)
+	require.Len(t, p.reqs, 1)
+}
+
+// A reply the gateway cut off at max_tokens is the one call failure halving can
+// fix, so it must reach the split retry instead of failing both works outright.
+func TestHTTPBatchSplitsAReplyCutOffAtMaxTokens(t *testing.T) {
+	p := fakeChat(t, func(_ chatReq, n int) (string, string) {
+		if n == 1 {
+			return `[{"i":0,"摘录":{"沙耶":"甲的介绍"`, "length"
+		}
+		return `[{"i":0,"摘录":{}}]`, "stop"
+	})
+
+	out := p.ex.ExtractBatch(context.Background(), twoWorks())
+	require.Len(t, out, 2)
+	assert.Len(t, p.reqs, 3, "the cut-off batch plus its two halves")
+	for i, e := range out {
+		require.NoError(t, e.Err, "work %d", i)
+	}
+}
+
+func TestHTTPBatchFailsEveryItemWhenSplittingCannotHelp(t *testing.T) {
+	p := fakeChat(t, func(chatReq, int) (string, string) {
+		return "抱歉,我无法完成这个任务。", "stop"
+	})
+
+	out := p.ex.ExtractBatch(context.Background(), twoWorks())
+	require.Len(t, out, 2)
+	assert.Len(t, p.reqs, 3)
+	for i, e := range out {
+		require.Error(t, e.Err, "work %d", i)
+		assert.Contains(t, e.Err.Error(), "no JSON array")
+	}
+}
+
+func TestHTTPBatchOmitsEffortWhenUnset(t *testing.T) {
+	p := fakeChat(t, func(chatReq, int) (string, string) { return `[{"i":0,"摘录":{}}]`, "stop" })
+	p.ex.effort = ""
+
+	out := p.ex.ExtractBatch(context.Background(), twoWorks()[:1])
+	require.NoError(t, out[0].Err)
+	assert.Empty(t, p.reqs[0].ReasoningEffort, fmt.Sprintf("req: %+v", p.reqs[0]))
+}

--- a/apps/api/cmd/extract-char-intros/cursor.go
+++ b/apps/api/cmd/extract-char-intros/cursor.go
@@ -6,10 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
-	"regexp"
-	"strings"
 	"time"
 )
 
@@ -174,207 +171,17 @@ func (c *cursorClient) requestOnce(ctx context.Context, method, path string, bod
 	return data, resp.StatusCode, nil
 }
 
-const batchEnvelopeRules = `下面是一个 JSON 数组,每项是一个待处理条目,` + "`i`" + ` 是它的序号。
-逐项独立处理,输出 JSON 数组 %s。
-必须满足:输出项数与输入完全一致;每项的 ` + "`i`" + ` 原样回显;顺序与输入一致。
-把 JSON 数组直接作为你的最终回复正文输出:不要解释、不要代码围栏、不要写入任何文件、不要使用任何工具。`
-
-func batchPrompt(rules, outShape string, items any) (string, error) {
-	raw, err := json.Marshal(items)
-	if err != nil {
-		return "", err
-	}
-	return rules + "\n\n" + fmt.Sprintf(batchEnvelopeRules, outShape) + "\n\n" + string(raw), nil
+// callBatch runs one batched prompt as an agent run. The agent face has no
+// system role, so the two halves of the call travel as one prompt.
+func (c *cursorClient) callBatch(ctx context.Context, b batchCall) (string, string, error) {
+	text, err := c.runAgent(ctx, b.Rules+"\n\n"+b.Items, b.Label)
+	return text, c.model, err
 }
-
-var jsonArrayRe = regexp.MustCompile(`(?s)\[.*\]`)
-
-// parseBatchArray is the integrity gate: the reply must carry exactly one
-// object per wanted index, no more, no fewer. A model that silently drops the
-// tail (observed at batch 1000: 418 of 1000 returned) fails here instead of
-// quietly shifting every downstream passage onto the wrong work.
-func parseBatchArray[T any](text string, want int) ([]T, error) {
-	m := jsonArrayRe.FindString(text)
-	if m == "" {
-		return nil, fmt.Errorf("no JSON array in reply: %s", truncate(strings.TrimSpace(text), 200))
-	}
-	var arr []struct {
-		I *int `json:"i"`
-	}
-	if err := json.Unmarshal([]byte(m), &arr); err != nil {
-		return nil, fmt.Errorf("reply is not a JSON array of objects: %w", err)
-	}
-	if len(arr) != want {
-		return nil, fmt.Errorf("count mismatch: got %d want %d", len(arr), want)
-	}
-	var items []T
-	if err := json.Unmarshal([]byte(m), &items); err != nil {
-		return nil, fmt.Errorf("reply items do not match the requested shape: %w", err)
-	}
-	seen := make(map[int]bool, want)
-	for _, a := range arr {
-		if a.I == nil {
-			return nil, fmt.Errorf("item missing index key")
-		}
-		seen[*a.I] = true
-	}
-	for i := range want {
-		if !seen[i] {
-			return nil, fmt.Errorf("index set mismatch: %d missing", i)
-		}
-	}
-	return items, nil
-}
-
-// --- extraction ---
-
-type cursorExtractItem struct {
-	I      int      `json:"i"`
-	Roster []string `json:"角色名单"`
-	Intro  string   `json:"作品简介"`
-}
-
-type cursorExtractReply struct {
-	I     int               `json:"i"`
-	Found map[string]string `json:"摘录"`
-}
-
-const extractOutShape = `[{"i":0,"摘录":{"角色名":"摘录到的介绍文本"}}]`
-
-// splitRetries is how many times a batch that fails the integrity gate is cut
-// in half and retried. One level is what wave 210 settled on: it rescues the
-// batch that was merely too big without letting a systematically bad item turn
-// one run into a binary search.
-const splitRetries = 1
 
 func (c *cursorClient) ExtractBatch(ctx context.Context, batch []candidateWork) []extraction {
-	return c.extractBatch(ctx, batch, 0)
+	return extractBatchVia(ctx, c, batch, 0)
 }
-
-func (c *cursorClient) extractBatch(ctx context.Context, batch []candidateWork, depth int) []extraction {
-	out := make([]extraction, len(batch))
-	items := make([]cursorExtractItem, len(batch))
-	plain := make([]map[string]string, len(batch))
-	for i, w := range batch {
-		names := make([]string, 0, len(w.Roster))
-		plain[i] = make(map[string]string, len(w.Roster))
-		for _, r := range w.Roster {
-			n := r.Name
-			if r.ZhName != "" && r.ZhName != r.Name {
-				n += "(中文名: " + r.ZhName + ")"
-			}
-			names = append(names, n)
-			plain[i][n] = r.Name
-		}
-		items[i] = cursorExtractItem{I: i, Roster: names, Intro: w.Intro}
-	}
-	rules := extractSystemPrompt + `
-5. ` + "`摘录`" + ` 的键必须逐字使用「角色名单」里给出的写法(带中文名括注的,只用括注前的名字);没有可摘录的角色介绍时该项输出空对象 {}。
-6. 摘录值必须是从简介正文里**原样复制**的连续文本:一个字都不能改、不能顺句、不能换标点、不能把相隔的句子拼起来。程序会逐字比对,改写过的一律丢弃——与其润色不如原样照抄。`
-	prompt, err := batchPrompt(rules, extractOutShape, items)
-	if err != nil {
-		return failAll(out, err)
-	}
-	text, err := c.runAgent(ctx, prompt, fmt.Sprintf("p3-extract-%d", batch[0].WorkID))
-	if err != nil {
-		return failAll(out, err)
-	}
-	replies, err := parseBatchArray[cursorExtractReply](text, len(batch))
-	if err != nil {
-		if depth < splitRetries && len(batch) > 1 {
-			slog.Warn("extraction batch failed the integrity gate — splitting", "works", len(batch), "err", err)
-			half := len(batch) / 2
-			return append(c.extractBatch(ctx, batch[:half], depth+1), c.extractBatch(ctx, batch[half:], depth+1)...)
-		}
-		return failAll(out, err)
-	}
-	for _, r := range replies {
-		if r.I < 0 || r.I >= len(out) {
-			continue
-		}
-		// The roster is shown as 「名字(中文名: …)」, and a model that echoes the
-		// whole label back would land in the unmatched-name bucket; map it home.
-		found := make(map[string]string, len(r.Found))
-		for name, passage := range r.Found {
-			if p, ok := plain[r.I][strings.TrimSpace(name)]; ok {
-				name = p
-			}
-			found[name] = passage
-		}
-		out[r.I] = extraction{Found: found, Model: c.model}
-	}
-	return out
-}
-
-func failAll(out []extraction, err error) []extraction {
-	for i := range out {
-		out[i] = extraction{Err: err}
-	}
-	return out
-}
-
-// --- panel judging ---
-
-type cursorJudgeItem struct {
-	I    int    `json:"i"`
-	Name string `json:"角色"`
-	A    string `json:"A"`
-	B    string `json:"B"`
-}
-
-type cursorJudgeReply struct {
-	I      int    `json:"i"`
-	Winner string `json:"winner"`
-}
-
-const judgeOutShape = `[{"i":0,"winner":"A"}]`
 
 func (c *cursorClient) CompareBatch(ctx context.Context, batch []comparison) []comparisonResult {
-	return c.compareBatch(ctx, batch, 0)
-}
-
-func (c *cursorClient) compareBatch(ctx context.Context, batch []comparison, depth int) []comparisonResult {
-	out := make([]comparisonResult, len(batch))
-	items := make([]cursorJudgeItem, len(batch))
-	for i, cmp := range batch {
-		first, second := cmp.Incumbent, cmp.Challenger
-		if cmp.ChallengerFirst {
-			first, second = cmp.Challenger, cmp.Incumbent
-		}
-		items[i] = cursorJudgeItem{I: i, Name: cmp.Name, A: first, B: second}
-	}
-	prompt, err := batchPrompt(judgeSystemPrompt, judgeOutShape, items)
-	if err != nil {
-		return failAllVotes(out, err)
-	}
-	text, err := c.runAgent(ctx, prompt, fmt.Sprintf("p3-judge-%d", len(batch)))
-	if err != nil {
-		return failAllVotes(out, err)
-	}
-	replies, err := parseBatchArray[cursorJudgeReply](text, len(batch))
-	if err != nil {
-		if depth < splitRetries && len(batch) > 1 {
-			slog.Warn("judge batch failed the integrity gate — splitting", "votes", len(batch), "err", err)
-			half := len(batch) / 2
-			return append(c.compareBatch(ctx, batch[:half], depth+1), c.compareBatch(ctx, batch[half:], depth+1)...)
-		}
-		return failAllVotes(out, err)
-	}
-	for _, r := range replies {
-		if r.I < 0 || r.I >= len(out) {
-			continue
-		}
-		out[r.I] = comparisonResult{Vote: voteOf(r.Winner, batch[r.I].ChallengerFirst)}
-		if out[r.I].Vote == voteEqual && r.Winner != "equal" {
-			out[r.I] = comparisonResult{Err: fmt.Errorf("judge answered %q", r.Winner)}
-		}
-	}
-	return out
-}
-
-func failAllVotes(out []comparisonResult, err error) []comparisonResult {
-	for i := range out {
-		out[i] = comparisonResult{Err: err}
-	}
-	return out
+	return compareBatchVia(ctx, c, batch, 0)
 }

--- a/apps/api/cmd/extract-char-intros/cursor_test.go
+++ b/apps/api/cmd/extract-char-intros/cursor_test.go
@@ -141,36 +141,6 @@ func TestCursorExtractBatchFailsEveryWorkWhenSplittingCannotHelp(t *testing.T) {
 	}
 }
 
-func TestParseBatchArrayIntegrityGate(t *testing.T) {
-	type reply struct {
-		I      int    `json:"i"`
-		Winner string `json:"winner"`
-	}
-	cases := []struct {
-		name    string
-		text    string
-		want    int
-		wantErr string
-	}{
-		{"clean", `[{"i":0,"winner":"A"},{"i":1,"winner":"B"}]`, 2, ""},
-		{"tolerates surrounding chatter", "好的:\n[{\"i\":0,\"winner\":\"A\"}]\n", 1, ""},
-		{"dropped tail", `[{"i":0,"winner":"A"}]`, 2, "count mismatch"},
-		{"duplicate index hides a gap", `[{"i":0,"winner":"A"},{"i":0,"winner":"B"}]`, 2, "index set mismatch"},
-		{"missing index key", `[{"winner":"A"},{"i":1,"winner":"B"}]`, 2, "item missing index key"},
-		{"no array at all", `抱歉,我无法完成。`, 1, "no JSON array"},
-	}
-	for _, c := range cases {
-		got, err := parseBatchArray[reply](c.text, c.want)
-		if c.wantErr != "" {
-			require.Error(t, err, c.name)
-			assert.Contains(t, err.Error(), c.wantErr, c.name)
-			continue
-		}
-		require.NoError(t, err, c.name)
-		assert.Len(t, got, c.want, c.name)
-	}
-}
-
 type countingJudge struct{ batches []int }
 
 func (j *countingJudge) CompareBatch(_ context.Context, batch []comparison) []comparisonResult {
@@ -250,12 +220,4 @@ func TestReadCursorKeyRejectsAnEmptyFile(t *testing.T) {
 	key, err := readCursorKey(path)
 	require.NoError(t, err)
 	assert.Equal(t, "crsr_secret", key)
-}
-
-func TestBatchPromptCarriesTheIntegrityRules(t *testing.T) {
-	p, err := batchPrompt("规则", `[{"i":0}]`, []cursorExtractItem{{I: 0, Intro: "简介"}})
-	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(p, "规则"))
-	assert.Contains(t, p, "输出项数与输入完全一致")
-	assert.Contains(t, p, `"作品简介":"简介"`)
 }

--- a/apps/api/cmd/extract-char-intros/extract.go
+++ b/apps/api/cmd/extract-char-intros/extract.go
@@ -129,24 +129,6 @@ const extractSystemPrompt = `你从视觉小说(galgame)的作品简介中摘录
 3. 输出严格的 JSON 对象:键 = 名单中给出的角色名(逐字使用名单写法),值 = 摘录的介绍文本。没有任何可摘录的角色介绍时输出 {}。
 4. 只输出 JSON,不要输出解释或代码块围栏。`
 
-func extractUserMessage(c candidateWork) string {
-	var sb strings.Builder
-	sb.WriteString("角色名单:\n")
-	for _, r := range c.Roster {
-		sb.WriteString("- ")
-		sb.WriteString(r.Name)
-		if r.ZhName != "" && r.ZhName != r.Name {
-			sb.WriteString("(中文名: ")
-			sb.WriteString(r.ZhName)
-			sb.WriteString(")")
-		}
-		sb.WriteString("\n")
-	}
-	sb.WriteString("\n作品简介:\n")
-	sb.WriteString(c.Intro)
-	return sb.String()
-}
-
 // extraction is one work's answer: the model's name→passage map, or the error
 // that kept it from arriving. A failed work writes nothing and stays a
 // candidate, so the next run retries it.
@@ -156,59 +138,64 @@ type extraction struct {
 	Err   error
 }
 
-// extractor answers a BATCH of works. The OpenAI-compatible gateway has no
-// batch face and its adapter just loops; Cursor's only face is a batch, and
-// there the batch is what makes the lane affordable.
+// extractor answers a BATCH of works. Both gateways run the same batched
+// envelope (batch.go); they differ only in how one prompt becomes one reply.
 type extractor interface {
 	ExtractBatch(ctx context.Context, batch []candidateWork) []extraction
-}
-
-func (t *httpExtractor) ExtractBatch(ctx context.Context, batch []candidateWork) []extraction {
-	out := make([]extraction, len(batch))
-	for i, c := range batch {
-		found, model, err := t.Extract(ctx, c)
-		out[i] = extraction{Found: found, Model: model, Err: err}
-	}
-	return out
 }
 
 type httpExtractor struct {
 	baseURL   string
 	token     string
 	model     string
+	effort    string
 	maxTokens int
 	http      *http.Client
 }
 
-func newHTTPExtractor(baseURL, token, model string, maxTokens int) *httpExtractor {
+func newHTTPExtractor(baseURL, token, model, effort string, maxTokens int) *httpExtractor {
 	return &httpExtractor{
 		baseURL:   strings.TrimRight(baseURL, "/"),
 		token:     token,
 		model:     model,
+		effort:    effort,
 		maxTokens: maxTokens,
-		http:      &http.Client{Timeout: 300 * time.Second},
+		http:      &http.Client{Timeout: 600 * time.Second},
 	}
 }
 
 func (t *httpExtractor) Configured() bool { return t.baseURL != "" && t.token != "" }
 
-func (t *httpExtractor) Extract(ctx context.Context, c candidateWork) (map[string]string, string, error) {
+func (t *httpExtractor) ExtractBatch(ctx context.Context, batch []candidateWork) []extraction {
+	return extractBatchVia(ctx, t, batch, 0)
+}
+
+func (t *httpExtractor) CompareBatch(ctx context.Context, batch []comparison) []comparisonResult {
+	return compareBatchVia(ctx, t, batch, 0)
+}
+
+// callBatch sends one batched prompt as a chat completion: the rules are the
+// system message, the JSON array is the user message.
+func (t *httpExtractor) callBatch(ctx context.Context, b batchCall) (string, string, error) {
 	body := map[string]any{
 		"model":       t.model,
 		"max_tokens":  t.maxTokens,
 		"temperature": 0,
 		"messages": []map[string]string{
-			{"role": "system", "content": extractSystemPrompt},
-			{"role": "user", "content": extractUserMessage(c)},
+			{"role": "system", "content": b.Rules},
+			{"role": "user", "content": b.Items},
 		},
+	}
+	if t.effort != "" {
+		body["reasoning_effort"] = t.effort
 	}
 	raw, err := json.Marshal(body)
 	if err != nil {
-		return nil, "", err
+		return "", "", err
 	}
 	data, err := t.postChat(ctx, raw)
 	if err != nil {
-		return nil, "", err
+		return "", "", err
 	}
 	var cr struct {
 		Model   string `json:"model"`
@@ -223,44 +210,24 @@ func (t *httpExtractor) Extract(ctx context.Context, c candidateWork) (map[strin
 		} `json:"error"`
 	}
 	if err := json.Unmarshal(data, &cr); err != nil {
-		return nil, "", fmt.Errorf("decode chat response: %w", err)
+		return "", "", fmt.Errorf("decode chat response: %w", err)
 	}
 	if cr.Error != nil {
-		return nil, "", fmt.Errorf("gateway error: %s", cr.Error.Message)
+		return "", "", fmt.Errorf("gateway error: %s", cr.Error.Message)
 	}
 	if len(cr.Choices) == 0 {
-		return nil, "", fmt.Errorf("gateway returned no choices")
-	}
-	if fr := cr.Choices[0].FinishReason; fr != "" && fr != "stop" {
-		return nil, "", fmt.Errorf("generation finished with finish_reason=%q — refusing partial output", fr)
-	}
-	found, err := parseExtraction(cr.Choices[0].Message.Content)
-	if err != nil {
-		return nil, "", err
+		return "", "", fmt.Errorf("gateway returned no choices")
 	}
 	model := cr.Model
 	if model == "" {
 		model = t.model
 	}
-	return found, model, nil
-}
-
-// parseExtraction decodes the model's JSON object, tolerating a stray code
-// fence. Anything that is not a flat string→string object is an error.
-func parseExtraction(s string) (map[string]string, error) {
-	s = strings.TrimSpace(s)
-	s = strings.TrimPrefix(s, "```json")
-	s = strings.TrimPrefix(s, "```")
-	s = strings.TrimSuffix(s, "```")
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return nil, fmt.Errorf("empty extraction output")
+	// A cut-off reply keeps its text: the caller halves the batch and retries,
+	// and the partial array would fail the integrity gate anyway.
+	if fr := cr.Choices[0].FinishReason; fr != "" && fr != "stop" {
+		return cr.Choices[0].Message.Content, model, fmt.Errorf("%w (finish_reason=%q)", errBatchOversize, fr)
 	}
-	var out map[string]string
-	if err := json.Unmarshal([]byte(s), &out); err != nil {
-		return nil, fmt.Errorf("extraction is not a flat JSON object: %w", err)
-	}
-	return out, nil
+	return cr.Choices[0].Message.Content, model, nil
 }
 
 func truncate(s string, n int) string {

--- a/apps/api/cmd/extract-char-intros/extract.go
+++ b/apps/api/cmd/extract-char-intros/extract.go
@@ -35,9 +35,10 @@ type rosterChar struct {
 
 // candidateOpts is the window every bucket's loader applies identically.
 type candidateOpts struct {
-	Limit  int
-	Offset int
-	Since  string // RFC3339; keep only works whose elected zh intro changed since
+	Limit   int
+	Offset  int
+	Since   string  // RFC3339; keep only works whose elected zh intro changed since
+	WorkIDs []int64 // keep only these works — the retry lane for a failed batch
 }
 
 // sinceClause filters on the ELECTED intro's updated_at — the row the zhi CTE
@@ -59,6 +60,19 @@ func sinceArgs(since string) []any {
 }
 
 func window(works []candidateWork, o candidateOpts) []candidateWork {
+	if len(o.WorkIDs) > 0 {
+		want := make(map[int64]bool, len(o.WorkIDs))
+		for _, id := range o.WorkIDs {
+			want[id] = true
+		}
+		kept := works[:0:0]
+		for _, w := range works {
+			if want[w.WorkID] {
+				kept = append(kept, w)
+			}
+		}
+		works = kept
+	}
 	if o.Offset > 0 {
 		if o.Offset >= len(works) {
 			return nil

--- a/apps/api/cmd/extract-char-intros/extract_test.go
+++ b/apps/api/cmd/extract-char-intros/extract_test.go
@@ -99,6 +99,21 @@ func workIDsOf(works []candidateWork) []int64 {
 	return out
 }
 
+func TestRosterIndexTakesTheSpacesOutButNotAmbiguously(t *testing.T) {
+	roster := []rosterChar{
+		{CharacterID: 1, Name: "河合 葉月"},
+		{CharacterID: 2, Name: "坂本 水葉"},
+		{CharacterID: 3, Name: "坂本水葉"},
+	}
+
+	idx := rosterIndex(roster)
+	assert.Equal(t, int64(1), idx["河合 葉月"].CharacterID)
+	assert.Equal(t, int64(1), idx["河合葉月"].CharacterID, "an unspaced answer still finds its character")
+	assert.Equal(t, int64(2), idx["坂本 水葉"].CharacterID, "an exact name always wins")
+	assert.Equal(t, int64(3), idx["坂本水葉"].CharacterID,
+		"two roster names collapsing to one key must not let the squashed lookup guess")
+}
+
 func TestParseWorkIDs(t *testing.T) {
 	got, err := parseWorkIDs(" 23427, 23449 ,")
 	require.NoError(t, err)

--- a/apps/api/cmd/extract-char-intros/extract_test.go
+++ b/apps/api/cmd/extract-char-intros/extract_test.go
@@ -80,6 +80,38 @@ func TestNameAppears(t *testing.T) {
 	}
 }
 
+func TestWorkIDsNarrowTheBucketToARetryList(t *testing.T) {
+	works := []candidateWork{{WorkID: 11}, {WorkID: 22}, {WorkID: 33}}
+
+	got := window(works, candidateOpts{WorkIDs: []int64{33, 11, 99}})
+	assert.Equal(t, []int64{11, 33}, workIDsOf(got), "id order stays the candidate order, and an id off the bucket is silently absent")
+	assert.Equal(t, []int64{11, 22, 33}, workIDsOf(works), "the caller's slice is untouched")
+
+	got = window(works, candidateOpts{WorkIDs: []int64{11, 22, 33}, Offset: 1, Limit: 1})
+	assert.Equal(t, []int64{22}, workIDsOf(got), "offset and limit still apply to what is left")
+}
+
+func workIDsOf(works []candidateWork) []int64 {
+	out := make([]int64, 0, len(works))
+	for _, w := range works {
+		out = append(out, w.WorkID)
+	}
+	return out
+}
+
+func TestParseWorkIDs(t *testing.T) {
+	got, err := parseWorkIDs(" 23427, 23449 ,")
+	require.NoError(t, err)
+	assert.Equal(t, []int64{23427, 23449}, got)
+
+	got, err = parseWorkIDs("")
+	require.NoError(t, err)
+	assert.Nil(t, got, "no list means the whole bucket, not an empty one")
+
+	_, err = parseWorkIDs("23427,oops")
+	assert.Error(t, err)
+}
+
 type fakeExtractor struct {
 	out map[string]string
 }

--- a/apps/api/cmd/extract-char-intros/extract_test.go
+++ b/apps/api/cmd/extract-char-intros/extract_test.go
@@ -80,19 +80,6 @@ func TestNameAppears(t *testing.T) {
 	}
 }
 
-func TestParseExtraction(t *testing.T) {
-	got, err := parseExtraction("```json\n{\"沙耶\": \"青梅竹马。\"}\n```")
-	require.NoError(t, err)
-	assert.Equal(t, map[string]string{"沙耶": "青梅竹马。"}, got)
-
-	_, err = parseExtraction("[1,2]")
-	assert.Error(t, err, "a non-object payload must be refused")
-
-	got, err = parseExtraction("{}")
-	require.NoError(t, err)
-	assert.Empty(t, got)
-}
-
 type fakeExtractor struct {
 	out map[string]string
 }

--- a/apps/api/cmd/extract-char-intros/main.go
+++ b/apps/api/cmd/extract-char-intros/main.go
@@ -193,8 +193,8 @@ func run(ctx context.Context, db *gorm.DB, ex extractor, judge panelJudge, o opt
 			return err
 		}
 	}
-	fmt.Printf("\nworks=%d extracted=%d inserted=%d updated=%d conflict=%d refused_not_verbatim=%d refused_short=%d refused_name_absent=%d unmatched_name=%d call_errors=%d touched_works=%d\n",
-		len(works), st.Extracted, st.Inserted, st.Updated, st.Conflict, st.RefusedNotVerbatim, st.RefusedShort, st.RefusedNameAbsent, st.UnmatchedName, st.CallErrors, st.Touched)
+	fmt.Printf("\nworks=%d extracted=%d inserted=%d updated=%d conflict=%d refused_not_verbatim=%d refused_not_chinese=%d refused_short=%d refused_name_absent=%d unmatched_name=%d call_errors=%d touched_works=%d\n",
+		len(works), st.Extracted, st.Inserted, st.Updated, st.Conflict, st.RefusedNotVerbatim, st.RefusedNotChinese, st.RefusedShort, st.RefusedNameAbsent, st.UnmatchedName, st.CallErrors, st.Touched)
 	if o.Panel {
 		fmt.Printf("panel: adopted=%d kept_incumbent=%d panel_errors=%d\n", st.PanelAdopted, st.PanelKept, st.PanelErrors)
 	}

--- a/apps/api/cmd/extract-char-intros/main.go
+++ b/apps/api/cmd/extract-char-intros/main.go
@@ -54,12 +54,12 @@ func main() {
 	llmBase := flag.String("llm-base", envOr("KUN_INTRO_MT_LLM_BASE", os.Getenv("KUN_AI_UPSTREAM_BASE_URL")), "OpenAI-compatible gateway base URL (…/v1)")
 	llmToken := flag.String("llm-token", envOr("KUN_INTRO_MT_LLM_TOKEN", os.Getenv("KUN_AI_UPSTREAM_TOKEN")), "gateway bearer token")
 	cursorKeyFile := flag.String("cursor-key-file", "", "file holding the Cursor API key (or set CURSOR_API_KEY) — never pass a key on the command line")
-	cursorEffort := flag.String("cursor-effort", "low", "Cursor reasoning effort: low | medium | high | xhigh")
+	effort := flag.String("effort", "", "reasoning effort: low | medium | high (empty = the gateway's own default; the cursor lane needs one and falls back to low)")
 	runTimeout := flag.Duration("run-timeout", 20*time.Minute, "how long one Cursor agent run may take")
-	batch := flag.Int("batch", 0, "works per extraction call (0 = 1 for openai, 20 for cursor)")
-	judgeBatch := flag.Int("judge-batch", 0, "comparisons per judge call (0 = 1 for openai, 40 for cursor)")
+	batch := flag.Int("batch", 0, "works per extraction call (0 = 20)")
+	judgeBatch := flag.Int("judge-batch", 0, "comparisons per judge call (0 = 40)")
 	workers := flag.Int("workers", 0, "concurrent calls in flight (0 = 1 for openai, 6 for cursor)")
-	maxTokens := flag.Int("max-tokens", 16384, "max_tokens per extraction call (openai gateway only)")
+	maxTokens := flag.Int("max-tokens", 16384, "max_tokens per call (openai gateway only)")
 	delayMS := flag.Int("delay-ms", 0, "delay before each gateway call (ms)")
 	samples := flag.Int("samples", 5, "how many extracted samples to print")
 	flag.Parse()
@@ -90,14 +90,15 @@ func main() {
 	var judge panelJudge
 	switch *gateway {
 	case "openai":
-		http := newHTTPExtractor(*llmBase, *llmToken, *model, *maxTokens)
+		http := newHTTPExtractor(*llmBase, *llmToken, *model, *effort, *maxTokens)
 		if !http.Configured() {
 			fmt.Println("BLOCKED: LLM gateway not configured (need --llm-base + --llm-token, or KUN_INTRO_MT_LLM_* / KUN_AI_UPSTREAM_*).")
 			os.Exit(3)
 		}
 		ex, judge = http, http
-		defaultTo(batch, 1)
-		defaultTo(judgeBatch, 1)
+		defaultTo(batch, 20)
+		defaultTo(judgeBatch, 40)
+		// The gateway serialises per account, so extra workers only buy 429s.
 		defaultTo(workers, 1)
 	case "cursor":
 		key, err := readCursorKey(*cursorKeyFile)
@@ -105,7 +106,7 @@ func main() {
 			fmt.Println("BLOCKED: " + err.Error())
 			os.Exit(3)
 		}
-		cur := newCursorClient(key, cursorModel(*model), *cursorEffort, *runTimeout)
+		cur := newCursorClient(key, cursorModel(*model), orDefault(*effort, "low"), *runTimeout)
 		ex, judge = cur, cur
 		defaultTo(batch, 20)
 		defaultTo(judgeBatch, 40)
@@ -334,6 +335,15 @@ func mode(apply bool) string {
 		return "APPLY"
 	}
 	return "DRY"
+}
+
+// orDefault fills in for a flag the cursor lane cannot leave empty: its agent
+// API requires an effort param, while the chat face is happy to omit one.
+func orDefault(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
 }
 
 func envOr(key, fallback string) string {

--- a/apps/api/cmd/extract-char-intros/main.go
+++ b/apps/api/cmd/extract-char-intros/main.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -49,6 +50,7 @@ func main() {
 	since := flag.String("since", "", "only works whose elected zh intro changed at or after this RFC3339 time (a re-scan trigger, not a filter on the rows)")
 	limit := flag.Int("limit", 0, "max WORKS this run (0 = all) — ramp through a small limit first (the rehearsal rule)")
 	offset := flag.Int("offset", 0, "skip the first N candidate works (stable id order)")
+	workIDs := flag.String("work-ids", "", "comma-separated work ids to run instead of the whole bucket — the retry lane for works a batch failed on")
 	gateway := flag.String("gateway", "openai", "openai (chat/completions) or cursor (agent runs, batched)")
 	model := flag.String("model", envOr("KUN_INTRO_MT_LLM_MODEL", envOr("KUN_AI_UPSTREAM_MODEL", "glm-5.2")), "served model id")
 	llmBase := flag.String("llm-base", envOr("KUN_INTRO_MT_LLM_BASE", os.Getenv("KUN_AI_UPSTREAM_BASE_URL")), "OpenAI-compatible gateway base URL (…/v1)")
@@ -79,6 +81,11 @@ func main() {
 			slog.Error("--since must be RFC3339", "value", *since, "error", err)
 			os.Exit(2)
 		}
+	}
+	ids, err := parseWorkIDs(*workIDs)
+	if err != nil {
+		slog.Error("--work-ids", "error", err)
+		os.Exit(2)
 	}
 	db, err := database.OpenJob(*dsn)
 	if err != nil {
@@ -121,7 +128,7 @@ func main() {
 
 	if err := run(context.Background(), db, ex, judge, opts{
 		Apply: *apply, Panel: *panel, Refresh: *refresh,
-		Cand:  candidateOpts{Limit: *limit, Offset: *offset, Since: *since},
+		Cand:  candidateOpts{Limit: *limit, Offset: *offset, Since: *since, WorkIDs: ids},
 		Batch: *batch, JudgeBatch: *judgeBatch, Workers: *workers,
 		Delay: time.Duration(*delayMS) * time.Millisecond, Samples: *samples,
 	}); err != nil {
@@ -335,6 +342,26 @@ func mode(apply bool) string {
 		return "APPLY"
 	}
 	return "DRY"
+}
+
+func parseWorkIDs(csv string) ([]int64, error) {
+	csv = strings.TrimSpace(csv)
+	if csv == "" {
+		return nil, nil
+	}
+	var out []int64
+	for field := range strings.SplitSeq(csv, ",") {
+		field = strings.TrimSpace(field)
+		if field == "" {
+			continue
+		}
+		id, err := strconv.ParseInt(field, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("%q is not a work id", field)
+		}
+		out = append(out, id)
+	}
+	return out, nil
 }
 
 // orDefault fills in for a flag the cursor lane cannot leave empty: its agent

--- a/apps/api/cmd/extract-char-intros/panel.go
+++ b/apps/api/cmd/extract-char-intros/panel.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strings"
 
 	"api/internal/platform/catalog/editspec"
 
@@ -104,15 +102,6 @@ type panelJudge interface {
 	CompareBatch(ctx context.Context, batch []comparison) []comparisonResult
 }
 
-func (t *httpExtractor) CompareBatch(ctx context.Context, batch []comparison) []comparisonResult {
-	out := make([]comparisonResult, len(batch))
-	for i, c := range batch {
-		v, err := t.Compare(ctx, c.Name, c.Incumbent, c.Challenger, c.ChallengerFirst)
-		out[i] = comparisonResult{Vote: v, Err: err}
-	}
-	return out
-}
-
 const panelVotes = 3
 
 // panelVerdict folds three votes by direction: equal votes are not opposing
@@ -131,68 +120,15 @@ func panelVerdict(votes []panelVote) bool {
 	return incumbent == 0 && challenger >= 2
 }
 
-const judgeSystemPrompt = `你在为视觉小说(galgame)数据库挑选更好的一段中文角色介绍。给你角色名和两段候选文本 A、B。
+const judgeSystemPrompt = `你在为视觉小说(galgame)数据库挑选更好的一段中文角色介绍。每个条目给出角色名和两段候选文本 A、B。
 判据(按重要性):
 1. 介绍性:说明角色的身份、性格、外貌或与他人的关系。纯剧情叙述、只在事件中顺带提到角色的文本不合格。
 2. 信息量:具体、有内容,不是空话。
 3. 通顺自然的中文;机翻腔、辞不达意、残缺句是硬伤。
-两段都合格且相当时输出 equal。只输出严格 JSON:{"winner":"A"} 或 {"winner":"B"} 或 {"winner":"equal"},不要解释。`
+两段都合格且相当时输出 equal。每项的 winner 取值只能是 "A"、"B"、"equal" 三者之一。`
 
-func (t *httpExtractor) Compare(ctx context.Context, name, incumbent, challenger string, challengerFirst bool) (panelVote, error) {
-	first, second := incumbent, challenger
-	if challengerFirst {
-		first, second = challenger, incumbent
-	}
-	user := fmt.Sprintf("角色:%s\n\nA:\n%s\n\nB:\n%s", name, first, second)
-	body := map[string]any{
-		"model":       t.model,
-		"max_tokens":  t.maxTokens,
-		"temperature": 0,
-		"messages": []map[string]string{
-			{"role": "system", "content": judgeSystemPrompt},
-			{"role": "user", "content": user},
-		},
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return voteEqual, err
-	}
-	data, err := t.postChat(ctx, raw)
-	if err != nil {
-		return voteEqual, err
-	}
-	var cr struct {
-		Choices []struct {
-			Message struct {
-				Content string `json:"content"`
-			} `json:"message"`
-			FinishReason string `json:"finish_reason"`
-		} `json:"choices"`
-		Error *struct {
-			Message string `json:"message"`
-		} `json:"error"`
-	}
-	if err := json.Unmarshal(data, &cr); err != nil {
-		return voteEqual, fmt.Errorf("decode judge response: %w", err)
-	}
-	if cr.Error != nil {
-		return voteEqual, fmt.Errorf("gateway error: %s", cr.Error.Message)
-	}
-	if len(cr.Choices) == 0 {
-		return voteEqual, fmt.Errorf("gateway returned no choices")
-	}
-	if fr := cr.Choices[0].FinishReason; fr != "" && fr != "stop" {
-		return voteEqual, fmt.Errorf("judge finished with finish_reason=%q", fr)
-	}
-	winner, err := parseJudgeWinner(cr.Choices[0].Message.Content)
-	if err != nil {
-		return voteEqual, err
-	}
-	return voteOf(winner, challengerFirst), nil
-}
-
-// voteOf maps the judge's answer back onto the two passages. parseJudgeWinner
-// (and the batch lane's own check) already rejected anything but A/B/equal.
+// voteOf maps the judge's answer back onto the two passages. Anything but
+// A/B/equal lands on equal, and the batch lane turns that into an error.
 func voteOf(winner string, challengerFirst bool) panelVote {
 	switch winner {
 	case "A":
@@ -207,22 +143,4 @@ func voteOf(winner string, challengerFirst bool) panelVote {
 		return voteChallenger
 	}
 	return voteEqual
-}
-
-func parseJudgeWinner(s string) (string, error) {
-	s = strings.TrimSpace(s)
-	s = strings.TrimPrefix(s, "```json")
-	s = strings.TrimPrefix(s, "```")
-	s = strings.TrimSuffix(s, "```")
-	var out struct {
-		Winner string `json:"winner"`
-	}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(s)), &out); err != nil {
-		return "", fmt.Errorf("judge output is not the expected JSON: %w", err)
-	}
-	w := strings.TrimSpace(out.Winner)
-	if w != "A" && w != "B" && w != "equal" {
-		return "", fmt.Errorf("judge answered %q", w)
-	}
-	return w, nil
 }

--- a/apps/api/cmd/extract-char-intros/refresh_test.go
+++ b/apps/api/cmd/extract-char-intros/refresh_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,6 +94,45 @@ func TestRunRefreshKeepsTheRowWhenNothingIsExtractable(t *testing.T) {
 			WHERE character_id = ?`, saya).Scan(&intro).Error)
 		assert.Equal(t, "旧的摘录。", intro, "a character never loses its intro to a failed refresh")
 	}
+}
+
+// Every string here is a real derived row from prod, picked off the
+// hiragana-ratio bands the 2026-08-22 rehearsal measured. The Chinese rows
+// around 30% are why the gate strips parenthesised readings first: by raw
+// ratio they sit ABOVE the Japanese prose it has to refuse.
+func TestLooksJapaneseSeparatesProseFromFurigana(t *testing.T) {
+	cases := []struct {
+		want bool
+		text string
+	}{
+		{true, "一方、兄の虎鉄は無名……どころか、一部には悪評がついて回る。\n大部分は誤解だが、しかし彼の金髪が威圧的なことは、言い逃れできない事実であり、"},
+		{true, "主人公の栂野 遥平は姉御肌でキャリアウーマンの母親——夏帆と、優しく家事万能である従姉の文香と三人で仲良く暮らしていた。"},
+		{true, "女子の比率が圧倒的に多い白鷺（しらさぎ）学園にて、騒がしいながらも平和に過ごしていた『加我見 和也』。"},
+		{false, "主人公藤宫晴真（ふじみや はるま），是上奈木（かみなぎ）学园的2年级学生。"},
+		{false, "幼年丧母的主人公『志賀海人（しが　かいと）』，像对待真正的母亲一样爱慕着身为继母的『志賀小夜』。"},
+		{false, "在高级美容按摩店工作的按摩师，安馬指男（あんまゆびお）25岁。"},
+		{false, "主人公“ターサ”是为了生存而进行盗窃的盗贼。与孤儿少女“秋秋(チュチュ)”穿越沙漠从一座城市旅行到另一座城市。"},
+		{false, "就这样，主人公いぶき一边借助青梅竹马あやめ的帮助，一边作为女学生开始了宿舍生活。"},
+		{false, "主人公的青梅竹马,性格开朗,总是照顾身边的每一个人。"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, looksJapanese(c.text), truncate(c.text, 30))
+	}
+}
+
+func TestRunRefusesJapaneseProse(t *testing.T) {
+	require.NoError(t, testDB.Exec(`TRUNCATE catalog_work, catalog_character RESTART IDENTITY CASCADE`).Error)
+	jaTail := "\n\n一方、兄の虎鉄は無名……どころか、一部には悪評がついて回る。大部分は誤解だが、しかし彼の金髪が威圧的なことは、言い逃れできない事実である。"
+	workID := seedWorkWithIntro(t, longIntro+jaTail)
+	kotetsu := seedRosterChar(t, workID, "虎鉄")
+
+	ex := fakeExtractor{out: map[string]string{"虎鉄": strings.TrimSpace(jaTail)}}
+	require.NoError(t, run(context.Background(), testDB, ex, nil, opts{Apply: true}))
+
+	var n int64
+	require.NoError(t, testDB.Raw(`SELECT count(*) FROM catalog_character_intro
+		WHERE character_id = ?`, kotetsu).Scan(&n).Error)
+	assert.Zero(t, n, "Japanese prose is verbatim in the intro and must still be refused")
 }
 
 func TestSinceFiltersOnTheElectedIntro(t *testing.T) {

--- a/apps/api/cmd/extract-char-intros/write.go
+++ b/apps/api/cmd/extract-char-intros/write.go
@@ -69,16 +69,18 @@ type gated struct {
 // batched across works, so gate only sorts the survivors into those that can
 // be written straight away and those that need a verdict first.
 func (w *writer) gate(cand candidateWork, found map[string]string, mtModel string) (ready, contested []gated) {
-	byName := make(map[string]rosterChar, len(cand.Roster))
-	for _, r := range cand.Roster {
-		byName[r.Name] = r
-	}
+	byName := rosterIndex(cand.Roster)
 	srcHash := hashText(cand.Intro)
 	for name, passage := range found {
 		w.st.Extracted++
-		target, ok := byName[strings.TrimSpace(name)]
+		name = strings.TrimSpace(name)
+		target, ok := byName[name]
+		if !ok {
+			target, ok = byName[squashSpace(name)]
+		}
 		if !ok {
 			w.st.UnmatchedName++
+			slog.Warn("extraction key is not a roster name", "work", cand.WorkID, "name", name)
 			continue
 		}
 		passage = strings.TrimSpace(passage)
@@ -117,6 +119,34 @@ func (w *writer) gate(cand candidateWork, found map[string]string, mtModel strin
 	}
 	return ready, contested
 }
+
+// rosterIndex keys the roster by name and, where it is unambiguous, by the
+// name with its spaces taken out. Asked for 「河合 葉月」 a model answers
+// 「河合葉月」 often enough to matter, and an exact-key lookup files that good
+// passage in the unmatched bucket (6 of 10 extractions on the 2026-08-22 fill
+// retry). Two roster names that collapse to the same key get no squashed entry
+// at all: guessing there hangs the passage on the wrong character.
+func rosterIndex(roster []rosterChar) map[string]rosterChar {
+	byName := make(map[string]rosterChar, len(roster)*2)
+	for _, r := range roster {
+		byName[r.Name] = r
+	}
+	seen := make(map[string]int, len(roster))
+	for _, r := range roster {
+		seen[squashSpace(r.Name)]++
+	}
+	for _, r := range roster {
+		k := squashSpace(r.Name)
+		if _, taken := byName[k]; !taken && seen[k] == 1 {
+			byName[k] = r
+		}
+	}
+	return byName
+}
+
+var spaceStripper = strings.NewReplacer(" ", "", "\t", "", "\u3000", "")
+
+func squashSpace(s string) string { return spaceStripper.Replace(s) }
 
 // commit writes one gated passage: a fresh derived row, or a rewrite of the
 // stale one in the refresh bucket.

--- a/apps/api/cmd/extract-char-intros/write.go
+++ b/apps/api/cmd/extract-char-intros/write.go
@@ -6,8 +6,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"api/internal/platform/catalog/model"
@@ -28,6 +30,7 @@ type stats struct {
 	Updated            int
 	Conflict           int
 	RefusedNotVerbatim int
+	RefusedNotChinese  int
 	RefusedShort       int
 	RefusedNameAbsent  int
 	UnmatchedName      int
@@ -92,6 +95,12 @@ func (w *writer) gate(cand candidateWork, found map[string]string, mtModel strin
 		if !verbatim(cand.Intro, passage) {
 			w.st.RefusedNotVerbatim++
 			slog.Warn("extraction failed the verbatim gate", "work", cand.WorkID,
+				"character", target.CharacterID, "name", name)
+			continue
+		}
+		if looksJapanese(passage) {
+			w.st.RefusedNotChinese++
+			slog.Warn("passage is Japanese prose, not a zh intro", "work", cand.WorkID,
 				"character", target.CharacterID, "name", name)
 			continue
 		}
@@ -298,6 +307,34 @@ func nameAppears(intro string, target rosterChar) bool {
 		}
 	}
 	return false
+}
+
+var parenSpan = regexp.MustCompile(`[（(][^）)]*[）)]`)
+
+// looksJapanese refuses a passage that is Japanese prose rather than Chinese.
+// A zh-Hans work intro can still carry untranslated Japanese, and the verbatim
+// gate is happy to quote it — the 2026-08-22 refresh rehearsal filed
+// 「一方、兄の虎鉄は無名……」 as a Chinese character intro.
+//
+// The hiragana ratio alone does NOT separate the two: measured over the whole
+// derived face, a Chinese intro carrying furigana readings reaches 29.7%
+// (主人公藤宫晴真（ふじみや はるま），是上奈木（かみなぎ）学园的…) while real
+// Japanese prose starts at 31.7%. Parenthesised readings are the whole
+// difference, so they come out first; what is left is Chinese with at most a
+// few kana names in it.
+func looksJapanese(passage string) bool {
+	s := parenSpan.ReplaceAllString(passage, "")
+	var hira, total int
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		total++
+		if r >= 'ぁ' && r <= 'ゖ' {
+			hira++
+		}
+	}
+	return total > 0 && float64(hira)/float64(total) > 0.30
 }
 
 var matchStripper = strings.NewReplacer(


### PR DESCRIPTION
fix(catalog): match an extraction key with its spaces taken out

Roster names carry a space (河合 葉月) and the model answers without one
(河合葉月). The lookup was an exact map hit, so a perfectly good passage
went to the unmatched-name bucket and the character kept no intro at
all: 6 of 10 extractions on the 2026-08-22 fill retry died this way, and
nothing in the output said which name had failed — the counter had no
log line behind it.

Two roster names that collapse to the same key get no squashed entry, so
the fallback never guesses which character a passage belongs to.
