### PR TITLE
fix(catalog): match an extraction key with its spaces taken out

### DIFF
--- a/apps/api/cmd/extract-char-intros/extract_test.go
+++ b/apps/api/cmd/extract-char-intros/extract_test.go
@@ -99,6 +99,21 @@ func workIDsOf(works []candidateWork) []int64 {
 	return out
 }
 
+func TestRosterIndexTakesTheSpacesOutButNotAmbiguously(t *testing.T) {
+	roster := []rosterChar{
+		{CharacterID: 1, Name: "河合 葉月"},
+		{CharacterID: 2, Name: "坂本 水葉"},
+		{CharacterID: 3, Name: "坂本水葉"},
+	}
+
+	idx := rosterIndex(roster)
+	assert.Equal(t, int64(1), idx["河合 葉月"].CharacterID)
+	assert.Equal(t, int64(1), idx["河合葉月"].CharacterID, "an unspaced answer still finds its character")
+	assert.Equal(t, int64(2), idx["坂本 水葉"].CharacterID, "an exact name always wins")
+	assert.Equal(t, int64(3), idx["坂本水葉"].CharacterID,
+		"two roster names collapsing to one key must not let the squashed lookup guess")
+}
+
 func TestParseWorkIDs(t *testing.T) {
 	got, err := parseWorkIDs(" 23427, 23449 ,")
 	require.NoError(t, err)

--- a/apps/api/cmd/extract-char-intros/write.go
+++ b/apps/api/cmd/extract-char-intros/write.go
@@ -69,16 +69,18 @@ type gated struct {
 // batched across works, so gate only sorts the survivors into those that can
 // be written straight away and those that need a verdict first.
 func (w *writer) gate(cand candidateWork, found map[string]string, mtModel string) (ready, contested []gated) {
-	byName := make(map[string]rosterChar, len(cand.Roster))
-	for _, r := range cand.Roster {
-		byName[r.Name] = r
-	}
+	byName := rosterIndex(cand.Roster)
 	srcHash := hashText(cand.Intro)
 	for name, passage := range found {
 		w.st.Extracted++
-		target, ok := byName[strings.TrimSpace(name)]
+		name = strings.TrimSpace(name)
+		target, ok := byName[name]
+		if !ok {
+			target, ok = byName[squashSpace(name)]
+		}
 		if !ok {
 			w.st.UnmatchedName++
+			slog.Warn("extraction key is not a roster name", "work", cand.WorkID, "name", name)
 			continue
 		}
 		passage = strings.TrimSpace(passage)
@@ -117,6 +119,34 @@ func (w *writer) gate(cand candidateWork, found map[string]string, mtModel strin
 	}
 	return ready, contested
 }
+
+// rosterIndex keys the roster by name and, where it is unambiguous, by the
+// name with its spaces taken out. Asked for 「河合 葉月」 a model answers
+// 「河合葉月」 often enough to matter, and an exact-key lookup files that good
+// passage in the unmatched bucket (6 of 10 extractions on the 2026-08-22 fill
+// retry). Two roster names that collapse to the same key get no squashed entry
+// at all: guessing there hangs the passage on the wrong character.
+func rosterIndex(roster []rosterChar) map[string]rosterChar {
+	byName := make(map[string]rosterChar, len(roster)*2)
+	for _, r := range roster {
+		byName[r.Name] = r
+	}
+	seen := make(map[string]int, len(roster))
+	for _, r := range roster {
+		seen[squashSpace(r.Name)]++
+	}
+	for _, r := range roster {
+		k := squashSpace(r.Name)
+		if _, taken := byName[k]; !taken && seen[k] == 1 {
+			byName[k] = r
+		}
+	}
+	return byName
+}
+
+var spaceStripper = strings.NewReplacer(" ", "", "\t", "", "\u3000", "")
+
+func squashSpace(s string) string { return spaceStripper.Replace(s) }
 
 // commit writes one gated passage: a fresh derived row, or a rewrite of the
 // stale one in the refresh bucket.


### PR DESCRIPTION
fix(catalog): match an extraction key with its spaces taken out

Roster names carry a space (河合 葉月) and the model answers without one
(河合葉月). The lookup was an exact map hit, so a perfectly good passage
went to the unmatched-name bucket and the character kept no intro at
all: 6 of 10 extractions on the 2026-08-22 fill retry died this way, and
nothing in the output said which name had failed — the counter had no
log line behind it.

Two roster names that collapse to the same key get no squashed entry, so
the fallback never guesses which character a passage belongs to.
