### PR TITLE
fix(catalog): --workers 1 must mean one gateway call, not one per stage

### DIFF
--- a/apps/api/cmd/extract-char-intros/cursor_test.go
+++ b/apps/api/cmd/extract-char-intros/cursor_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -159,7 +160,7 @@ func TestVoteDispatchChunksAndKeepsOrder(t *testing.T) {
 		cmps[i] = comparison{Name: fmt.Sprint(i), ChallengerFirst: i%2 == 1}
 	}
 
-	out := voteDispatch(j, 2, 1, 0)(context.Background(), cmps)
+	out := voteDispatch(j, 2, newCallSlots(1), 0)(context.Background(), cmps)
 	require.Len(t, out, 5)
 	assert.Equal(t, []int{2, 2, 1}, j.batches)
 	for i, r := range out {
@@ -182,10 +183,51 @@ func TestResolvePanelKeepsIncumbentWhenARoundFails(t *testing.T) {
 	w := &writer{st: &stats{}, judge: shortJudge{}}
 	contested := []gated{{WorkID: 1, Target: rosterChar{CharacterID: 1, Name: "沙耶", Incumbent: "既有"}, Passage: "提取"}}
 
-	adopted := w.resolvePanel(context.Background(), contested, voteDispatch(shortJudge{}, 10, 1, 0))
+	adopted := w.resolvePanel(context.Background(), contested, voteDispatch(shortJudge{}, 10, newCallSlots(1), 0))
 	assert.Empty(t, adopted)
 	assert.Equal(t, 1, w.st.PanelErrors)
 	assert.Zero(t, w.st.PanelKept, "an unjudged character is not a kept verdict — it is retryable")
+}
+
+type trackingExtractor struct{ enter func() func() }
+
+func (e trackingExtractor) ExtractBatch(_ context.Context, batch []candidateWork) []extraction {
+	defer e.enter()()
+	return make([]extraction, len(batch))
+}
+
+type trackingJudge struct{ enter func() func() }
+
+func (j trackingJudge) CompareBatch(_ context.Context, batch []comparison) []comparisonResult {
+	defer j.enter()()
+	return make([]comparisonResult, len(batch))
+}
+
+// --workers 1 has to mean one gateway call in flight, not one per stage. With a
+// semaphore each, extractBatches prefetches the next extraction while the
+// consumer is still judging the previous batch — two calls at once, which a
+// gateway that serialises per account answers with 429.
+func TestCallSlotsBoundBothStagesTogether(t *testing.T) {
+	var inFlight, peak atomic.Int32
+	enter := func() func() {
+		n := inFlight.Add(1)
+		for {
+			p := peak.Load()
+			if n <= p || peak.CompareAndSwap(p, n) {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		return func() { inFlight.Add(-1) }
+	}
+	slots := newCallSlots(1)
+	dispatch := voteDispatch(trackingJudge{enter}, 1, slots, 0)
+
+	batches := chunkWorks(make([]candidateWork, 6), 2)
+	for range extractBatches(context.Background(), trackingExtractor{enter}, batches, slots, 0) {
+		dispatch(context.Background(), make([]comparison, 2))
+	}
+	assert.Equal(t, int32(1), peak.Load())
 }
 
 func TestCursorModelFallsBackOffTheOpenAIDefault(t *testing.T) {

--- a/apps/api/cmd/extract-char-intros/main.go
+++ b/apps/api/cmd/extract-char-intros/main.go
@@ -171,10 +171,11 @@ func run(ctx context.Context, db *gorm.DB, ex extractor, judge panelJudge, o opt
 	fmt.Printf("\n=== extract-char-intros (%s) candidate_works=%d ===\n", modeStr, len(works))
 	st := &stats{}
 	w := &writer{db: db, apply: o.Apply, refresh: o.Refresh, st: st, samples: o.Samples, judge: judge}
-	dispatch := voteDispatch(judge, at(o.JudgeBatch, 1), at(o.Workers, 1), o.Delay)
+	slots := newCallSlots(at(o.Workers, 1))
+	dispatch := voteDispatch(judge, at(o.JudgeBatch, 1), slots, o.Delay)
 
 	done := 0
-	for res := range extractBatches(ctx, ex, chunkWorks(works, at(o.Batch, 1)), at(o.Workers, 1), o.Delay) {
+	for res := range extractBatches(ctx, ex, chunkWorks(works, at(o.Batch, 1)), slots, o.Delay) {
 		var contested []gated
 		for i, cand := range res.works {
 			e := res.out[i]
@@ -228,20 +229,32 @@ func chunkWorks(works []candidateWork, size int) [][]candidateWork {
 	return out
 }
 
+// callSlots caps how many gateway calls are in flight across BOTH stages. One
+// semaphore per stage is not enough: extractBatches starts the next extraction
+// the moment the previous one returns, so it overlaps the judge round the
+// consumer is still working through — two calls in flight even at --workers 1.
+// A gateway that serialises per account answers the second with 429, and after
+// the backoff ladder that costs a whole batch (2026-08-22: 40 works).
+type callSlots chan struct{}
+
+func newCallSlots(n int) callSlots { return make(callSlots, max(n, 1)) }
+
+func (s callSlots) acquire() { s <- struct{}{} }
+func (s callSlots) release() { <-s }
+
 // extractBatches runs the batches concurrently but delivers them in order, so
 // a rerun with the same window walks the same works in the same sequence and
 // the progress line means what it says.
-func extractBatches(ctx context.Context, ex extractor, batches [][]candidateWork, workers int, delay time.Duration) <-chan batchResult {
+func extractBatches(ctx context.Context, ex extractor, batches [][]candidateWork, slotsIn callSlots, delay time.Duration) <-chan batchResult {
 	slots := make([]chan batchResult, len(batches))
 	for i := range slots {
 		slots[i] = make(chan batchResult, 1)
 	}
 	go func() {
-		sem := make(chan struct{}, workers)
 		for i, b := range batches {
-			sem <- struct{}{}
+			slotsIn.acquire()
 			go func(i int, b []candidateWork) {
-				defer func() { <-sem }()
+				defer slotsIn.release()
 				if delay > 0 {
 					time.Sleep(delay)
 				}
@@ -264,18 +277,17 @@ func extractBatches(ctx context.Context, ex extractor, batches [][]candidateWork
 	return out
 }
 
-func voteDispatch(judge panelJudge, size, workers int, delay time.Duration) voteDispatcher {
+func voteDispatch(judge panelJudge, size int, slots callSlots, delay time.Duration) voteDispatcher {
 	return func(ctx context.Context, cmps []comparison) []comparisonResult {
 		out := make([]comparisonResult, len(cmps))
-		sem := make(chan struct{}, workers)
 		var wg sync.WaitGroup
 		for start := 0; start < len(cmps); start += size {
 			end := min(start+size, len(cmps))
 			wg.Add(1)
-			sem <- struct{}{}
+			slots.acquire()
 			go func(start, end int) {
 				defer wg.Done()
-				defer func() { <-sem }()
+				defer slots.release()
 				if delay > 0 {
 					time.Sleep(delay)
 				}


### PR DESCRIPTION
fix(catalog): --workers 1 must mean one gateway call, not one per stage

extractBatches and voteDispatch each held their own semaphore, so at
--workers 1 there were still two calls in flight: extractBatches starts
the next extraction the moment the previous one returns, which overlaps
the judge round the consumer is still working through.

A gateway that serialises per account answers the second call with

  429 "Concurrency limit exceeded for account, please retry later"

and once the backoff ladder is spent that costs a whole batch. The
2026-08-22 panel run lost 40 works to this while running --workers 1,
which is exactly the setting that was supposed to prevent it.

Both stages now take the same callSlots. The regression test drives the
real pipeline and fails with a peak of 2 if either stage gets its own
semaphore back.
