### PR TITLE
fix(catalog): playtime is open to every app with a user token

### DIFF
--- a/apps/api/internal/platform/apiv2/handler/me_routes.go
+++ b/apps/api/internal/platform/apiv2/handler/me_routes.go
@@ -54,22 +54,22 @@ func registerMe(api huma.API, cat *Catalog) {
 	errs := collectionErrors(http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusServiceUnavailable)
 	huma.Register(api, huma.Operation{
 		OperationID: "listMyPlaytimes", Method: http.MethodGet, Path: "/v2/me/playtimes",
-		Summary: "List my playtimes", Description: "The bearer user's playtime rows. work_ids= is a batch read. Requires a user access token.",
+		Summary: "List my playtimes", Description: "The bearer user's playtime rows. work_ids= is a batch read. Requires a user access token. Any app may call this; playtime:read is not required.",
 		Tags: me, Errors: errs, SkipValidateParams: true,
 	}, listMyPlaytimes(cat))
 	huma.Register(api, huma.Operation{
 		OperationID: "getMyPlaytime", Method: http.MethodGet, Path: "/v2/me/playtimes/{work_id}",
-		Summary: "Get my playtime on one work", Description: "404 when the user has never reported. Requires a user access token.",
+		Summary: "Get my playtime on one work", Description: "404 when the user has never reported. Requires a user access token. Any app may call this; playtime:read is not required.",
 		Tags: me, Errors: errs, SkipValidateParams: true,
 	}, getMyPlaytime(cat))
 	huma.Register(api, huma.Operation{
 		OperationID: "putMyPlaytime", Method: http.MethodPut, Path: "/v2/me/playtimes/{work_id}",
-		Summary: "Replace my playtime on one work", Description: "Absolute minutes. Naturally idempotent. Requires a user access token.",
+		Summary: "Replace my playtime on one work", Description: "Absolute minutes. Naturally idempotent. Requires a user access token. Any app may call this; playtime:write is not required.",
 		Tags: me, Errors: errs, SkipValidateParams: true,
 	}, putMyPlaytime(cat))
 	huma.Register(api, huma.Operation{
 		OperationID: "deleteMyPlaytime", Method: http.MethodDelete, Path: "/v2/me/playtimes/{work_id}",
-		Summary: "Delete my playtime on one work", Description: "204 with no body. Requires a user access token.",
+		Summary: "Delete my playtime on one work", Description: "204 with no body. Requires a user access token. Any app may call this; playtime:write is not required.",
 		Tags: me, Errors: errs, DefaultStatus: http.StatusNoContent, SkipValidateParams: true,
 	}, deleteMyPlaytime(cat))
 	huma.Register(api, huma.Operation{

--- a/apps/api/internal/platform/apiv2/handler/me_write_routes.go
+++ b/apps/api/internal/platform/apiv2/handler/me_write_routes.go
@@ -18,7 +18,7 @@ func registerMeWrite(api huma.API, cat *Catalog) {
 
 	huma.Register(api, huma.Operation{
 		OperationID: "batchMyPlaytimes", Method: http.MethodPost, Path: "/v2/me/playtimes",
-		Summary: "Batch write playtimes", Description: "207 Multi-Status. Each item is a playtime or a problem. Requires a user access token.",
+		Summary: "Batch write playtimes", Description: "207 Multi-Status. Each item is a playtime or a problem. Requires a user access token. Any app may call this; playtime:write is not required.",
 		Tags: me, Errors: writeErrs, DefaultStatus: 207, SkipValidateParams: true,
 	}, batchMyPlaytimes(cat))
 	huma.Register(api, huma.Operation{

--- a/apps/api/internal/platform/catalog/handler/playtime_gate.go
+++ b/apps/api/internal/platform/catalog/handler/playtime_gate.go
@@ -15,11 +15,6 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
-const (
-	ScopePlaytimeRead  = devapi.ScopePlaytimeRead
-	ScopePlaytimeWrite = devapi.ScopePlaytimeWrite
-)
-
 const PlaytimePrefix = "/v1/playtime"
 
 const playtimeMinePageSize = 200
@@ -29,8 +24,6 @@ const (
 	playtimeRateWindow = time.Minute
 )
 
-const ctxKeyScope ctxKey = "catalog:token_scope"
-
 func PlaytimeGate(limiter PlaytimeLimiter) fiber.Handler {
 	return func(c fiber.Ctx) error {
 		uid, _ := c.Locals("user_id").(uint)
@@ -39,11 +32,10 @@ func PlaytimeGate(limiter PlaytimeLimiter) fiber.Handler {
 				"the access token carries no user identity")
 		}
 
-		scope, _ := c.Locals("user_scope").(string)
-		if !hasScope(scope, ScopePlaytimeRead) && !hasScope(scope, ScopePlaytimeWrite) {
-			return response.ForbiddenMsg(c, errors.ErrForbidden,
-				"the access token is missing the "+ScopePlaytimeRead+" / "+ScopePlaytimeWrite+" scope")
-		}
+		// playtime:read / playtime:write used to be required here. A token whose
+		// client never asked for them 403'd, so every app had to put the scopes
+		// on allowed_scopes and the authorize URL (letmoe saw "无效的权限范围").
+		// The face is open to every client-bound user token.
 
 		clientID, _ := c.Locals("token_client_id").(string)
 		if clientID == "" {
@@ -93,9 +85,6 @@ func PlaytimeBridge(ctx huma.Context, next func(huma.Context)) {
 	if id, ok := fc.Locals("user_id").(uint); ok {
 		ctx = huma.WithValue(ctx, ctxKeyUserID, int64(id))
 	}
-	if scope, ok := fc.Locals("user_scope").(string); ok {
-		ctx = huma.WithValue(ctx, ctxKeyScope, scope)
-	}
 	if clientID, ok := fc.Locals("token_client_id").(string); ok {
 		ctx = huma.WithValue(ctx, ctxKeyPlaytimeClient, clientID)
 	}
@@ -103,15 +92,6 @@ func PlaytimeBridge(ctx huma.Context, next func(huma.Context)) {
 }
 
 const ctxKeyPlaytimeClient ctxKey = "catalog:playtime_client"
-
-func requireScope(ctx context.Context, want string) *houseError {
-	scope, _ := ctx.Value(ctxKeyScope).(string)
-	if !hasScope(scope, want) {
-		return apiErrMsg(http.StatusForbidden, errors.ErrForbidden,
-			"the access token is missing the "+want+" scope")
-	}
-	return nil
-}
 
 func playtimeActor(ctx context.Context) (uid int64, clientID string, he *houseError) {
 	uid = userIDFromCtx(ctx)

--- a/apps/api/internal/platform/catalog/handler/playtime_gate_test.go
+++ b/apps/api/internal/platform/catalog/handler/playtime_gate_test.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlaytimeGate_AnyClientBoundToken(t *testing.T) {
+	cases := []struct {
+		name       string
+		uid        uint
+		clientID   string
+		scope      string
+		wantStatus int
+	}{
+		{name: "no user", wantStatus: fiber.StatusUnauthorized},
+		{name: "user without client", uid: 7, wantStatus: fiber.StatusForbidden},
+		{name: "client-bound token without playtime scope", uid: 7, clientID: "letmoe", wantStatus: fiber.StatusOK},
+		{name: "client-bound token that still has the old scopes", uid: 7, clientID: "kungal", scope: "openid playtime:read playtime:write", wantStatus: fiber.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := fiber.New()
+			app.Use(PlaytimePrefix, func(c fiber.Ctx) error {
+				if tc.uid != 0 {
+					c.Locals("user_id", tc.uid)
+				}
+				c.Locals("token_client_id", tc.clientID)
+				c.Locals("user_scope", tc.scope)
+				return c.Next()
+			}, PlaytimeGate(nil))
+			app.Get(PlaytimePrefix+"/mine", func(c fiber.Ctx) error { return c.SendString("ok") })
+
+			resp, err := app.Test(httptest.NewRequest("GET", PlaytimePrefix+"/mine", nil))
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantStatus, resp.StatusCode)
+		})
+	}
+}

--- a/apps/api/internal/platform/catalog/handler/user_playtime.go
+++ b/apps/api/internal/platform/catalog/handler/user_playtime.go
@@ -40,35 +40,35 @@ func RegisterPlaytimeOps(api huma.API, svc *service.UserPlaytimeService) {
 	huma.Register(api, huma.Operation{
 		OperationID: "reportPlaytime", Method: http.MethodPut,
 		Path:    PlaytimePrefix + "/works/{workID}",
-		Summary: "Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Requires playtime:write",
+		Summary: "Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Any app with a user access token may call this; playtime:write is not required.",
 		Tags:    tags,
 	}, s.report)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "reportPlaytimeByRef", Method: http.MethodPut,
 		Path:    PlaytimePrefix + "/by-ref/{source}/{externalID}",
-		Summary: "Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Requires playtime:write",
+		Summary: "Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Any app with a user access token may call this; playtime:write is not required.",
 		Tags:    tags,
 	}, s.reportByRef)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "reportPlaytimeBatch", Method: http.MethodPost,
 		Path:    PlaytimePrefix + "/batch",
-		Summary: "Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Requires playtime:write",
+		Summary: "Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Any app with a user access token may call this; playtime:write is not required.",
 		Tags:    tags,
 	}, s.reportBatch)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "listOwnPlaytime", Method: http.MethodGet,
 		Path:    PlaytimePrefix + "/mine",
-		Summary: "Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Requires playtime:read",
+		Summary: "Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Any app with a user access token may call this; playtime:read is not required.",
 		Tags:    tags,
 	}, s.listMine)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "getOwnPlaytimeForWork", Method: http.MethodGet,
 		Path:    PlaytimePrefix + "/works/{workID}",
-		Summary: "The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Requires playtime:read",
+		Summary: "The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Any app with a user access token may call this; playtime:read is not required.",
 		Tags:    tags,
 	}, s.getMine)
 }
@@ -100,9 +100,6 @@ type playtimeRecordOutput struct {
 }
 
 func (s *PlaytimeServer) report(ctx context.Context, in *playtimeReportInput) (*playtimeRecordOutput, error) {
-	if he := requireScope(ctx, ScopePlaytimeWrite); he != nil {
-		return nil, he
-	}
 	uid, clientID, he := playtimeActor(ctx)
 	if he != nil {
 		return nil, he
@@ -121,9 +118,6 @@ type playtimeByRefInput struct {
 }
 
 func (s *PlaytimeServer) reportByRef(ctx context.Context, in *playtimeByRefInput) (*playtimeRecordOutput, error) {
-	if he := requireScope(ctx, ScopePlaytimeWrite); he != nil {
-		return nil, he
-	}
 	uid, clientID, he := playtimeActor(ctx)
 	if he != nil {
 		return nil, he
@@ -185,9 +179,6 @@ type playtimeBatchOutput struct {
 }
 
 func (s *PlaytimeServer) reportBatch(ctx context.Context, in *playtimeBatchInput) (*playtimeBatchOutput, error) {
-	if he := requireScope(ctx, ScopePlaytimeWrite); he != nil {
-		return nil, he
-	}
 	uid, clientID, he := playtimeActor(ctx)
 	if he != nil {
 		return nil, he
@@ -257,9 +248,6 @@ type playtimeMineOutput struct {
 }
 
 func (s *PlaytimeServer) listMine(ctx context.Context, in *playtimeMineInput) (*playtimeMineOutput, error) {
-	if he := requireScope(ctx, ScopePlaytimeRead); he != nil {
-		return nil, he
-	}
 	uid := userIDFromCtx(ctx)
 	var since time.Time
 	if in.UpdatedSince != "" {
@@ -298,9 +286,6 @@ type playtimeSelfOutput struct {
 }
 
 func (s *PlaytimeServer) getMine(ctx context.Context, in *playtimeSelfInput) (*playtimeSelfOutput, error) {
-	if he := requireScope(ctx, ScopePlaytimeRead); he != nil {
-		return nil, he
-	}
 	uid := userIDFromCtx(ctx)
 	got, err := s.svc.GetMine(ctx, uid, in.WorkID)
 	if err != nil {

--- a/apps/developer/app/constants/docs.ts
+++ b/apps/developer/app/constants/docs.ts
@@ -22,7 +22,7 @@ export const DOCS_FACE_META: Record<
     icon: 'lucide:timer',
     label: '游玩时长',
     tagline:
-      '用户自己的游玩时长：上报（单条 / 用外部 id 定位 / 批量）与回拉。用用户授权后的访问令牌，不是 API 密钥；一个用户只读写得到自己的记录。'
+      '用户自己的游玩时长：上报（单条 / 用外部 id 定位 / 批量）与回拉。用用户访问令牌，不是 API 密钥。任何已开通用户登录的应用都可以调用，不需要 playtime:read / playtime:write；一个用户只读写得到自己的记录。'
   },
   edit: {
     icon: 'lucide:pencil',

--- a/apps/developer/app/generated/docs-model.ts
+++ b/apps/developer/app/generated/docs-model.ts
@@ -5235,6 +5235,11 @@ export const docsModel: DocsModel = {
                                   "type": "integer"
                                 },
                                 {
+                                  "name": "id",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                {
                                   "name": "kind",
                                   "type": "string"
                                 },
@@ -6448,6 +6453,11 @@ export const docsModel: DocsModel = {
                               "children": [
                                 {
                                   "name": "height",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                {
+                                  "name": "id",
                                   "format": "int64",
                                   "type": "integer"
                                 },
@@ -14658,7 +14668,7 @@ export const docsModel: DocsModel = {
         "kind": "user_token",
         "curl": "Authorization: Bearer <ACCESS_TOKEN>",
         "display": "Authorization: Bearer <用户访问令牌>",
-        "note": "用户授权后拿到的访问令牌,不是 API 密钥"
+        "note": "用户访问令牌。任何已开通用户登录的应用都可以调用，不需要 playtime:read / playtime:write"
       },
       "groups": [
         {
@@ -14669,8 +14679,8 @@ export const docsModel: DocsModel = {
               "id": "reportPlaytime",
               "method": "put",
               "path": "/v1/playtime/works/{workID}",
-              "summary": "Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Requires playtime:write",
-              "scope": "playtime:write",
+              "summary": "Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Any app with a user access token may call this; playtime:write is not required.",
+              "scope": "",
               "params": [
                 {
                   "name": "workID",
@@ -14805,8 +14815,8 @@ export const docsModel: DocsModel = {
               "id": "reportPlaytimeByRef",
               "method": "put",
               "path": "/v1/playtime/by-ref/{source}/{externalID}",
-              "summary": "Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Requires playtime:write",
-              "scope": "playtime:write",
+              "summary": "Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Any app with a user access token may call this; playtime:write is not required.",
+              "scope": "",
               "params": [
                 {
                   "name": "source",
@@ -14947,8 +14957,8 @@ export const docsModel: DocsModel = {
               "id": "reportPlaytimeBatch",
               "method": "post",
               "path": "/v1/playtime/batch",
-              "summary": "Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Requires playtime:write",
-              "scope": "playtime:write",
+              "summary": "Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Any app with a user access token may call this; playtime:write is not required.",
+              "scope": "",
               "params": [],
               "requestBody": {
                 "type": "object",
@@ -15119,8 +15129,8 @@ export const docsModel: DocsModel = {
               "id": "listOwnPlaytime",
               "method": "get",
               "path": "/v1/playtime/mine",
-              "summary": "Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Requires playtime:read",
-              "scope": "playtime:read",
+              "summary": "Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Any app with a user access token may call this; playtime:read is not required.",
+              "scope": "",
               "params": [
                 {
                   "name": "updated_since",
@@ -15250,8 +15260,8 @@ export const docsModel: DocsModel = {
               "id": "getOwnPlaytimeForWork",
               "method": "get",
               "path": "/v1/playtime/works/{workID}",
-              "summary": "The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Requires playtime:read",
-              "scope": "playtime:read",
+              "summary": "The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Any app with a user access token may call this; playtime:read is not required.",
+              "scope": "",
               "params": [
                 {
                   "name": "workID",
@@ -17208,6 +17218,7 @@ export const docsModel: DocsModel = {
       },
       "notes": [
         "preview：形状还可以改，包括删除与改名。第三方拿不到 /v2 凭证，继续用 /v1。",
+        "/v2/me/playtimes 与 /v1/playtime 一样：用户令牌即可，不需要 playtime:read / playtime:write。任何已开通用户登录的应用都可以调用。",
         "错误体是 RFC 9457 application/problem+json。type URI 解析到本站 /problems/{domain}/{kebab-code}。",
         "客户端必须忽略未知字段、容忍开放词表中未见过的取值，并为未知错误 code 准备一个按 HTTP status 的兜底分支。"
       ],
@@ -73988,7 +73999,7 @@ export const docsModel: DocsModel = {
               "method": "get",
               "path": "/v2/me/playtimes",
               "summary": "List my playtimes",
-              "description": "The bearer user's playtime rows. work_ids= is a batch read. Requires a user access token.",
+              "description": "The bearer user's playtime rows. work_ids= is a batch read. Requires a user access token. Any app may call this; playtime:read is not required.",
               "scope": "",
               "params": [
                 {
@@ -74923,7 +74934,7 @@ export const docsModel: DocsModel = {
               "method": "post",
               "path": "/v2/me/playtimes",
               "summary": "Batch write playtimes",
-              "description": "207 Multi-Status. Each item is a playtime or a problem. Requires a user access token.",
+              "description": "207 Multi-Status. Each item is a playtime or a problem. Requires a user access token. Any app may call this; playtime:write is not required.",
               "scope": "",
               "params": [],
               "requestBody": {
@@ -76280,7 +76291,7 @@ export const docsModel: DocsModel = {
               "method": "get",
               "path": "/v2/me/playtimes/{work_id}",
               "summary": "Get my playtime on one work",
-              "description": "404 when the user has never reported. Requires a user access token.",
+              "description": "404 when the user has never reported. Requires a user access token. Any app may call this; playtime:read is not required.",
               "scope": "",
               "params": [
                 {
@@ -77143,7 +77154,7 @@ export const docsModel: DocsModel = {
               "method": "put",
               "path": "/v2/me/playtimes/{work_id}",
               "summary": "Replace my playtime on one work",
-              "description": "Absolute minutes. Naturally idempotent. Requires a user access token.",
+              "description": "Absolute minutes. Naturally idempotent. Requires a user access token. Any app may call this; playtime:write is not required.",
               "scope": "",
               "params": [
                 {
@@ -78014,7 +78025,7 @@ export const docsModel: DocsModel = {
               "method": "delete",
               "path": "/v2/me/playtimes/{work_id}",
               "summary": "Delete my playtime on one work",
-              "description": "204 with no body. Requires a user access token.",
+              "description": "204 with no body. Requires a user access token. Any app may call this; playtime:write is not required.",
               "scope": "",
               "params": [
                 {

--- a/apps/developer/public/docs/playtime.md
+++ b/apps/developer/public/docs/playtime.md
@@ -10,21 +10,21 @@
 **署名**：目前阶段使用 NextMoe·未萌 API，可以将 API 的名字标记为『鲲 Galgame 论坛』（如果你使用 Galgame 数据）或『LetMoe·一启萌』（如果你使用同人游戏数据）。
 
 - 路径前缀：`/v1/playtime`
-- 凭据：Authorization: Bearer <用户访问令牌>（用户授权后拿到的访问令牌,不是 API 密钥）
+- 凭据：Authorization: Bearer <用户访问令牌>（用户访问令牌。任何已开通用户登录的应用都可以调用，不需要 playtime:read / playtime:write）
 - 端点数：5
 
 ## 端点
 
 ### 上报
 
-- `PUT /v1/playtime/works/{workID}` — Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Requires playtime:write [详情](https://developer.nextmoe.dev/docs/playtime/reportPlaytime.md)
-- `PUT /v1/playtime/by-ref/{source}/{externalID}` — Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Requires playtime:write [详情](https://developer.nextmoe.dev/docs/playtime/reportPlaytimeByRef.md)
-- `POST /v1/playtime/batch` — Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Requires playtime:write [详情](https://developer.nextmoe.dev/docs/playtime/reportPlaytimeBatch.md)
+- `PUT /v1/playtime/works/{workID}` — Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Any app with a user access token may call this; playtime:write is not required. [详情](https://developer.nextmoe.dev/docs/playtime/reportPlaytime.md)
+- `PUT /v1/playtime/by-ref/{source}/{externalID}` — Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Any app with a user access token may call this; playtime:write is not required. [详情](https://developer.nextmoe.dev/docs/playtime/reportPlaytimeByRef.md)
+- `POST /v1/playtime/batch` — Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Any app with a user access token may call this; playtime:write is not required. [详情](https://developer.nextmoe.dev/docs/playtime/reportPlaytimeBatch.md)
 
 ### 回拉
 
-- `GET /v1/playtime/mine` — Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Requires playtime:read [详情](https://developer.nextmoe.dev/docs/playtime/listOwnPlaytime.md)
-- `GET /v1/playtime/works/{workID}` — The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Requires playtime:read [详情](https://developer.nextmoe.dev/docs/playtime/getOwnPlaytimeForWork.md)
+- `GET /v1/playtime/mine` — Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Any app with a user access token may call this; playtime:read is not required. [详情](https://developer.nextmoe.dev/docs/playtime/listOwnPlaytime.md)
+- `GET /v1/playtime/works/{workID}` — The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Any app with a user access token may call this; playtime:read is not required. [详情](https://developer.nextmoe.dev/docs/playtime/getOwnPlaytimeForWork.md)
 
 ---
 本页来源 · NextMoe 开发者平台 · https://developer.nextmoe.dev/docs/playtime

--- a/apps/developer/public/docs/playtime/getOwnPlaytimeForWork.md
+++ b/apps/developer/public/docs/playtime/getOwnPlaytimeForWork.md
@@ -1,4 +1,4 @@
-# The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Requires playtime:read · 游玩时长 API
+# The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Any app with a user access token may call this; playtime:read is not required. · 游玩时长 API
 
 > NextMoe·未萌 开放 API —— ACGN 数据，以此为准。同一部作品在六个源各有一个页面，NextMoe 把它们对齐成一条记录，逐字段给出裁定后的标准答案，并附上答案取自哪个源。
 
@@ -11,11 +11,11 @@
 
 ## GET /v1/playtime/works/{workID}
 
-The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Requires playtime:read
+The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Any app with a user access token may call this; playtime:read is not required.
 
 - 所属 API：游玩时长 API（/v1/playtime）
 - 鉴权：Authorization: Bearer <用户访问令牌>
-- scope：playtime:read
+- scope：无需凭据
 
 | 参数 | 位置 | 必填 | 类型 | 说明 |
 | --- | --- | --- | --- | --- |

--- a/apps/developer/public/docs/playtime/listOwnPlaytime.md
+++ b/apps/developer/public/docs/playtime/listOwnPlaytime.md
@@ -1,4 +1,4 @@
-# Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Requires playtime:read · 游玩时长 API
+# Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Any app with a user access token may call this; playtime:read is not required. · 游玩时长 API
 
 > NextMoe·未萌 开放 API —— ACGN 数据，以此为准。同一部作品在六个源各有一个页面，NextMoe 把它们对齐成一条记录，逐字段给出裁定后的标准答案，并附上答案取自哪个源。
 
@@ -11,11 +11,11 @@
 
 ## GET /v1/playtime/mine
 
-Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Requires playtime:read
+Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Any app with a user access token may call this; playtime:read is not required.
 
 - 所属 API：游玩时长 API（/v1/playtime）
 - 鉴权：Authorization: Bearer <用户访问令牌>
-- scope：playtime:read
+- scope：无需凭据
 
 | 参数 | 位置 | 必填 | 类型 | 说明 |
 | --- | --- | --- | --- | --- |

--- a/apps/developer/public/docs/playtime/reportPlaytime.md
+++ b/apps/developer/public/docs/playtime/reportPlaytime.md
@@ -1,4 +1,4 @@
-# Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Requires playtime:write · 游玩时长 API
+# Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Any app with a user access token may call this; playtime:write is not required. · 游玩时长 API
 
 > NextMoe·未萌 开放 API —— ACGN 数据，以此为准。同一部作品在六个源各有一个页面，NextMoe 把它们对齐成一条记录，逐字段给出裁定后的标准答案，并附上答案取自哪个源。
 
@@ -11,11 +11,11 @@
 
 ## PUT /v1/playtime/works/{workID}
 
-Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Requires playtime:write
+Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Any app with a user access token may call this; playtime:write is not required.
 
 - 所属 API：游玩时长 API（/v1/playtime）
 - 鉴权：Authorization: Bearer <用户访问令牌>
-- scope：playtime:write
+- scope：无需凭据
 
 | 参数 | 位置 | 必填 | 类型 | 说明 |
 | --- | --- | --- | --- | --- |

--- a/apps/developer/public/docs/playtime/reportPlaytimeBatch.md
+++ b/apps/developer/public/docs/playtime/reportPlaytimeBatch.md
@@ -1,4 +1,4 @@
-# Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Requires playtime:write · 游玩时长 API
+# Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Any app with a user access token may call this; playtime:write is not required. · 游玩时长 API
 
 > NextMoe·未萌 开放 API —— ACGN 数据，以此为准。同一部作品在六个源各有一个页面，NextMoe 把它们对齐成一条记录，逐字段给出裁定后的标准答案，并附上答案取自哪个源。
 
@@ -11,11 +11,11 @@
 
 ## POST /v1/playtime/batch
 
-Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Requires playtime:write
+Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Any app with a user access token may call this; playtime:write is not required.
 
 - 所属 API：游玩时长 API（/v1/playtime）
 - 鉴权：Authorization: Bearer <用户访问令牌>
-- scope：playtime:write
+- scope：无需凭据
 
 无参数。
 

--- a/apps/developer/public/docs/playtime/reportPlaytimeByRef.md
+++ b/apps/developer/public/docs/playtime/reportPlaytimeByRef.md
@@ -1,4 +1,4 @@
-# Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Requires playtime:write · 游玩时长 API
+# Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Any app with a user access token may call this; playtime:write is not required. · 游玩时长 API
 
 > NextMoe·未萌 开放 API —— ACGN 数据，以此为准。同一部作品在六个源各有一个页面，NextMoe 把它们对齐成一条记录，逐字段给出裁定后的标准答案，并附上答案取自哪个源。
 
@@ -11,11 +11,11 @@
 
 ## PUT /v1/playtime/by-ref/{source}/{externalID}
 
-Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Requires playtime:write
+Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Any app with a user access token may call this; playtime:write is not required.
 
 - 所属 API：游玩时长 API（/v1/playtime）
 - 鉴权：Authorization: Bearer <用户访问令牌>
-- scope：playtime:write
+- scope：无需凭据
 
 | 参数 | 位置 | 必填 | 类型 | 说明 |
 | --- | --- | --- | --- | --- |

--- a/apps/developer/public/docs/v2.md
+++ b/apps/developer/public/docs/v2.md
@@ -16,6 +16,7 @@
 ## 使用须知
 
 - preview：形状还可以改，包括删除与改名。第三方拿不到 /v2 凭证，继续用 /v1。
+- /v2/me/playtimes 与 /v1/playtime 一样：用户令牌即可，不需要 playtime:read / playtime:write。任何已开通用户登录的应用都可以调用。
 - 错误体是 RFC 9457 application/problem+json。type URI 解析到本站 /problems/{domain}/{kebab-code}。
 - 客户端必须忽略未知字段、容忍开放词表中未见过的取值，并为未知错误 code 准备一个按 HTTP status 的兜底分支。
 

--- a/apps/developer/public/docs/v2/batchMyPlaytimes.md
+++ b/apps/developer/public/docs/v2/batchMyPlaytimes.md
@@ -13,7 +13,7 @@
 
 Batch write playtimes
 
-207 Multi-Status. Each item is a playtime or a problem. Requires a user access token.
+207 Multi-Status. Each item is a playtime or a problem. Requires a user access token. Any app may call this; playtime:write is not required.
 
 - 所属 API：Public API v2（preview）（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…

--- a/apps/developer/public/docs/v2/deleteMyPlaytime.md
+++ b/apps/developer/public/docs/v2/deleteMyPlaytime.md
@@ -13,7 +13,7 @@
 
 Delete my playtime on one work
 
-204 with no body. Requires a user access token.
+204 with no body. Requires a user access token. Any app may call this; playtime:write is not required.
 
 - 所属 API：Public API v2（preview）（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…

--- a/apps/developer/public/docs/v2/getMyPlaytime.md
+++ b/apps/developer/public/docs/v2/getMyPlaytime.md
@@ -13,7 +13,7 @@
 
 Get my playtime on one work
 
-404 when the user has never reported. Requires a user access token.
+404 when the user has never reported. Requires a user access token. Any app may call this; playtime:read is not required.
 
 - 所属 API：Public API v2（preview）（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…

--- a/apps/developer/public/docs/v2/listMyPlaytimes.md
+++ b/apps/developer/public/docs/v2/listMyPlaytimes.md
@@ -13,7 +13,7 @@
 
 List my playtimes
 
-The bearer user's playtime rows. work_ids= is a batch read. Requires a user access token.
+The bearer user's playtime rows. work_ids= is a batch read. Requires a user access token. Any app may call this; playtime:read is not required.
 
 - 所属 API：Public API v2（preview）（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…

--- a/apps/developer/public/docs/v2/putMyPlaytime.md
+++ b/apps/developer/public/docs/v2/putMyPlaytime.md
@@ -13,7 +13,7 @@
 
 Replace my playtime on one work
 
-Absolute minutes. Naturally idempotent. Requires a user access token.
+Absolute minutes. Naturally idempotent. Requires a user access token. Any app may call this; playtime:write is not required.
 
 - 所属 API：Public API v2（preview）（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…

--- a/apps/developer/public/llms-full.txt
+++ b/apps/developer/public/llms-full.txt
@@ -894,18 +894,18 @@ curl "https://api.nextmoe.dev/v1/catalog/stats"
 # 游玩时长 API
 
 - 路径前缀：`/v1/playtime`
-- 凭据：Authorization: Bearer <用户访问令牌>（用户授权后拿到的访问令牌,不是 API 密钥）
+- 凭据：Authorization: Bearer <用户访问令牌>（用户访问令牌。任何已开通用户登录的应用都可以调用，不需要 playtime:read / playtime:write）
 - 端点数：5
 
 ## 上报
 
 ### PUT /v1/playtime/works/{workID}
 
-Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Requires playtime:write
+Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Any app with a user access token may call this; playtime:write is not required.
 
 - 所属 API：游玩时长 API（/v1/playtime）
 - 鉴权：Authorization: Bearer <用户访问令牌>
-- scope：playtime:write
+- scope：无需凭据
 
 | 参数 | 位置 | 必填 | 类型 | 说明 |
 | --- | --- | --- | --- | --- |
@@ -920,11 +920,11 @@ curl -X PUT "https://api.nextmoe.dev/v1/playtime/works/1" \
 
 ### PUT /v1/playtime/by-ref/{source}/{externalID}
 
-Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Requires playtime:write
+Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Any app with a user access token may call this; playtime:write is not required.
 
 - 所属 API：游玩时长 API（/v1/playtime）
 - 鉴权：Authorization: Bearer <用户访问令牌>
-- scope：playtime:write
+- scope：无需凭据
 
 | 参数 | 位置 | 必填 | 类型 | 说明 |
 | --- | --- | --- | --- | --- |
@@ -940,11 +940,11 @@ curl -X PUT "https://api.nextmoe.dev/v1/playtime/by-ref/value/value" \
 
 ### POST /v1/playtime/batch
 
-Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Requires playtime:write
+Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Any app with a user access token may call this; playtime:write is not required.
 
 - 所属 API：游玩时长 API（/v1/playtime）
 - 鉴权：Authorization: Bearer <用户访问令牌>
-- scope：playtime:write
+- scope：无需凭据
 
 无参数。
 
@@ -959,11 +959,11 @@ curl -X POST "https://api.nextmoe.dev/v1/playtime/batch" \
 
 ### GET /v1/playtime/mine
 
-Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Requires playtime:read
+Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Any app with a user access token may call this; playtime:read is not required.
 
 - 所属 API：游玩时长 API（/v1/playtime）
 - 鉴权：Authorization: Bearer <用户访问令牌>
-- scope：playtime:read
+- scope：无需凭据
 
 | 参数 | 位置 | 必填 | 类型 | 说明 |
 | --- | --- | --- | --- | --- |
@@ -977,11 +977,11 @@ curl "https://api.nextmoe.dev/v1/playtime/mine" \
 
 ### GET /v1/playtime/works/{workID}
 
-The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Requires playtime:read
+The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Any app with a user access token may call this; playtime:read is not required.
 
 - 所属 API：游玩时长 API（/v1/playtime）
 - 鉴权：Authorization: Bearer <用户访问令牌>
-- scope：playtime:read
+- scope：无需凭据
 
 | 参数 | 位置 | 必填 | 类型 | 说明 |
 | --- | --- | --- | --- | --- |
@@ -1204,6 +1204,8 @@ curl "https://api.nextmoe.dev/v1/news/1" \
 - 端点数：73
 
 > preview：形状还可以改，包括删除与改名。第三方拿不到 /v2 凭证，继续用 /v1。
+
+> /v2/me/playtimes 与 /v1/playtime 一样：用户令牌即可，不需要 playtime:read / playtime:write。任何已开通用户登录的应用都可以调用。
 
 > 错误体是 RFC 9457 application/problem+json。type URI 解析到本站 /problems/{domain}/{kebab-code}。
 
@@ -2504,7 +2506,7 @@ curl -X DELETE "https://api.nextmoe.dev/v2/me/cover-votes/value" \
 
 List my playtimes
 
-The bearer user's playtime rows. work_ids= is a batch read. Requires a user access token.
+The bearer user's playtime rows. work_ids= is a batch read. Requires a user access token. Any app may call this; playtime:read is not required.
 
 - 所属 API：Public API v2（preview）（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…
@@ -2523,7 +2525,7 @@ curl "https://api.nextmoe.dev/v2/me/playtimes" \
 
 Batch write playtimes
 
-207 Multi-Status. Each item is a playtime or a problem. Requires a user access token.
+207 Multi-Status. Each item is a playtime or a problem. Requires a user access token. Any app may call this; playtime:write is not required.
 
 - 所属 API：Public API v2（preview）（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…
@@ -2542,7 +2544,7 @@ curl -X POST "https://api.nextmoe.dev/v2/me/playtimes" \
 
 Get my playtime on one work
 
-404 when the user has never reported. Requires a user access token.
+404 when the user has never reported. Requires a user access token. Any app may call this; playtime:read is not required.
 
 - 所属 API：Public API v2（preview）（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…
@@ -2561,7 +2563,7 @@ curl "https://api.nextmoe.dev/v2/me/playtimes/value" \
 
 Replace my playtime on one work
 
-Absolute minutes. Naturally idempotent. Requires a user access token.
+Absolute minutes. Naturally idempotent. Requires a user access token. Any app may call this; playtime:write is not required.
 
 - 所属 API：Public API v2（preview）（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…
@@ -2582,7 +2584,7 @@ curl -X PUT "https://api.nextmoe.dev/v2/me/playtimes/value" \
 
 Delete my playtime on one work
 
-204 with no body. Requires a user access token.
+204 with no body. Requires a user access token. Any app may call this; playtime:write is not required.
 
 - 所属 API：Public API v2（preview）（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…

--- a/apps/developer/scripts/faces.mjs
+++ b/apps/developer/scripts/faces.mjs
@@ -44,12 +44,12 @@ export const FACES = [
     name: '游玩时长 API',
     file: PUBLIC_SPEC,
     prefix: '/v1/playtime',
-    scope: (method) => (method === 'get' ? 'playtime:read' : 'playtime:write'),
+    scope: () => '',
     auth: {
       kind: 'user_token',
       curl: 'Authorization: Bearer <ACCESS_TOKEN>',
       display: 'Authorization: Bearer <用户访问令牌>',
-      note: '用户授权后拿到的访问令牌,不是 API 密钥'
+      note: '用户访问令牌。任何已开通用户登录的应用都可以调用，不需要 playtime:read / playtime:write'
     }
   },
   {
@@ -134,6 +134,7 @@ export const FACES = [
     ],
     notes: [
       'preview：形状还可以改，包括删除与改名。第三方拿不到 /v2 凭证，继续用 /v1。',
+      '/v2/me/playtimes 与 /v1/playtime 一样：用户令牌即可，不需要 playtime:read / playtime:write。任何已开通用户登录的应用都可以调用。',
       '错误体是 RFC 9457 application/problem+json。type URI 解析到本站 /problems/{domain}/{kebab-code}。',
       '客户端必须忽略未知字段、容忍开放词表中未见过的取值，并为未知错误 code 准备一个按 HTTP status 的兜底分支。'
     ]

--- a/apps/developer/scripts/sync-specs.mjs
+++ b/apps/developer/scripts/sync-specs.mjs
@@ -20,7 +20,7 @@
  * projection was delisted and its spec deleted.
  *
  * Three spec files, four faces. `public-openapi.yaml` carries catalog (API-key,
- * read-only) and playtime (user-token; scope differs per method). Modelling
+ * read-only) and playtime (user-token; no playtime scope required). Modelling
  * those as one face published five playtime operations as `catalog:read` with
  * an `nm_live_` key in the curl sample — a credential that face rejects.
  * `openapi.yaml` is the user-edit subset only: the third face, `edit`, claims

--- a/docs/catalog/01-service-and-contract.md
+++ b/docs/catalog/01-service-and-contract.md
@@ -443,13 +443,12 @@ wave 176-179 把人类的**写**搬完了;本波搬的是搬完写之后还留�
 
 > 绑定 client 的用户访问令牌本身就带齐两个身份 —— `id` 说是哪个人,`client_id` 说是哪个应用。
 
-再加一把 API key,证明的是已经证明过的事,代价却是**同一个 scope 词写在两个注册表里**(`developer_api_keys.scopes` 和 `oauth_clients.allowed_scopes`),两处授予、两处撤销。于是必然出现「key 有而 client 没有」的工单,而排查的人要先知道存在两套 scope。所以:一个凭证、一次 scope 判定、一处吊销。
+再加一把 API key,证明的是已经证明过的事,代价却是**同一个 scope 词写在两个注册表里**(`developer_api_keys.scopes` 和 `oauth_clients.allowed_scopes`),两处授予、两处撤销。于是必然出现「key 有而 client 没有」的工单,而排查的人要先知道存在两套 scope。所以:一个凭证、一处吊销。`playtime:read` / `playtime:write` **不再判定**——任何已开通用户登录的应用都可以调这张脸。
 
 链是 `JWTAuth → PlaytimeGate`:
 1. 令牌指名一个用户(时长是某个人的);
 2. 令牌**绑定 client**(应用 id 是主键第三段,也是剔除坏应用的把手;`/auth/login` 的一等会话令牌无 `client_id`,在此被拒);
-3. 令牌至少持 `playtime:read` / `playtime:write` 之一,**具体哪个由每个 op 自己再判**;
-4. 按 (应用, 用户) 限流(120 次/分)。限流器故障时**放行** —— 它是防跑飞的护栏,不是授权判定,Redis 抖一下不该让所有人记不了时长。
+3. 按 (应用, 用户) 限流(120 次/分)。限流器故障时**放行** —— 它是防跑飞的护栏,不是授权判定,Redis 抖一下不该让所有人记不了时长。
 
 **不要求 `catalog_site` 绑定**:catalog 三张写面从它解析租户,因为它们写的每行都归属某个产品站;而时长归属的是用户与应用。要求 catalog 租户等于把这张脸存在的意义全挡在门外。
 
@@ -460,20 +459,20 @@ wave 176-179 把人类的**写**搬完了;本波搬的是搬完写之后还留�
 ```json
 { "name": "Kurumi", "user_login": {
     "redirect_uris": ["http://127.0.0.1:53682/callback"],
-    "scopes": ["playtime:read", "playtime:write"] } }
+    "scopes": ["openid", "profile"] } }
 ```
 
 后端据此把 app 置为 `is_public` + `grants: [authorization_code, refresh_token]`,并把申请的 scope 写进 `allowed_scopes`。四道护栏见 [developer-platform/05](../developer-platform/05-developer-portal.md) 的自助登录一节:回调白名单(仅 `https://` 与 `127.0.0.1`/`[::1]` 环回)、强制 PKCE、保留名拒绝、第三方姿态。桌面管理器走 RFC 8252 原生应用模式,环回回调**按端口无关匹配**(端口是运行时才知道的)。
 
 ### 端点
 
-| op | 路径 | scope |
-|---|---|---|
-| `reportPlaytime` | `PUT /v1/playtime/works/{workID}` | write |
-| `reportPlaytimeByRef` | `PUT /v1/playtime/by-ref/{source}/{externalID}` | write |
-| `reportPlaytimeBatch` | `POST /v1/playtime/batch`(≤200,逐条成败) | write |
-| `listOwnPlaytime` | `GET /v1/playtime/mine?updated_since=` | read |
-| `getOwnPlaytimeForWork` | `GET /v1/playtime/works/{workID}` | read |
+| op | 路径 |
+|---|---|
+| `reportPlaytime` | `PUT /v1/playtime/works/{workID}` |
+| `reportPlaytimeByRef` | `PUT /v1/playtime/by-ref/{source}/{externalID}` |
+| `reportPlaytimeBatch` | `POST /v1/playtime/batch`(≤200,逐条成败) |
+| `listOwnPlaytime` | `GET /v1/playtime/mine?updated_since=` |
+| `getOwnPlaytimeForWork` | `GET /v1/playtime/works/{workID}` |
 
 `by-ref` 决定这张脸**能不能被接入**:管理器手上是 VNDB id 或 DLsite workno,从来不是我们的 work id;强制要 work id 等于把映射问题推给每一个应用作者。**只有 exact 锚解析** —— probable 链接是线索不是身份,拿它归属别人的时长就是记到错的游戏上。
 
@@ -497,7 +496,7 @@ wave 176-179 把人类的**写**搬完了;本波搬的是搬完写之后还留�
 - **admin face(`/api/v1/admin/catalog/*`)**:Bearer JWT(accept-both verifier)+ **ren 角色(超管专属)**,与 site 绑定列无关;wave 187b 起还要过 **client 闸**——令牌若签发自第三方应用(`oauth_clients.owner_user_id` 非空)一律 403,先于权限判定(空 `client_id` 的第一方会话令牌放行,见 §4.2 的缺口条)。
 - **user face(`/api/v1/user/catalog/*`,wave 176)**:Bearer **用户**访问令牌(同一 accept-both verifier)+ `catalog:edit` scope + **client 绑定**。这里 `oauth_clients.catalog_site` 的用法与 S2S 写面**不同**:S2S 校验「绑定值 == 请求体 site」,user face **根本不收 site**——绑定值**就是**写入的租户。因此新增消费站的动作仍是同一条(给其 client 设 `catalog_site`),但一等登录令牌(无 `client_id`)在本面**永远**拿不到租户,只能走 OAuth 授权码流取得 client 绑定令牌。详见 §4。
 - **编辑引擎提案桥面已死**(曾为 09-open-api-phase2 06b 的过渡参考):`/internal/edit/*`(scope `galgame:propose`、计量 face `galgame_internal_propose`)随 galgame 面退役**整体移除**——今天这些路径连 410 都不是,就是 404。编辑引擎的 S2S 面(`/api/v1/catalog/edit/*`)在 wave 181/185 两轮收缩后只剩 list(第三人称统计读)/revisions/diff **三条只读**,写与裁决全在用户面。「第三方实际开放」已于 **wave R3(2026-08-17)裁定并落地**:不复活桥面、不开 /v1 编辑路由,第三方经自助 user_login 申请 `catalog:edit` 用户 scope 后走用户面(见 §4 的第三方准入段)。
-- **playtime face(`/v1/playtime/*`)**:Bearer 用户访问令牌 + `playtime:read` / `playtime:write` + **client 绑定**,**无 API key**(令牌已带齐用户与应用两个身份,再加 key 就是第二套 scope 注册表),**不要求** `catalog_site`。详见 §4.6。
+- **playtime face(`/v1/playtime/*`)**:Bearer 用户访问令牌 + **client 绑定**,**无 API key**,**不要求** `playtime:read` / `playtime:write`(任何已开通用户登录的应用都可以调),**不要求** `catalog_site`。详见 §4.6。
 - **public face(`/v1/catalog/*`)**:开发者平台 API key(`Authorization: Bearer nm_live_…`)+ `catalog:read`,过 `internal/platform/devapi` 的中间件链(凭据解析 → 用量记账 → 限流 → 日配额 → scope)。**唯一例外 `GET /v1/catalog/stats` 无鉴权**:它只发布「目录有多大」的聚合数(LIVE works × medium + 身份族存量,无 `nsfw` 参数、人人同一份 payload),是公开站与开发者门户在任何人持 key 之前就要渲染的那几个数字;不计量、不限流,由 `Cache-Control: s-maxage=3600` 兜住。**该路由裸挂在 app 上且必须排在 `/v1/catalog` 分组之前**——Fiber 按注册序匹配、分组的 handler 即前缀 `Use`,挪到分组之后路由仍然通,只是悄悄退回 key 闸后面(钉子:`cmd/catalog/public_stats_route_test.go`,带反序对照)。
 - `GET /openapi.json`(S2S spec)、`GET /healthz` 无鉴权。
 

--- a/docs/catalog/public-openapi.yaml
+++ b/docs/catalog/public-openapi.yaml
@@ -1511,6 +1511,9 @@ components:
         height:
           format: int64
           type: integer
+        id:
+          format: int64
+          type: integer
         kind:
           type: string
         portrait_pinned:
@@ -5805,7 +5808,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/HouseError"
           description: Error
-      summary: Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Requires playtime:write
+      summary: Report up to 200 works in one call — the first-login library sync. Each item is accepted or rejected on its own and the response reports per-item outcomes; a single bad item never fails the batch. Any app with a user access token may call this; playtime:write is not required.
       tags:
         - playtime
   /v1/playtime/by-ref/{source}/{externalID}:
@@ -5845,7 +5848,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/HouseError"
           description: Error
-      summary: Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Requires playtime:write
+      summary: Report playtime addressing the work by an external id the client already holds (vndb/dlsite/getchu/bangumi …) instead of a catalog work id. Only EXACT anchors resolve; the response echoes the resolved work_id, which the client should cache. 404 when nothing is anchored to that id. Any app with a user access token may call this; playtime:write is not required.
       tags:
         - playtime
   /v1/playtime/mine:
@@ -5883,7 +5886,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/HouseError"
           description: Error
-      summary: Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Requires playtime:read
+      summary: Page the bearer token's own playtime rows in (updated_at) order — the sync-back leg for a second device. Hand `cursor` back as ?updated_since= to fetch only what changed. Any app with a user access token may call this; playtime:read is not required.
       tags:
         - playtime
   /v1/playtime/works/{workID}:
@@ -5912,7 +5915,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/HouseError"
           description: Error
-      summary: The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Requires playtime:read
+      summary: The bearer token's own playtime on ONE work, folded across their applications (MAX minutes — two apps watching one save file are not two playthroughs). `playtime` is null when the user has never reported here; that is a 200, not a 404. This is the call a rating form makes to offer 'you played 30h — attach it?'. Any app with a user access token may call this; playtime:read is not required.
       tags:
         - playtime
     put:
@@ -5946,6 +5949,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/HouseError"
           description: Error
-      summary: "Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Requires playtime:write"
+      summary: "Report the bearer token's own playtime on a work. The body carries the ABSOLUTE cumulative total in minutes, never a delta — re-sending the same number is a no-op, which makes the call safe to retry. Keyed by (user, work, client): a second app of the same user reports alongside, not over. Any app with a user access token may call this; playtime:write is not required."
       tags:
         - playtime

--- a/docs/catalog/v2-openapi.yaml
+++ b/docs/catalog/v2-openapi.yaml
@@ -9695,7 +9695,7 @@ paths:
         - me
   /v2/me/playtimes:
     get:
-      description: The bearer user's playtime rows. work_ids= is a batch read. Requires a user access token.
+      description: The bearer user's playtime rows. work_ids= is a batch read. Requires a user access token. Any app may call this; playtime:read is not required.
       operationId: listMyPlaytimes
       parameters:
         - description: Comma-separated work ids, max 100. Batch read, no pagination.
@@ -9767,7 +9767,7 @@ paths:
       tags:
         - me
     post:
-      description: 207 Multi-Status. Each item is a playtime or a problem. Requires a user access token.
+      description: 207 Multi-Status. Each item is a playtime or a problem. Requires a user access token. Any app may call this; playtime:write is not required.
       operationId: batchMyPlaytimes
       requestBody:
         content:
@@ -9853,7 +9853,7 @@ paths:
         - me
   /v2/me/playtimes/{work_id}:
     delete:
-      description: 204 with no body. Requires a user access token.
+      description: 204 with no body. Requires a user access token. Any app may call this; playtime:write is not required.
       operationId: deleteMyPlaytime
       parameters:
         - description: Catalog work id.
@@ -9921,7 +9921,7 @@ paths:
       tags:
         - me
     get:
-      description: 404 when the user has never reported. Requires a user access token.
+      description: 404 when the user has never reported. Requires a user access token. Any app may call this; playtime:read is not required.
       operationId: getMyPlaytime
       parameters:
         - description: Catalog work id.
@@ -9995,7 +9995,7 @@ paths:
       tags:
         - me
     put:
-      description: Absolute minutes. Naturally idempotent. Requires a user access token.
+      description: Absolute minutes. Naturally idempotent. Requires a user access token. Any app may call this; playtime:write is not required.
       operationId: putMyPlaytime
       parameters:
         - description: Catalog work id.

--- a/docs/developer-platform/02-public-api.md
+++ b/docs/developer-platform/02-public-api.md
@@ -167,13 +167,13 @@
 
 **playtime 面**(后端 = `cmd/catalog` 同进程挂载;**平台第二个公开面,也是第一个用「用户 Bearer 令牌」而非 API key 认证的公开面**——语义与错误面详见 §3.8):
 
-| 公开端点(`/v1`) | scope | 说明 |
+| 公开端点(`/v1`) | 凭据 | 说明 |
 |---|---|---|
-| `PUT /v1/playtime/works/{workID}` | `playtime:write` | 上报**自己**在某作品上的游玩时长。body `{minutes, status?, last_played_at?}`,`minutes` 是**绝对累计值(分钟),永远不是增量**——重发同一个数是 no-op,故该调用**可安全重试**。按 `(user, work, client)` 三元组落行:同一用户的第二个 App **并排写**而不是覆盖。作品非 LIVE / 不存在 → 404 |
-| `PUT /v1/playtime/by-ref/{source}/{externalID}` | `playtime:write` | 同上,但用客户端手里已有的**外部 id** 寻址(`vndb`/`dlsite`/`getchu`/`bangumi`…),免去先跑一趟 lookup。**只认 exact 锚**;响应回显解析出的 `work_id`(带 `resolved_from`),客户端应缓存它。源键未知 / 无锚 → 404 |
-| `POST /v1/playtime/batch` | `playtime:write` | 首次登录的**库同步**:一次最多 200 条,每条可用 `work_id` **或** `source`+`external_id` 寻址。**逐条判定**——响应给 `{accepted, refused, results[]}`,`results[i]` 带 `{index, status(ok\|not_found\|rejected), work_id, error}`;**一条坏数据永不带崩整批**(不是事务) |
-| `GET /v1/playtime/mine` | `playtime:read` | 分页拉**自己**的全部记录,按 `updated_at` 升序;`updated_since=`(RFC 3339)只取该时刻之后变化的行,`limit` 1-200 缺省 200。响应的 `cursor` 就是本页最后一行的 `updated_at`,**原样回填成下一次的 `updated_since=`** 即增量续拉——第二台设备的回灌腿 |
-| `GET /v1/playtime/works/{workID}` | `playtime:read` | 自己在**某一部**作品上的记录,**跨自己的多个 App 折叠**:`minutes` 取 **MAX**(两个 App 盯同一份存档不是两周目),`status` 取那一行的状态但**任一行 finished 即整体 finished**,`last_played_at` 取最新,另给 `clients` = 折叠了几个 App。从未上报过 → `data` 为 **`null` 且是 200,不是 404**(评分表单据此问「你玩了 30 小时,要附上吗?」) |
+| `PUT /v1/playtime/works/{workID}` | 用户令牌(任意 app) | 上报**自己**在某作品上的游玩时长。body `{minutes, status?, last_played_at?}`,`minutes` 是**绝对累计值(分钟),永远不是增量**——重发同一个数是 no-op,故该调用**可安全重试**。按 `(user, work, client)` 三元组落行:同一用户的第二个 App **并排写**而不是覆盖。作品非 LIVE / 不存在 → 404。**不需要** `playtime:write` |
+| `PUT /v1/playtime/by-ref/{source}/{externalID}` | 用户令牌(任意 app) | 同上,但用客户端手里已有的**外部 id** 寻址(`vndb`/`dlsite`/`getchu`/`bangumi`…),免去先跑一趟 lookup。**只认 exact 锚**;响应回显解析出的 `work_id`(带 `resolved_from`),客户端应缓存它。源键未知 / 无锚 → 404 |
+| `POST /v1/playtime/batch` | 用户令牌(任意 app) | 首次登录的**库同步**:一次最多 200 条,每条可用 `work_id` **或** `source`+`external_id` 寻址。**逐条判定**——响应给 `{accepted, refused, results[]}`,`results[i]` 带 `{index, status(ok\|not_found\|rejected), work_id, error}`;**一条坏数据永不带崩整批**(不是事务) |
+| `GET /v1/playtime/mine` | 用户令牌(任意 app) | 分页拉**自己**的全部记录,按 `updated_at` 升序;`updated_since=`(RFC 3339)只取该时刻之后变化的行,`limit` 1-200 缺省 200。响应的 `cursor` 就是本页最后一行的 `updated_at`,**原样回填成下一次的 `updated_since=`** 即增量续拉——第二台设备的回灌腿。**不需要** `playtime:read` |
+| `GET /v1/playtime/works/{workID}` | 用户令牌(任意 app) | 自己在**某一部**作品上的记录,**跨自己的多个 App 折叠**:`minutes` 取 **MAX**(两个 App 盯同一份存档不是两周目),`status` 取那一行的状态但**任一行 finished 即整体 finished**,`last_played_at` 取最新,另给 `clients` = 折叠了几个 App。从未上报过 → `data` 为 **`null` 且是 200,不是 404**(评分表单据此问「你玩了 30 小时,要附上吗?」) |
 
 ### 3.2.1 D7 投影约定(2026-07-29 A2-1a 落账)
 
@@ -577,7 +577,7 @@ Content-Type: application/json
 | 凭据 | 机器 API key:`X-API-Key: nm_live_…`(或 `Authorization: Bearer nm_live_…`) | **用户** OAuth 访问令牌:`Authorization: Bearer <access token>` |
 | 主体 | 一把 key = 一个应用,与人无关 | 令牌里的**那一个用户**;写谁的行由令牌推导,请求里**没有** uid 参数 |
 | 门 | key 有效性 + tier + 日配额 | JWT/JWKS 验签 → 令牌须**带用户身份**,否则 401;须**绑定 OAuth client**(`client_id`),否则 403 |
-| scope | `catalog:read` | `playtime:read` / `playtime:write`,**两者都可在开发者门户自助申请**(与 `openid`/`profile`/`email` 同属 self-service 名单) |
+| scope | `catalog:read` | **无。**`playtime:read` / `playtime:write` 不再判定。任何已开通用户登录的应用,用它签出的用户令牌即可读写该用户自己的时长。这两个 scope 仍可出现在同意页(旧授权 URL 不 400),但缺它们不再 403 |
 | 限流 | key 级配额 | **每 (client, user) 每分钟 120 次**,超出 429;Redis 不可用时**fail-open** |
 
 - **令牌必须绑 client 不是形式主义**:记录按 `(user, work, client)` 三元组落行,`client_id` 是主键的一部分。没有它就没有「这条是哪个 App 报的」,读面的跨 App 折叠也就无从谈起——所以无 client 绑定的令牌(例如站内直接登录换来的那种)在本面一律 403,而不是悄悄写进一个空 client。
@@ -594,7 +594,7 @@ Content-Type: application/json
 **它如何回到公开面(以及如何不回)**
 
 - **只有 `finished` 的行进公开聚合**(`playing`/`dropped`/`on_hold` 与 `<10` 分钟的行一并剔除):聚合作业先按用户折叠(同用户多 client 取 MAX),再对用户取**中位数**,**至少 3 个上报用户**才写出一行,落 `catalog_work_playtime` 的 `nextmoe` 源。它出现在 catalog 面 `works/{id}` 的 `playtimes[]` 里,与 vndb / erogamescape 的同名块**同形同源键规则**(`source=nextmoe`)。
-- **个人行永不上公开面**:公开面看得到的只有那个中位数与上报人数;谁玩了多久只有本人的 `playtime:read` 令牌读得到。
+- **个人行永不上公开面**:公开面看得到的只有那个中位数与上报人数;谁玩了多久只有本人的用户令牌读得到。
 
 **与 MCP 的关系**:playtime 面**刻意不进 MCP 工具面**,理由见 [09 §4](./09-mcp-server.md)。
 

--- a/docs/developer-platform/05-developer-portal.md
+++ b/docs/developer-platform/05-developer-portal.md
@@ -58,7 +58,7 @@
 ```json
 { "name": "Kurumi", "user_login": {
     "redirect_uris": ["http://127.0.0.1:53682/callback"],
-    "scopes": ["playtime:read", "playtime:write"] } }
+    "scopes": ["openid", "profile"] } }
 ```
 
 给出它 → app 置 `is_public=true`、`grants=["authorization_code","refresh_token"]`,scope 并入 `allowed_scopes`(`openid` 自动补)。**不给 → 完全保持原样**,本字段出现前注册的每个 app 行为逐字节不变。`user_login` 是**整体替换**而非 patch:否则删掉一个回调将永远做不到,而废弃的回调正是最该能删的东西。
@@ -68,7 +68,7 @@
 1. **回调白名单**:只收 `https://`(且不是裸 IP)与 `http://` 到 `127.0.0.1` / `[::1]` 环回。拒绝通配、fragment(隐式流的令牌通道)、userinfo(`https://example.com@evil.com/cb` 在人眼里是前者)、以及到任何非环回主机的明文 http —— 授权码就走在这个 URL 里。**`localhost` 也拒**:它过主机名解析,可以被指向别处,`127.0.0.1` 不能。
 2. **强制 PKCE**:桌面应用把二进制发给用户,里面没有秘密。标 `is_public` 即让 OAuth 服务在无 `code_challenge` 时**拒绝**它的授权码。环回回调按 **RFC 8252 §7.3 端口无关**匹配(端口是运行时才选的),scheme/host/path/query 仍精确匹配 —— 非环回 URI 永远走不到这个分支。
 3. **保留名**:同意页把应用名显示在用户账号旁边,「NextMoe 官方助手」就是我们自己托管的钓鱼页。含 nextmoe / 未萌 / kungal / 官方 / official / admin 等片段一律拒。这是地板不是滤网(存心的冒充者会用同形字),配套的是同意页上不靠猜意图的**第三方标记**(`owner_user_id` 非空)。
-4. **同意 scope 白名单**(`selfServiceUserScopes`):`openid` / `profile` / `email` / `playtime:read` / `playtime:write` / **`catalog:edit`(wave R3,2026-08-17 起)**。**注意仍不在其中的**:`image:upload`、`artifact:upload` —— 自助注册不能向人索取花我们存储的权限。往这张表里加一项是**政策决定**,不是改配置;`catalog:edit` 就是这样一次政策决定,其代价已在面上收讫:第三方令牌永远 `ModerationCapped`(只能提案、不能裁决),且每用户未决提案帽 20(429)。写共享语料因此始终隔着一道人审。
+4. **同意 scope 白名单**(`selfServiceUserScopes`):`openid` / `profile` / `email` / `playtime:read` / `playtime:write` / **`catalog:edit`(wave R3,2026-08-17 起)**。**`playtime:read` / `playtime:write` 仍可申请,但调 `/v1/playtime` 与 `/v2/me/playtimes` 不再需要它们**——任何已开通用户登录的应用都能读写该用户自己的时长。这两个词留在白名单里只是为了让旧授权 URL 不 400。**注意仍不在其中的**:`image:upload`、`artifact:upload` —— 自助注册不能向人索取花我们存储的权限。往这张表里加一项是**政策决定**,不是改配置;`catalog:edit` 就是这样一次政策决定,其代价已在面上收讫:第三方令牌永远 `ModerationCapped`(只能提案、不能裁决),且每用户未决提案帽 20(429)。写共享语料因此始终隔着一道人审。
 
 它与 API key 的 scope 白名单(`selfServiceScopes`,2026-08-18 起只剩 `catalog:read`)**故意分开**:两者管的是不同凭证。一个说机器 key 匿名能干什么,另一个说应用**能向人要什么**。合并就等于让只读 key 的白名单去决定同意页的政策。
 


### PR DESCRIPTION
## What

`/v1/playtime` and `/v2/me/playtimes` no longer require `playtime:read` / `playtime:write`. A client-bound user access token from any app that has user login enabled is enough.

Those scopes stay on the self-service whitelist so existing authorize URLs do not 400. The HTTP gate no longer 403s when they are absent.

## Why

Every app had to put the scopes on `allowed_scopes` and the authorize URL. Clients that did not (letmoe) failed consent with an invalid-scope error, then 403'd on the face.

## Docs

Portal playtime pages, `02-public-api.md` §3.8, and `01-service-and-contract.md` §4.6 now say any app may call this. Regenerated OpenAPI + docs-model.

No schema change.