### PR TITLE
feat(catalog): strip the store-listing furniture out of a work intro

### DIFF
--- a/apps/api/internal/jobs/intromt/sanitize.go
+++ b/apps/api/internal/jobs/intromt/sanitize.go
@@ -14,5 +14,7 @@ func sanitizeSource(s string) string {
 	s = reBBURL.ReplaceAllString(s, "$1")
 	s = reBBSpoil.ReplaceAllString(s, "")
 	s = reBBRaw.ReplaceAllString(s, "")
-	return s
+	// After the markup, not before: [url=…]https://…[/url] only becomes a bare
+	// URL line once the tags are gone.
+	return stripStructuredNoise(s)
 }

--- a/apps/api/internal/jobs/intromt/structnoise.go
+++ b/apps/api/internal/jobs/intromt/structnoise.go
@@ -1,0 +1,118 @@
+package intromt
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Work intros arrive with the store listing's furniture still attached: a spec
+// table, a staff roll, a bare product URL. Wave 214 adjudicated those as
+// strippable because each already has a structured home — platform/engine rows,
+// the credits roster, the release links — and 2026-08-23 counted them in the ja
+// corpus: 436 intros with a 対応OS/動作環境 header, 2,280 with a labelled staff
+// line, 1,069 with a URL.
+//
+// Two things deliberately survive, both from reading the text rather than the
+// label list:
+//
+//   - `CV：` is NOT a staff label here. It reads as one, but in practice it sits
+//     inside a character block (work 481: `すみれ` / `CV:野中みかん` / `身長:158cm`
+//     / then the character's actual description), and extract-char-intros reads
+//     exactly those blocks.
+//   - 身長 / 体重 / スリーサイズ / 血液型 and the rest of the stat sheet stay for
+//     the same reason: 736 intros carry them, interleaved with the prose that
+//     makes the block worth extracting.
+//
+// This runs inside sanitizeSource, so it is part of src_hash: a work whose ja
+// text strips down to something different retranslates on its own, with no
+// forced pass.
+var (
+	reSpecLabel = regexp.MustCompile(`^[\s・◆●■□▼▽★☆\-–—]*` +
+		`(対応OS|動作環境|必要環境|推奨環境|必要動作環境|推奨動作環境|` +
+		`CPU|メモリ|メモリー|VRAM|DirectX|HDD|ハードディスク|` +
+		`解像度|画面サイズ|画面解像度|サウンド|グラフィック|グラフィックス|OS)` +
+		`\s*[:：]`)
+
+	reStaffLabel = regexp.MustCompile(`^[\s・◆●■□▼▽★☆\-–—]*` +
+		`(シナリオ|原画|イラスト|キャラクターデザイン|キャラデザ|` +
+		`音楽|楽曲制作|楽曲|主題歌|挿入歌|エンディングテーマ|オープニングテーマ|` +
+		`声優|制作|企画|企画原案|プロデューサー|ディレクター|背景|塗り)` +
+		`\s*[:：]`)
+
+	reSectionHeader = regexp.MustCompile(`^[\s・◆●■□▼▽★☆\-–—【\[]*` +
+		`(SPEC|Spec|spec|STAFF|Staff|staff|スタッフ|動作環境|必要動作環境|推奨動作環境|SPEC表)` +
+		`[】\]\s:：]*$`)
+
+	reDupPurchase = regexp.MustCompile(`重複(して)?(ご)?購入|二重購入`)
+
+	reBareURL = regexp.MustCompile(`^\s*(https?://\S+|www\.\S+)\s*$`)
+)
+
+// A run stripped past this is not an intro with furniture attached, it IS the
+// furniture; keeping the original beats shipping two words.
+const minStrippedRunes = 60
+
+func stripStructuredNoise(s string) string {
+	lines := strings.Split(s, "\n")
+	drop := make([]bool, len(lines))
+	for i, ln := range lines {
+		t := strings.TrimRight(ln, "\r")
+		drop[i] = reSpecLabel.MatchString(t) ||
+			reStaffLabel.MatchString(t) ||
+			reBareURL.MatchString(t) ||
+			(reDupPurchase.MatchString(t) && strings.TrimSpace(t) != "")
+	}
+	for i, ln := range lines {
+		if drop[i] || !reSectionHeader.MatchString(strings.TrimRight(ln, "\r")) {
+			continue
+		}
+		for j := i + 1; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) == "" {
+				continue
+			}
+			drop[i] = drop[j]
+			break
+		}
+	}
+
+	dropped := false
+	for _, d := range drop {
+		if d {
+			dropped = true
+			break
+		}
+	}
+	if !dropped {
+		return s
+	}
+
+	out := closeUp(lines, drop)
+	if len([]rune(strings.TrimSpace(out))) < minStrippedRunes {
+		return s
+	}
+	return out
+}
+
+// closeUp joins the kept lines, swallowing only the blank runs that removal
+// created. A preview over 2,521 prod intros caught the naive version doing the
+// opposite: work 39255 lost 804 runes to blank-line collapsing while its content
+// was untouched, which both rewrites text no rule objected to and contradicts
+// the prompt's own "keep the original paragraph structure".
+func closeUp(lines []string, drop []bool) string {
+	out := make([]string, 0, len(lines))
+	droppedSinceEmit := false
+	for i, ln := range lines {
+		if drop[i] {
+			droppedSinceEmit = true
+			continue
+		}
+		blank := strings.TrimSpace(ln) == ""
+		if blank && droppedSinceEmit &&
+			(len(out) == 0 || strings.TrimSpace(out[len(out)-1]) == "") {
+			continue
+		}
+		out = append(out, ln)
+		droppedSinceEmit = false
+	}
+	return strings.TrimRight(strings.Join(out, "\n"), "\n \t\r")
+}

--- a/apps/api/internal/jobs/intromt/structnoise_test.go
+++ b/apps/api/internal/jobs/intromt/structnoise_test.go
@@ -1,0 +1,100 @@
+package intromt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Work 94, the case that opened this: two real sentences under a staff roll and
+// a SPEC table, both of which live in structured columns already.
+const work94Intro = `同人サークルNEKO WORKsの看板娘ショコラとバニラが豪華スタッフで同人ゲーム化しました。
+E-moteシステムでキャラが動いたり、Hシーンもアニメーションしちゃいます!
+タイトル:ネコぱら vol.1 ソレイユ開店しました!
+ジャンル:ちょっとHでハートフルなネココメディ
+原画:さより
+シナリオ:雪仁
+楽曲制作:水城新人
+主題歌:nao/霜月はるか
+デザイン:KOMEWORKS
+SPEC
+対応OS:Microsoft Windows Vista/7/8/8.1
+解像度:1280×720ドット以上
+CPU:Pentium4 1.8GHz 以上(推奨 Intel Core2Duo 2.0GHz 以上)
+メモリ:1GB(推奨 2GB以上)
+DirectX 9.0 に完全対応したビデオカード
+VRAM:128MB以上 (推奨 256MB以上)
+サウンド:DirectSound に正式対応したサウンドカード`
+
+func TestStripsTheStoreListingFurniture(t *testing.T) {
+	got := stripStructuredNoise(work94Intro)
+
+	assert.Contains(t, got, "看板娘ショコラとバニラ", "the two real sentences survive")
+	assert.Contains(t, got, "E-moteシステムで")
+	for _, gone := range []string{"対応OS", "VRAM", "サウンド:", "原画:", "シナリオ:", "楽曲制作:", "主題歌:"} {
+		assert.NotContains(t, got, gone)
+	}
+	assert.NotContains(t, got, "SPEC", "a section header whose whole body went must go with it")
+	assert.Contains(t, got, "ジャンル:", "genre is a fact about the product, not a credit")
+}
+
+func TestKeepsTheCharacterBlockItLooksLike(t *testing.T) {
+	// Work 481's shape. CV: and the stat lines read like labelled furniture and
+	// are not: they sit inside the character block extract-char-intros reads.
+	in := `CHARACTER
+すみれ
+CV:野中みかん
+身長:158cm
+体重:42kg
+スリーサイズ:86(D)/59/87
+忍の里の頭領の一人娘。忍者としての資質・実力・知識も十分だが、天然且つドジで失敗が多い。
+父から修行を命じられ山奥にある忍者の里から街に出てきた。`
+
+	got := stripStructuredNoise(in)
+	assert.Equal(t, in, got, "nothing in a character block is furniture")
+}
+
+func TestDropsBareURLLinesButNotProseThatMentionsOne(t *testing.T) {
+	in := `本編の続きが配信中です。主人公は異世界に転生し、そこで出会った少女たちとの日々を過ごすことになります。
+https://www.dlsite.com/maniax/work/=/product_id/RJ01024197.html
+
+詳しくは https://example.com/info をご覧ください。`
+
+	got := stripStructuredNoise(in)
+	assert.NotContains(t, got, "RJ01024197", "a line that is only a URL is a link, not prose")
+	assert.Contains(t, got, "詳しくは https://example.com/info をご覧ください。",
+		"a URL inside a sentence stays — removing it would break the sentence")
+}
+
+func TestAnIntroThatIsOnlyFurnitureIsLeftAlone(t *testing.T) {
+	in := `SPEC
+対応OS:Windows 10
+CPU:Core i3
+メモリ:4GB`
+
+	assert.Equal(t, in, stripStructuredNoise(in),
+		"stripping to nothing is worse than shipping the spec table")
+}
+
+func TestSanitizeRunsTheStripperAfterTheMarkup(t *testing.T) {
+	in := `本作の紹介ページです。ここでは物語のあらすじと登場人物について説明しています。
+[url=https://example.com/product]https://example.com/product[/url]
+物語は主人公が異世界に転生するところから始まります。彼は世界最強のスキルを手に入れた。`
+
+	got := sanitizeSource(in)
+	assert.NotContains(t, got, "example.com",
+		"the bbcode unwrap leaves a bare URL line, which the stripper must then see")
+	assert.Contains(t, got, "異世界に転生する")
+}
+
+func TestStrippingChangesTheHashSoTheWorkRetranslatesOnItsOwn(t *testing.T) {
+	clean := strings.Repeat("物語は静かに始まる。", 10)
+	dirty := clean + "\n原画:さより\n対応OS:Windows 10"
+
+	require.NotEqual(t, hashSource(sanitizeSource(dirty)), hashSource(dirty),
+		"a stripped work must not keep hashing as the text it used to send")
+	assert.Equal(t, hashSource(clean), hashSource(sanitizeSource(dirty)),
+		"and it must land on the hash of what actually gets sent")
+}


### PR DESCRIPTION
The 94-class, scheduled off wave 214 §4.14. Work 94's intro is two real sentences about the game under a staff roll and a SPEC table — both of which are already structured data elsewhere.

## Scope, from a census rather than a guess

Enumerating every labelled line in the ja corpus first, then deciding:

| stripped | ja intros |
|---|---|
| `対応OS` / `動作環境` / CPU / VRAM / DirectX / 解像度 / 画面サイズ … | 436 |
| labelled staff lines (シナリオ / 原画 / イラスト / 音楽 / 主題歌 / 制作 / 企画 …) | 2,280 |
| lines that are only a URL | 1,069 |
| 重複購入 warnings | 8 |

Two families that *look* strippable and are not, both decided by reading the text:

- **`CV：` is not a staff label here.** In work 481 it sits inside the character block — `すみれ` / `CV:野中みかん` / `身長:158cm` / then the description — which is precisely what `extract-char-intros` feeds on.
- **The stat sheet stays** (身長 / 体重 / スリーサイズ / 血液型, 736 intros) for the same reason: interleaved with the prose that makes the block worth extracting.

## What the preview caught

Ran the real stripper over all 2,521 matching prod intros before shipping. The first version removed 804 runes from work 39255 — **entirely blank-line collapsing**, with not one content line matching a rule. That both rewrites text no rule objected to and contradicts the prompt's own "keep the original paragraph structure".

Blank runs are now closed up only where a removal created them, and an intro where nothing matched comes back byte-identical. After the fix:

| | |
|---|---|
| works changed | 2,447 of 2,521 |
| unchanged (no rule fired) | 68 |
| kept by the floor (would have stripped below 60 runes) | 6 |
| runes removed | avg 64, max 1,408 |

The 1,408 is a credits section that is bare URL lines end to end; nothing in it is prose.

## Honest limit

This is a trim, not a solution to the class. Work 206900 is still 80% furniture after it — 実況・生放送について rules, 使用素材クレジット, a version changelog — none of which a label regex can reach. Whether to go further (having the model drop non-intro blocks by judgment) is a separate call, not this PR's.

## Placement

It runs inside `sanitizeSource`, so it is part of `src_hash`: the affected works become retranslate candidates on their own. No backfill, no `--force`.

Package tests pass against a real database.