### PR TITLE
fix(catalog): never let the panel put kana names back into a clean intro

### DIFF
--- a/apps/api/cmd/extract-char-intros/extract_test.go
+++ b/apps/api/cmd/extract-char-intros/extract_test.go
@@ -99,6 +99,31 @@ func workIDsOf(works []candidateWork) []int64 {
 	return out
 }
 
+func TestHasBareKanaIgnoresParenthesisedReadings(t *testing.T) {
+	assert.False(t, hasBareKana("主人公藤宫晴真（ふじみや はるま），是上奈木学园的学生。"),
+		"furigana in parentheses is legitimate in a Chinese intro")
+	assert.True(t, hasBareKana("曾与いぶき和なずな一起解决事件。"), "kana in the running text is an untranslated name")
+	assert.True(t, hasBareKana("ミア是被卖掉的亚人少女。"), "katakana counts too")
+	assert.False(t, hasBareKana("秀一最爱的妻子，顾家、开朗且性格温柔。"))
+}
+
+func TestPanelRefusesAnExcerptThatPutsKanaBack(t *testing.T) {
+	w := &writer{st: &stats{}, judge: shortJudge{}}
+	intro := "「沙耶」\n曾与いぶき和なずな一起为了解决事件，使用擅长的幽体脱离进行侦察任务。\n\n「玲」\n转校生，沉默寡言，但其实很受班上同学欢迎，擅长做点心。"
+	cand := candidateWork{WorkID: 1, Intro: intro, Roster: []rosterChar{
+		{CharacterID: 1, Name: "沙耶", Incumbent: "青梅竹马，性格开朗。"},
+		{CharacterID: 2, Name: "玲", Incumbent: "转学过来的女孩子。"},
+	}}
+
+	_, contested := w.gate(cand, map[string]string{
+		"沙耶": "曾与いぶき和なずな一起为了解决事件，使用擅长的幽体脱离进行侦察任务。",
+		"玲":  "转校生，沉默寡言，但其实很受班上同学欢迎，擅长做点心。",
+	}, "grok-4.6")
+	require.Len(t, contested, 1, "only the excerpt that keeps the intro kana-free reaches the panel")
+	assert.Equal(t, int64(2), contested[0].Target.CharacterID)
+	assert.Equal(t, 1, w.st.RefusedKanaBack)
+}
+
 func TestRosterIndexTakesTheSpacesOutButNotAmbiguously(t *testing.T) {
 	roster := []rosterChar{
 		{CharacterID: 1, Name: "河合 葉月"},

--- a/apps/api/cmd/extract-char-intros/main.go
+++ b/apps/api/cmd/extract-char-intros/main.go
@@ -201,8 +201,8 @@ func run(ctx context.Context, db *gorm.DB, ex extractor, judge panelJudge, o opt
 			return err
 		}
 	}
-	fmt.Printf("\nworks=%d extracted=%d inserted=%d updated=%d conflict=%d refused_not_verbatim=%d refused_not_chinese=%d refused_short=%d refused_name_absent=%d unmatched_name=%d call_errors=%d touched_works=%d\n",
-		len(works), st.Extracted, st.Inserted, st.Updated, st.Conflict, st.RefusedNotVerbatim, st.RefusedNotChinese, st.RefusedShort, st.RefusedNameAbsent, st.UnmatchedName, st.CallErrors, st.Touched)
+	fmt.Printf("\nworks=%d extracted=%d inserted=%d updated=%d conflict=%d refused_not_verbatim=%d refused_not_chinese=%d refused_short=%d refused_name_absent=%d refused_kana_back=%d unmatched_name=%d call_errors=%d touched_works=%d\n",
+		len(works), st.Extracted, st.Inserted, st.Updated, st.Conflict, st.RefusedNotVerbatim, st.RefusedNotChinese, st.RefusedShort, st.RefusedNameAbsent, st.RefusedKanaBack, st.UnmatchedName, st.CallErrors, st.Touched)
 	if o.Panel {
 		fmt.Printf("panel: adopted=%d kept_incumbent=%d panel_errors=%d\n", st.PanelAdopted, st.PanelKept, st.PanelErrors)
 	}

--- a/apps/api/cmd/extract-char-intros/write.go
+++ b/apps/api/cmd/extract-char-intros/write.go
@@ -34,6 +34,7 @@ type stats struct {
 	RefusedShort       int
 	RefusedNameAbsent  int
 	UnmatchedName      int
+	RefusedKanaBack    int
 	CallErrors         int
 	Touched            int
 	PanelAdopted       int
@@ -108,6 +109,17 @@ func (w *writer) gate(cand candidateWork, found map[string]string, mtModel strin
 		}
 		g := gated{WorkID: cand.WorkID, Target: target, Passage: passage, SrcHash: srcHash, MTModel: mtModel}
 		if target.Incumbent != "" && w.judge != nil {
+			// The panel scores 介绍性/信息量/通顺中文 and gives kana no weight at
+			// all, so it will happily adopt a better-written excerpt that puts kana
+			// names back into a clean incumbent — the exact complaint this wave
+			// exists to fix. 3 of the first 24 adoptions on 2026-08-22 did that,
+			// against 2 that fixed one. Refuse the regression before it costs votes.
+			if hasBareKana(passage) && !hasBareKana(target.Incumbent) {
+				w.st.RefusedKanaBack++
+				slog.Warn("excerpt would put kana names back into a clean intro", "work", cand.WorkID,
+					"character", target.CharacterID, "name", name)
+				continue
+			}
 			contested = append(contested, g)
 			continue
 		}
@@ -340,6 +352,15 @@ func nameAppears(intro string, target rosterChar) bool {
 }
 
 var parenSpan = regexp.MustCompile(`[（(][^）)]*[）)]`)
+
+var bareKana = regexp.MustCompile(`[ぁ-ゖァ-ヺ]{2,}`)
+
+// hasBareKana reports whether kana survive OUTSIDE parentheses. Parenthesised
+// readings are legitimate in a Chinese intro (藤宫晴真（ふじみや はるま）); kana
+// in the running text is an untranslated name.
+func hasBareKana(s string) bool {
+	return bareKana.MatchString(parenSpan.ReplaceAllString(s, ""))
+}
 
 // looksJapanese refuses a passage that is Japanese prose rather than Chinese.
 // A zh-Hans work intro can still carry untranslated Japanese, and the verbatim


### PR DESCRIPTION
fix(catalog): never let the panel put kana names back into a clean intro

The judge scores 介绍性 / 信息量 / 通顺中文 and weighs kana at zero, so a
better-written excerpt can win while carrying untranslated kana names —
which is the complaint the whole wave exists to fix. Measured on the
first 24 adoptions of the 2026-08-22 panel run:

  FIXED (incumbent had kana, excerpt does not)   2
  WORSE (incumbent was clean, excerpt has kana)  3

Net negative on the axis that matters, from a panel whose criteria never
mention it. This is a deterministic property, not a judgement call, so it
belongs in gate() with the other refusals rather than in the prompt: an
excerpt that carries kana outside parentheses is refused when the
incumbent does not, before it costs three votes.

Parenthesised readings stay legitimate — 藤宫晴真（ふじみや はるま） is a
correct Chinese intro, and 576 of the rows this wave touched are that
shape. Only kana in the running text counts.
