### PR TITLE
fix(catalog): the backoff ladder has to outlast one call, not one hiccup

### DIFF
--- a/apps/api/cmd/extract-char-intros/gateway.go
+++ b/apps/api/cmd/extract-char-intros/gateway.go
@@ -9,7 +9,17 @@ import (
 	"time"
 )
 
-var retryBackoff = []time.Duration{5 * time.Second, 10 * time.Second, 20 * time.Second, 40 * time.Second, 60 * time.Second}
+// The ladder has to outlast ONE call, not one hiccup. A gateway that queues
+// answers 429 for as long as the call ahead is still running, and a batched
+// extraction runs ~100s: the old 5/10/20/40/60 ladder spent all five retries
+// inside a single legitimate wait and then failed, which cost the 2026-08-22
+// panel run 20% of its characters. Splitting cannot rescue this — the batch was
+// never too big — so patience is the only fix.
+var retryBackoff = []time.Duration{
+	5 * time.Second, 10 * time.Second, 20 * time.Second, 40 * time.Second,
+	60 * time.Second, 60 * time.Second, 60 * time.Second, 60 * time.Second,
+	60 * time.Second, 60 * time.Second,
+}
 
 // postChat retries throttled and transient gateway failures with backoff. Without
 // this a 429 turns the pacing from inference latency (~20s) into delay-only fast


### PR DESCRIPTION
fix(catalog): the backoff ladder has to outlast one call, not one hiccup

A gateway that queues answers 429 for as long as the call ahead of you
is still running. A batched extraction runs about 100 seconds, and the
old 5/10/20/40/60 ladder totals 135 — so a call could spend every retry
inside a single legitimate wait and then fail. That is what cost the
2026-08-22 panel run 20% of its characters (576 judge rounds), and it is
also why running strictly one call at a time was 3x slower: 17.1s per
work against 5.74s, for the same work on the same pool.

Splitting cannot rescue a 429 — the batch was never too big — so the
only fix is patience. The ladder now runs to ~7 minutes, comfortably
past several call durations.
