### PR TITLE
fix(catalog): tell the translation gateway not to reason about a translation

### DIFF
--- a/apps/api/cmd/intro-mt/main.go
+++ b/apps/api/cmd/intro-mt/main.go
@@ -30,6 +30,7 @@ func main() {
 	workers := flag.Int("workers", 1, "apply-mode concurrency (per-request latency dominates; 8 ≈ 10 req/min, far under gateway rate limits)")
 	workIDs := flag.String("work-ids", "", "comma-separated work ids — the named list IS the population, so --top stops applying")
 	force := flag.Bool("force", false, "retranslate even when src_hash is unchanged (the prompt is not in the hash, so a prompt rewrite needs this)")
+	effort := flag.String("effort", "", "reasoning effort: low | medium | high (empty = the gateway's own default; a reasoning model needs low or it thinks for minutes about a translation)")
 	flag.Parse()
 
 	ids, err := parseWorkIDs(*workIDs)
@@ -53,6 +54,7 @@ func main() {
 		} else {
 			ht := intromt.NewHTTPTranslator(*llmBase, *llmToken, *model, *maxTokens)
 			ht.SetSourceLang(intromt.SourceLang(*sourceLang))
+			ht.SetEffort(*effort)
 			if !ht.Configured() {
 				fmt.Printf("BLOCKED: LLM gateway not configured (need --llm-base + --llm-token, or KUN_INTRO_MT_LLM_* / KUN_AI_UPSTREAM_*).\n" +
 					"This is a designed precondition for a real --apply, not a failure. Use --mock for the offline write-path rehearsal.\n")

--- a/apps/api/internal/jobs/intromt/force_test.go
+++ b/apps/api/internal/jobs/intromt/force_test.go
@@ -2,7 +2,11 @@ package intromt
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,4 +64,27 @@ func TestForceRewritesWhatTheHashCallsCurrent(t *testing.T) {
 		`SELECT intro FROM catalog_work_intro WHERE work_id = ? AND lang = 'zh-Hans' AND provenance = 1`,
 		w).Scan(&zh).Error)
 	assert.Equal(t, "[译2] あらすじ本文。", zh, "the forced pass overwrote the row")
+}
+
+func TestReasoningEffortReachesTheWireAndIsOmittedByDefault(t *testing.T) {
+	var raw map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		raw = nil
+		_ = json.Unmarshal(b, &raw)
+		_, _ = io.WriteString(w, `{"model":"m","choices":[{"message":{"role":"assistant","content":"译"},"finish_reason":"stop"}]}`)
+	}))
+	defer srv.Close()
+
+	plain := NewHTTPTranslator(srv.URL, "t", "m", 64)
+	_, _, err := plain.Translate(context.Background(), "x", nil)
+	require.NoError(t, err)
+	_, present := raw["reasoning_effort"]
+	assert.False(t, present, "no effort set — the key must not appear, so the Cloudflare lane is unchanged")
+
+	low := NewHTTPTranslator(srv.URL, "t", "m", 64)
+	low.SetEffort("low")
+	_, _, err = low.Translate(context.Background(), "x", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "low", raw["reasoning_effort"])
 }

--- a/apps/api/internal/jobs/intromt/translate.go
+++ b/apps/api/internal/jobs/intromt/translate.go
@@ -94,6 +94,7 @@ type HTTPTranslator struct {
 	baseURL    string
 	token      string
 	model      string
+	effort     string
 	maxTokens  int
 	http       *http.Client
 }
@@ -116,10 +117,11 @@ type chatMessage struct {
 }
 
 type chatRequest struct {
-	Model       string        `json:"model"`
-	Messages    []chatMessage `json:"messages"`
-	MaxTokens   int           `json:"max_tokens"`
-	Temperature float64       `json:"temperature"`
+	Model           string        `json:"model"`
+	Messages        []chatMessage `json:"messages"`
+	MaxTokens       int           `json:"max_tokens"`
+	Temperature     float64       `json:"temperature"`
+	ReasoningEffort string        `json:"reasoning_effort,omitempty"`
 }
 
 type chatResponse struct {
@@ -137,9 +139,10 @@ var retrySchedule = []time.Duration{2 * time.Second, 8 * time.Second, 30 * time.
 
 func (t *HTTPTranslator) Translate(ctx context.Context, jaText string, gloss Glossary) (string, string, error) {
 	body := chatRequest{
-		Model:       t.model,
-		MaxTokens:   t.maxTokens,
-		Temperature: 0,
+		Model:           t.model,
+		MaxTokens:       t.maxTokens,
+		Temperature:     0,
+		ReasoningEffort: t.effort,
 		Messages: []chatMessage{
 			{Role: "system", Content: withGlossary(t.systemPrompt(), gloss)},
 			{Role: "user", Content: jaText},
@@ -245,6 +248,13 @@ func truncate(s string, n int) string {
 }
 
 func (t *HTTPTranslator) SetSourceLang(src SourceLang) { t.sourceLang = src }
+
+// A reasoning model left on its own default treats "translate this paragraph"
+// as a problem to think about: 2026-08-23 grok-4.6 spent an average of 8,165
+// output tokens and 154 seconds on intros whose translation is ~800 tokens, and
+// long ones ran past the gateway's 100s ceiling into the retry ladder. Omitted
+// when empty, so the Cloudflare lane the nightly rides is unaffected.
+func (t *HTTPTranslator) SetEffort(effort string) { t.effort = effort }
 
 func (t *HTTPTranslator) systemPrompt() string {
 	if t.sourceLang == SourceEn {


### PR DESCRIPTION
Follows #57. The first pilot of the new prompt on the s2a lane wrote 9/10 rows clean — and took 12 minutes to do it.

The gateway's usage log says why:

| | |
|---|---|
| avg output tokens per call | **8,165** |
| avg duration | **154s** (max 283s) |
| `reasoning_effort` recorded | `(null)` — the model's own default |
| upstream calls for 10 works | **22** (long calls crossed the 100s ceiling and retried) |

The translation itself is ~800 tokens. Around 90% of the spend was the model thinking about how to translate a paragraph. Extrapolated, the 17,975-work sweep is ~250 hours.

`--effort` sets `reasoning_effort` on the chat request — the knob `extract-char-intros` already carries and uses at `low`. It is `omitempty`, so the nightly's Cloudflare lane sends a byte-identical request to what it sent before; the test asserts the key is absent with no effort set and present with it.

25 package tests pass against a real database in 2.76s.