### PR TITLE
fix(catalog): let a call the gateway gave up on reach the split retry

### DIFF
--- a/apps/api/cmd/extract-char-intros/batch.go
+++ b/apps/api/cmd/extract-char-intros/batch.go
@@ -29,10 +29,11 @@ type promptCaller interface {
 	callBatch(ctx context.Context, c batchCall) (text, model string, err error)
 }
 
-// errBatchOversize marks a reply the gateway cut short. It is the one call
-// failure that halving the batch can fix, so it reaches the split retry
-// instead of failing every item outright.
-var errBatchOversize = errors.New("reply truncated before it finished")
+// errBatchOversize marks a call that a SMALLER call might have survived: the
+// reply was cut off at max_tokens, or the gateway ran out of patience with one
+// that took too long. Only these reach the split retry; every other failure
+// fails its batch outright.
+var errBatchOversize = errors.New("batch too big for one call")
 
 const batchEnvelopeRules = `下面是一个 JSON 数组,每项是一个待处理条目,` + "`i`" + ` 是它的序号。
 逐项独立处理,输出 JSON 数组 %s。

--- a/apps/api/cmd/extract-char-intros/batch_test.go
+++ b/apps/api/cmd/extract-char-intros/batch_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,8 +67,9 @@ type chatReq struct {
 }
 
 type chatProbe struct {
-	ex   *httpExtractor
-	reqs []chatReq
+	ex     *httpExtractor
+	reqs   []chatReq
+	status func(n int) int // HTTP status for the nth call; nil means 200
 }
 
 func fakeChat(t *testing.T, answer func(req chatReq, n int) (content, finish string)) *chatProbe {
@@ -80,6 +82,12 @@ func fakeChat(t *testing.T, answer func(req chatReq, n int) (content, finish str
 		var req chatReq
 		require.NoError(t, json.Unmarshal(body, &req))
 		p.reqs = append(p.reqs, req)
+		if p.status != nil {
+			if code := p.status(len(p.reqs)); code != http.StatusOK {
+				http.Error(w, "error code: "+http.StatusText(code), code)
+				return
+			}
+		}
 		content, finish := answer(req, len(p.reqs))
 		out, _ := json.Marshal(map[string]any{
 			"model": "grok-4.6",
@@ -174,4 +182,28 @@ func TestHTTPBatchOmitsEffortWhenUnset(t *testing.T) {
 	out := p.ex.ExtractBatch(context.Background(), twoWorks()[:1])
 	require.NoError(t, out[0].Err)
 	assert.Empty(t, p.reqs[0].ReasoningEffort, fmt.Sprintf("req: %+v", p.reqs[0]))
+}
+
+// Cloudflare answers 524 once the origin passes 100s, which a 40-work
+// extraction does. Failing the whole batch there costs 40 works at a time, so
+// an exhausted retryable status has to reach the split retry like a truncated
+// reply does.
+func TestHTTPBatchSplitsWhenTheGatewayGivesUp(t *testing.T) {
+	orig := retryBackoff
+	retryBackoff = []time.Duration{time.Millisecond}
+	t.Cleanup(func() { retryBackoff = orig })
+
+	p := fakeChat(t, func(chatReq, int) (string, string) { return `[{"i":0,"摘录":{}}]`, "stop" })
+	p.status = func(n int) int {
+		if n <= len(retryBackoff)+1 {
+			return 524 // the first call and every one of its retries
+		}
+		return http.StatusOK
+	}
+
+	out := p.ex.ExtractBatch(context.Background(), twoWorks())
+	require.Len(t, out, 2)
+	for i, e := range out {
+		require.NoError(t, e.Err, "work %d survived on a half-sized call", i)
+	}
 }

--- a/apps/api/cmd/extract-char-intros/gateway.go
+++ b/apps/api/cmd/extract-char-intros/gateway.go
@@ -24,8 +24,15 @@ func (t *httpExtractor) postChat(ctx context.Context, raw []byte) ([]byte, error
 		}
 		retryable := status == 0 || status == http.StatusTooManyRequests ||
 			status == http.StatusRequestTimeout || status >= http.StatusInternalServerError
-		if !retryable || attempt >= len(retryBackoff) {
+		if !retryable {
 			return nil, err
+		}
+		// Out of retries on a failure a SMALLER call might survive, so hand it to
+		// the split retry rather than failing the whole batch. Cloudflare answers
+		// 524 once the origin passes 100s, which a 40-work extraction does often
+		// enough to cost 40 works at a time (2026-08-22 panel run).
+		if attempt >= len(retryBackoff) {
+			return nil, fmt.Errorf("%w: %v", errBatchOversize, err)
 		}
 		select {
 		case <-time.After(retryBackoff[attempt]):


### PR DESCRIPTION
fix(catalog): let a call the gateway gave up on reach the split retry

Cloudflare answers 524 once the origin passes 100 seconds, and a 40-work
extraction passes it often enough to matter: the 2026-08-22 panel run
lost 40 works in one go, twice, to

  gateway http 524: error code: 524

A truncated reply already reached the split retry, because halving is
exactly the fix for a call that was too big. A call the gateway timed
out on is the same situation and was failing its whole batch instead.
So an exhausted retryable status now carries errBatchOversize, which is
renamed from "reply truncated" to what it actually means: this batch was
too big for one call.

Non-retryable failures (auth, a bad request) are unchanged — halving
those would just double the damage.
