### PR TITLE
feat(catalog): name the entities to retranslate instead of forcing the whole lane

### DIFF
--- a/apps/api/cmd/entity-intro-mt/main.go
+++ b/apps/api/cmd/entity-intro-mt/main.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"api/internal/jobs/entityintromt"
@@ -26,7 +28,14 @@ func main() {
 	mock := flag.Bool("mock", false, "REHEARSAL ONLY: offline deterministic mock translator (no network; obvious marker output)")
 	workers := flag.Int("workers", 1, "apply-mode concurrency (per-request latency dominates)")
 	force := flag.Bool("force", false, "retranslate rows whose src_hash already matches — the prompt is not in the hash, so a prompt change needs this")
+	entityIDs := flag.String("entity-ids", "", "comma-separated entity ids for --lane; the named list IS the population")
 	flag.Parse()
+
+	ids, err := parseEntityIDs(*entityIDs)
+	if err != nil {
+		slog.Error("--entity-ids", "error", err)
+		os.Exit(2)
+	}
 
 	logger.Init("development")
 
@@ -54,9 +63,10 @@ func main() {
 
 	st, err := entityintromt.Run(context.Background(), tr, entityintromt.Opts{
 		DSN: *dsn, Apply: *apply, Lane: *lane, Limit: *limit, Offset: *offset,
-		Delay:   time.Duration(*delayMS) * time.Millisecond,
-		Workers: *workers,
-		Force:   *force,
+		Delay:     time.Duration(*delayMS) * time.Millisecond,
+		Workers:   *workers,
+		Force:     *force,
+		EntityIDs: ids,
 	})
 	if err != nil {
 		slog.Error("run failed", "error", err)
@@ -125,6 +135,22 @@ func modelSuffix(m string) string {
 		return ""
 	}
 	return " · " + m
+}
+
+func parseEntityIDs(csv string) ([]int64, error) {
+	var out []int64
+	for _, f := range strings.Split(csv, ",") {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		id, err := strconv.ParseInt(f, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("%q is not an entity id", f)
+		}
+		out = append(out, id)
+	}
+	return out, nil
 }
 
 func envOr(key, fallback string) string {

--- a/apps/api/internal/jobs/entityintromt/entityids_test.go
+++ b/apps/api/internal/jobs/entityintromt/entityids_test.go
@@ -1,0 +1,42 @@
+package entityintromt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamedEntityIDsAreThePopulation(t *testing.T) {
+	clean(t)
+	vndb, _ := srcIDs(t)
+	ctx := context.Background()
+
+	wanted := mkCharacter(t, "wanted")
+	mkCharIntro(t, wanted, "ja", "主人公のクラスメイト。", vndb)
+	other := mkCharacter(t, "other")
+	mkCharIntro(t, other, "ja", "幼馴染の妹。", vndb)
+
+	st, err := Run(ctx, MockTranslator{}, Opts{
+		DSN: testDSN, Apply: true, Lane: LaneCharacter, EntityIDs: []int64{wanted},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, st[0].Candidates, "the named list is the population, not a filter over it")
+	assert.Equal(t, 1, st[0].Inserted)
+
+	var untouched int64
+	require.NoError(t, testDB.Raw(
+		`SELECT count(*) FROM catalog_character_intro WHERE character_id = ? AND provenance = 1`,
+		other).Scan(&untouched).Error)
+	assert.Zero(t, untouched, "an unnamed character must not be written")
+}
+
+func TestEntityIDsWithoutALaneAreRefused(t *testing.T) {
+	clean(t)
+	_, err := Run(context.Background(), MockTranslator{}, Opts{
+		DSN: testDSN, Apply: true, EntityIDs: []int64{1, 2, 3},
+	})
+	require.Error(t, err, "character 42, person 42 and label 42 are three different rows")
+	assert.Contains(t, err.Error(), "--entity-ids needs --lane")
+}

--- a/apps/api/internal/jobs/entityintromt/entityintromt.go
+++ b/apps/api/internal/jobs/entityintromt/entityintromt.go
@@ -39,6 +39,10 @@ type Opts struct {
 	Delay   time.Duration
 	Workers int
 	Force   bool
+	// EntityIDs is meaningful only together with Lane: the three lanes number
+	// their entities independently, so the same integers name a different row in
+	// each one. Run rejects the combination rather than filtering all three.
+	EntityIDs []int64
 }
 
 type Sample struct {
@@ -81,6 +85,9 @@ func Run(ctx context.Context, tr Translator, opts Opts) ([]*LaneStats, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(opts.EntityIDs) > 0 && opts.Lane == "" {
+		return nil, fmt.Errorf("--entity-ids needs --lane: entity ids are per-lane, so an unlaned list would also match unrelated persons and labels holding the same numbers")
+	}
 	db, err := database.OpenJob(opts.DSN)
 	if err != nil {
 		return nil, fmt.Errorf("connect catalog db: %w", err)
@@ -91,7 +98,7 @@ func Run(ctx context.Context, tr Translator, opts Opts) ([]*LaneStats, error) {
 
 	var out []*LaneStats
 	for _, lane := range selected {
-		cands, err := loadCandidates(ctx, db, lane, opts.Limit, opts.Offset)
+		cands, err := loadCandidates(ctx, db, lane, opts.Limit, opts.Offset, opts.EntityIDs)
 		if err != nil {
 			return nil, fmt.Errorf("load %s candidates: %w", lane.key, err)
 		}
@@ -112,7 +119,12 @@ func Run(ctx context.Context, tr Translator, opts Opts) ([]*LaneStats, error) {
 		slog.Info("entity-intro-mt candidates", "lane", lane.key,
 			"candidates", len(cands), "from_ja", st.FromJa, "from_en", st.FromEn,
 			"with_glossary", st.WithGlossary,
-			"apply", opts.Apply, "limit", opts.Limit, "offset", opts.Offset)
+			"apply", opts.Apply, "limit", opts.Limit, "offset", opts.Offset,
+			"entity_ids", len(opts.EntityIDs), "force", opts.Force)
+		if n := len(opts.EntityIDs); n > 0 && n != len(cands) {
+			slog.Warn("named entity ids did not all become candidates — the rest fail this lane's gates (deleted, a source zh intro, or no ja/en source intro)",
+				"lane", lane.key, "named", n, "candidates", len(cands))
+		}
 
 		r := &runner{db: db, tr: tr, lane: lane, force: opts.Force, stats: st}
 		r.process(ctx, cands, opts.Apply, opts.Delay, opts.Workers)

--- a/apps/api/internal/jobs/entityintromt/entityintromt_test.go
+++ b/apps/api/internal/jobs/entityintromt/entityintromt_test.go
@@ -200,7 +200,7 @@ func TestLoadCandidates_SourcePreference(t *testing.T) {
 	blank := mkCharacter(t, "blank")
 	mkCharIntro(t, blank, "ja", "   \n  ", lo)
 
-	cands, err := loadCandidates(ctx, testDB, lane, 0, 0)
+	cands, err := loadCandidates(ctx, testDB, lane, 0, 0, nil)
 	require.NoError(t, err)
 
 	byID := map[int64]candidate{}

--- a/apps/api/internal/jobs/entityintromt/source.go
+++ b/apps/api/internal/jobs/entityintromt/source.go
@@ -24,8 +24,14 @@ type candidate struct {
 	Gloss      Glossary `gorm:"-"`
 }
 
-func loadCandidates(ctx context.Context, db *gorm.DB, lane laneDef, limit, offset int) ([]candidate, error) {
+func loadCandidates(ctx context.Context, db *gorm.DB, lane laneDef, limit, offset int, entityIDs []int64) ([]candidate, error) {
 	t, id := lane.introTable, lane.idCol
+	idGate, args := ``, []any{}
+	if len(entityIDs) > 0 {
+		idGate = `
+		  AND src.entity_id IN (?)`
+		args = append(args, entityIDs)
+	}
 	q := `
 		WITH src AS (
 			SELECT DISTINCT ON (` + id + `) ` + id + ` AS entity_id, lang, source_id, intro
@@ -48,9 +54,8 @@ func loadCandidates(ctx context.Context, db *gorm.DB, lane laneDef, limit, offse
 		JOIN ` + lane.entityTable + ` e ON e.id = src.entity_id AND e.deleted_at IS NULL
 		LEFT JOIN has_zh_source hz ON hz.entity_id = src.entity_id
 		LEFT JOIN mzh ON mzh.entity_id = src.entity_id
-		WHERE hz.entity_id IS NULL
+		WHERE hz.entity_id IS NULL` + idGate + `
 		ORDER BY src.entity_id ASC`
-	args := []any{}
 	if limit > 0 {
 		q += ` LIMIT ?`
 		args = append(args, limit)


### PR DESCRIPTION
## Why

#61 fixed the entity translator's prompt. It changed nothing already written: the prompt is not an input to `src_hash`, so every existing row still hashes as current and the nightly skips all 33,281 dirty ones. `--force` is the only lever, and it had no target — the sole windows were `--limit`/`--offset` over the whole candidate set.

That matters at this size. Clearing the character lane means rewriting **30,215** dirty rows; without an id filter `--force` would rewrite all **114,847**, which at the measured 8-concurrent ceiling is the difference between ~2 days and ~8.

## What

`--entity-ids`, the entity lanes' version of the work lane's `--work-ids` (#57). Same semantics: the named list *is* the population, and a warn fires when named ids don't all survive the lane's gates.

It requires `--lane`. The three lanes number their entities independently, so an unlaned list of character ids would also match whatever persons and labels hold the same integers — the failure mode is silent, and it writes.

## Tests

- named ids are the population, and an unnamed sibling character stays unwritten
- `--entity-ids` without `--lane` is refused

Both run against a real ephemeral catalog DB (`REQUIRE_DB_TESTS` does not cover this package — the tell is runtime, and these take 2.2s, not 0.03s).

## Migration

None — no schema change.