### PR TITLE
fix(catalog): let an oversize batch keep halving, one cut is not always enough

### DIFF
--- a/apps/api/cmd/extract-char-intros/batch.go
+++ b/apps/api/cmd/extract-char-intros/batch.go
@@ -97,7 +97,24 @@ func parseBatchArray[T any](text string, want int) ([]T, error) {
 // one run into a binary search.
 const splitRetries = 1
 
-func splittable(depth, size int) bool { return depth < splitRetries && size > 1 }
+// An oversize batch is the one failure halving converges on, so it keeps
+// halving. 2026-08-23 measured both ends of that on the same run: at --batch 10
+// a single cut (10 -> 5) cleared Cloudflare's 100s cap on the first try, but at
+// --batch 25 the one allowed cut landed on 12, which was still over the cap, so
+// the whole batch died with a fix one more cut away. Four levels take any batch
+// this tool ships down to 1.
+const oversizeSplitRetries = 4
+
+// splittable answers per cause, because the two failures want opposite depths:
+// a shape mismatch means one item is systematically bad and deeper cuts only
+// binary-search for it, while an oversize call is fixed by getting smaller.
+func splittable(depth, size int, err error) bool {
+	limit := splitRetries
+	if errors.Is(err, errBatchOversize) {
+		limit = oversizeSplitRetries
+	}
+	return depth < limit && size > 1
+}
 
 // --- extraction ---
 
@@ -165,7 +182,7 @@ func extractBatchVia(ctx context.Context, c promptCaller, batch []candidateWork,
 	if err == nil {
 		err = gateErr
 	}
-	if splittable(depth, len(batch)) {
+	if splittable(depth, len(batch), err) {
 		slog.Warn("extraction batch failed the integrity gate — splitting", "works", len(batch), "err", err)
 		half := len(batch) / 2
 		return append(extractBatchVia(ctx, c, batch[:half], depth+1), extractBatchVia(ctx, c, batch[half:], depth+1)...)
@@ -230,7 +247,7 @@ func compareBatchVia(ctx context.Context, c promptCaller, batch []comparison, de
 	if err == nil {
 		err = gateErr
 	}
-	if splittable(depth, len(batch)) {
+	if splittable(depth, len(batch), err) {
 		slog.Warn("judge batch failed the integrity gate — splitting", "votes", len(batch), "err", err)
 		half := len(batch) / 2
 		return append(compareBatchVia(ctx, c, batch[:half], depth+1), compareBatchVia(ctx, c, batch[half:], depth+1)...)

--- a/apps/api/cmd/extract-char-intros/batch_test.go
+++ b/apps/api/cmd/extract-char-intros/batch_test.go
@@ -210,3 +210,60 @@ func TestHTTPBatchSplitsOnA524WithoutRetrying(t *testing.T) {
 	}
 	require.Len(t, p.reqs, 3, "the oversized call must go straight to the split, not up the ladder")
 }
+
+func fourWorks() []candidateWork {
+	return []candidateWork{
+		{WorkID: 11, Intro: "甲作品简介", Roster: []rosterChar{{CharacterID: 1, Name: "沙耶"}}},
+		{WorkID: 22, Intro: "乙作品简介", Roster: []rosterChar{{CharacterID: 2, Name: "玲"}}},
+		{WorkID: 33, Intro: "丙作品简介", Roster: []rosterChar{{CharacterID: 3, Name: "葵"}}},
+		{WorkID: 44, Intro: "丁作品简介", Roster: []rosterChar{{CharacterID: 4, Name: "樒"}}},
+	}
+}
+
+// oversizeOnlyOK answers 524 to any call carrying more than one item, so a
+// batch only survives once it has been cut all the way down to 1.
+func oversizeOnlyOK(p *chatProbe) func(int) int {
+	return func(n int) int {
+		if strings.Count(p.reqs[n-1].Messages[1].Content, `"i":`) > 1 {
+			return 524
+		}
+		return http.StatusOK
+	}
+}
+
+// One cut is not always enough. The 2026-08-23 panel run measured both ends of
+// this: at --batch 10 the single allowed cut landed on 5 and cleared the 100s
+// cap, but at --batch 25 it landed on 12, still over the cap, and the batch died
+// one cut short of working. Oversize is the failure halving converges on, so it
+// keeps halving: 4 -> 2 -> 1 is 1 + 2 + 4 = 7 calls.
+func TestHTTPBatchKeepsHalvingWhileTheCauseIsOversize(t *testing.T) {
+	orig := retryBackoff
+	retryBackoff = []time.Duration{time.Millisecond}
+	t.Cleanup(func() { retryBackoff = orig })
+
+	p := fakeChat(t, func(chatReq, int) (string, string) { return `[{"i":0,"摘录":{}}]`, "stop" })
+	p.status = oversizeOnlyOK(p)
+
+	out := p.ex.ExtractBatch(context.Background(), fourWorks())
+	require.Len(t, out, 4)
+	for i, e := range out {
+		require.NoError(t, e.Err, "work %d survived once the batch reached size 1", i)
+	}
+	assert.Len(t, p.reqs, 7, "4 -> two 2s -> four 1s")
+}
+
+// The negative control for the rule above: a reply of the wrong shape means one
+// item is systematically bad, and deeper cuts would only binary-search for it.
+// That cause still stops after a single level — 4 plus its two halves.
+func TestHTTPBatchStopsAtOneCutWhenTheShapeIsWrong(t *testing.T) {
+	p := fakeChat(t, func(chatReq, int) (string, string) {
+		return "抱歉,我无法完成这个任务。", "stop"
+	})
+
+	out := p.ex.ExtractBatch(context.Background(), fourWorks())
+	require.Len(t, out, 4)
+	for i, e := range out {
+		require.Error(t, e.Err, "work %d", i)
+	}
+	assert.Len(t, p.reqs, 3, "one cut only; a bad item must not turn the run into a binary search")
+}


### PR DESCRIPTION
A batch that fails the integrity gate is cut in half **once**. That is right for a
shape mismatch — one item is systematically bad, and deeper cuts only binary-search
for it — but wrong for an oversize call, which halving actually converges on.

The 2026-08-23 panel run measured both ends on the same lane:

| `--batch` | one allowed cut lands on | result |
|---|---|---|
| 10 | 5 | cleared Cloudflare's 100 s cap on the first try |
| 25 | 12 | still over the cap → the batch died one cut short of working |

`splittable` now answers per cause: a shape mismatch keeps its single level,
`errBatchOversize` gets four — which takes any batch this tool ships down to 1.

## Tests

Two new cases pin the split depth from opposite directions, so a future
"simplify it back to one constant" is caught:

- `TestHTTPBatchKeepsHalvingWhileTheCauseIsOversize`
- `TestHTTPBatchStopsAtOneCutWhenTheShapeIsWrong`

`go test ./cmd/extract-char-intros/ -count=1 -p 1` — 37 pass.
(Run with a `TEST_DATABASE_DSN` set: the package's `TestMain` skips the whole
suite green without one.)

## Scope

Code only — no schema change, no migration. The wave-214 panel run that produced
the measurement already finished on the old binary; this is for re-runs and for
whatever ships next on this lane.