### PR TITLE
fix(catalog): emit SchemaField.key pattern in v2 OpenAPI

### DIFF
--- a/docs/catalog/v2-openapi.yaml
+++ b/docs/catalog/v2-openapi.yaml
@@ -3657,6 +3657,7 @@ components:
         key:
           description: Editing-engine field key. Must not be used as a discriminant.
           maxLength: 128
+          pattern: ^[a-z0-9_]+(\.[a-z0-9_]+)+$
           type: string
         max_elements:
           description: Cap on a list field's element count. 0 for scalar fields.


### PR DESCRIPTION
Follow-up to #64. Escaping the struct tag made `go vet` pass and Huma started emitting `pattern` on `SchemaField.key`. The committed `docs/catalog/v2-openapi.yaml` was missing that line, so the code-to-spec freeze in `test.yml` failed.