### PR TITLE
fix(catalog): a 524 is a size verdict, so split instead of waiting

### DIFF
--- a/apps/api/cmd/extract-char-intros/batch_test.go
+++ b/apps/api/cmd/extract-char-intros/batch_test.go
@@ -184,19 +184,21 @@ func TestHTTPBatchOmitsEffortWhenUnset(t *testing.T) {
 	assert.Empty(t, p.reqs[0].ReasoningEffort, fmt.Sprintf("req: %+v", p.reqs[0]))
 }
 
-// Cloudflare answers 524 once the origin passes 100s, which a 40-work
-// extraction does. Failing the whole batch there costs 40 works at a time, so
-// an exhausted retryable status has to reach the split retry like a truncated
-// reply does.
-func TestHTTPBatchSplitsWhenTheGatewayGivesUp(t *testing.T) {
+// Cloudflare answers 524 once the origin passes its 100s cap, so retrying the
+// same call just spends another 100s reaching the same cap. The 2026-08-23
+// panel run lost 42 minutes to one 25-work batch doing exactly that, and then
+// got both halves on the first try.
+func TestHTTPBatchSplitsOnA524WithoutRetrying(t *testing.T) {
 	orig := retryBackoff
 	retryBackoff = []time.Duration{time.Millisecond}
 	t.Cleanup(func() { retryBackoff = orig })
 
 	p := fakeChat(t, func(chatReq, int) (string, string) { return `[{"i":0,"摘录":{}}]`, "stop" })
+	// 524 is what a call that runs long gets, so the probe answers it by size:
+	// the whole batch times out, either half gets through.
 	p.status = func(n int) int {
-		if n <= len(retryBackoff)+1 {
-			return 524 // the first call and every one of its retries
+		if strings.Count(p.reqs[n-1].Messages[1].Content, `"i":`) > 1 {
+			return 524
 		}
 		return http.StatusOK
 	}
@@ -206,4 +208,5 @@ func TestHTTPBatchSplitsWhenTheGatewayGivesUp(t *testing.T) {
 	for i, e := range out {
 		require.NoError(t, e.Err, "work %d survived on a half-sized call", i)
 	}
+	require.Len(t, p.reqs, 3, "the oversized call must go straight to the split, not up the ladder")
 }

--- a/apps/api/cmd/extract-char-intros/gateway.go
+++ b/apps/api/cmd/extract-char-intros/gateway.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+// Cloudflare answers 524 when the origin passes its 100s cap. net/http has no
+// name for it because it is not an IANA status.
+const statusCloudflareTimeout = 524
+
 // The ladder has to outlast ONE call, not one hiccup. A gateway that queues
 // answers 429 for as long as the call ahead is still running, and a batched
 // extraction runs ~100s: the old 5/10/20/40/60 ladder spent all five retries
@@ -37,10 +41,16 @@ func (t *httpExtractor) postChat(ctx context.Context, raw []byte) ([]byte, error
 		if !retryable {
 			return nil, err
 		}
+		// Cloudflare's 524 is a duration cap, not a queue signal: the origin went
+		// past 100s, and the same call goes past it again. Waiting is the wrong
+		// answer here even though waiting is right for the 429 below. The
+		// 2026-08-23 panel run spent 42 minutes emptying the ladder into one
+		// 25-work batch and then got both halves on the first try.
+		if status == statusCloudflareTimeout {
+			return nil, fmt.Errorf("%w: %v", errBatchOversize, err)
+		}
 		// Out of retries on a failure a SMALLER call might survive, so hand it to
-		// the split retry rather than failing the whole batch. Cloudflare answers
-		// 524 once the origin passes 100s, which a 40-work extraction does often
-		// enough to cost 40 works at a time (2026-08-22 panel run).
+		// the split retry rather than failing the whole batch.
 		if attempt >= len(retryBackoff) {
 			return nil, fmt.Errorf("%w: %v", errBatchOversize, err)
 		}


### PR DESCRIPTION
fix(catalog): a 524 is a size verdict, so split instead of waiting

The ladder from #53 is right for 429 and wrong for 524, and postChat could
not tell them apart: both are "retryable", so a Cloudflare timeout climbed
all ten rungs before reaching the split. Each of those attempts costs the
full 100s Cloudflare allows before cutting the connection, so one oversized
batch burns ~17 minutes of doomed calls plus ~7 minutes of backoff.

That is measured, not estimated. The 2026-08-23 panel run stalled 42
minutes between works 100 and 125, and the log names one cause:

  03:22:31 WARN extraction batch failed the integrity gate — splitting
           works=25 err="batch too big for one call: gateway http 524"

Both halves then succeeded on the first try, which is the whole argument:
halving gets under the 100s cap and waiting never does. 524 now goes
straight to the split retry. 429 keeps the ladder.

At the 23 events per 8,138 works these runs see, this is ~14 hours over
the remaining panel pass.
