### PR TITLE
feat(catalog): admit type4-gated anchors and landscape covers to the bangumi cover backfill

### DIFF
--- a/apps/api/cmd/backfill-bangumi-covers/main.go
+++ b/apps/api/cmd/backfill-bangumi-covers/main.go
@@ -21,6 +21,7 @@ func main() {
 	offset := flag.Int("offset", 0, "skip this many candidate works (for chunking)")
 	imageBaseURL := flag.String("image-base-url", "", "image_service base override (point at the LOCAL dev service, e.g. http://127.0.0.1:9278)")
 	uploadGap := flag.Duration("upload-gap", 0, "min delay between uploads (0 = none; raise for a gentle production sweep)")
+	allowLandscape := flag.Bool("allow-landscape", false, "also write landscape covers (never portrait-pinned); default keeps the portrait-only behavior")
 	flag.Parse()
 
 	_ = godotenv.Load("apps/api/.env")
@@ -33,13 +34,14 @@ func main() {
 	logger.Init(cfg.Server.Env)
 
 	sum, err := bangumicovers.Run(context.Background(), cfg, bangumicovers.Opts{
-		Apply:         *apply,
-		Limit:         *limit,
-		Offset:        *offset,
-		DSN:           *dsn,
-		BangumiMirror: *mirror,
-		ImageBaseURL:  *imageBaseURL,
-		UploadGap:     *uploadGap,
+		Apply:          *apply,
+		Limit:          *limit,
+		Offset:         *offset,
+		DSN:            *dsn,
+		BangumiMirror:  *mirror,
+		ImageBaseURL:   *imageBaseURL,
+		UploadGap:      *uploadGap,
+		AllowLandscape: *allowLandscape,
 	})
 	if sum != nil {
 		slog.Info("backfill-bangumi-covers summary", "summary", sum)

--- a/apps/api/internal/jobs/bangumicovers/bangumicovers.go
+++ b/apps/api/internal/jobs/bangumicovers/bangumicovers.go
@@ -18,13 +18,14 @@ import (
 const defaultTimeout = 60 * time.Second
 
 type Opts struct {
-	Apply         bool
-	Limit         int
-	Offset        int
-	DSN           string
-	BangumiMirror string
-	ImageBaseURL  string
-	UploadGap     time.Duration
+	Apply          bool
+	Limit          int
+	Offset         int
+	DSN            string
+	BangumiMirror  string
+	ImageBaseURL   string
+	UploadGap      time.Duration
+	AllowLandscape bool
 }
 
 type imageUploader interface {
@@ -34,16 +35,17 @@ type imageUploader interface {
 }
 
 type counters struct {
-	coverUploaded  int
-	coverWould     int
-	coverExists    int
-	coverLandscape int
-	coverNoDims    int
-	coverMissing   int
-	coverRejected  int
-	coverRefused   int
-	coverDedup     int
-	errors         int
+	coverUploaded    int
+	coverWould       int
+	coverExists      int
+	coverLandscape   int
+	coverLandscapeOK int
+	coverNoDims      int
+	coverMissing     int
+	coverRejected    int
+	coverRefused     int
+	coverDedup       int
+	errors           int
 }
 
 type runner struct {
@@ -155,8 +157,11 @@ func (r *runner) process(ctx context.Context, opts Opts, cands []candidate, d *d
 			continue
 		}
 		if !e.portrait() {
-			r.c.coverLandscape++
-			continue
+			if !opts.AllowLandscape {
+				r.c.coverLandscape++
+				continue
+			}
+			r.c.coverLandscapeOK++
 		}
 		if r.writeCover(ctx, opts.BangumiMirror, c, e, opts.Apply) {
 			return true
@@ -174,6 +179,7 @@ func (r *runner) summary(opts Opts, candidates int) map[string]any {
 			"would_upload":    r.c.coverWould,
 			"already_exists":  r.c.coverExists,
 			"landscape_skip":  r.c.coverLandscape,
+			"landscape_used":  r.c.coverLandscapeOK,
 			"no_dims_skip":    r.c.coverNoDims,
 			"missing_file":    r.c.coverMissing,
 			"rejected":        r.c.coverRejected,

--- a/apps/api/internal/jobs/bangumicovers/bangumicovers_test.go
+++ b/apps/api/internal/jobs/bangumicovers/bangumicovers_test.go
@@ -137,6 +137,9 @@ func TestLoadCandidates(t *testing.T) {
 	want := mkWork(t, reg.galgameMedium, "bodyless-exact", nil)
 	mkRef(t, want, reg.bangumiSource, "111", model.LinkKindExact, ruleBgmTitleYear)
 
+	wantType4 := mkWork(t, reg.galgameMedium, "bodyless-type4", nil)
+	mkRef(t, wantType4, reg.bangumiSource, "666", model.LinkKindExact, ruleBgmType4Gated)
+
 	wProbable := mkWork(t, reg.galgameMedium, "bodyless-probable", nil)
 	mkRef(t, wProbable, reg.bangumiSource, "222", model.LinkKindProbable, "rule:bgm-title-only")
 
@@ -144,16 +147,20 @@ func TestLoadCandidates(t *testing.T) {
 	mkRef(t, wClaimed, reg.bangumiSource, "333", model.LinkKindExact, ruleBgmTitleYear)
 
 	wManga := mkWork(t, 2, "manga-exact", nil)
-	mkRef(t, wManga, reg.bangumiSource, "444", model.LinkKindExact, ruleBgmTitleYear)
+	mkRef(t, wManga, reg.bangumiSource, "444", model.LinkKindExact, ruleBgmType4Gated)
 
 	wOtherRule := mkWork(t, reg.galgameMedium, "bodyless-otherrule", nil)
 	mkRef(t, wOtherRule, reg.bangumiSource, "555", model.LinkKindExact, "rule:title-year-strict")
 
 	cands, err := loadCandidates(context.Background(), testDB, reg, 0, 0)
 	require.NoError(t, err)
-	require.Len(t, cands, 1, "only the bodyless galgame exact rule:bgm-title-year anchor is a candidate")
-	assert.Equal(t, want, cands[0].WorkID)
-	assert.Equal(t, "111", cands[0].SubjectID)
+	require.Len(t, cands, 2, "only bodyless galgame exact anchors of the two trusted rules are candidates")
+	byWork := map[int64]string{}
+	for _, c := range cands {
+		byWork[c.WorkID] = c.SubjectID
+	}
+	assert.Equal(t, "111", byWork[want])
+	assert.Equal(t, "666", byWork[wantType4])
 }
 
 func TestWritePath(t *testing.T) {
@@ -225,6 +232,40 @@ func TestWritePath(t *testing.T) {
 	assert.Equal(t, 0, r3.c.coverUploaded)
 	assert.Equal(t, 1, r3.c.coverDedup, "ON CONFLICT refuses the duplicate under a stale preload")
 	require.Len(t, coversOf(t, wPortrait), 1, "still exactly one cover row")
+}
+
+func TestAllowLandscape(t *testing.T) {
+	truncate(t)
+	reg := resolveTestRegistry(t)
+
+	wLandscape := mkWork(t, reg.galgameMedium, "landscape-ok", nil)
+	wPortrait := mkWork(t, reg.galgameMedium, "portrait-ok", nil)
+
+	mirror := writeMirror(t, []dimsEntry{
+		{SubjectID: 9401, W: 1200, H: 800, File: "9401/cover.jpg"},
+		{SubjectID: 9402, W: 800, H: 1200, File: "9402/cover.jpg"},
+	}, map[string]bool{"9401": true, "9402": true})
+	d, err := loadDims(mirror)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	r := &runner{db: testDB, cli: &fakeUploader{}, sourceID: reg.bangumiSource, exist: map[int64]bool{}}
+	require.False(t, r.process(ctx, Opts{Apply: true, BangumiMirror: mirror, AllowLandscape: true}, []candidate{
+		{WorkID: wLandscape, SubjectID: "9401", Site: nil},
+		{WorkID: wPortrait, SubjectID: "9402", Site: nil},
+	}, d))
+
+	assert.Equal(t, 2, r.c.coverUploaded)
+	assert.Equal(t, 1, r.c.coverLandscapeOK)
+	assert.Equal(t, 0, r.c.coverLandscape)
+
+	landRows := coversOf(t, wLandscape)
+	require.Len(t, landRows, 1)
+	assert.False(t, landRows[0].PortraitPinned, "a landscape cover must never take the portrait pin")
+
+	portRows := coversOf(t, wPortrait)
+	require.Len(t, portRows, 1)
+	assert.True(t, portRows[0].PortraitPinned, "the portrait in the same run still pins")
 }
 
 func TestTwoCoversReadFace(t *testing.T) {

--- a/apps/api/internal/jobs/bangumicovers/source.go
+++ b/apps/api/internal/jobs/bangumicovers/source.go
@@ -9,15 +9,25 @@ import (
 	"gorm.io/gorm"
 )
 
-// ruleBgmTitleYear is the matched_by tag of the EXACT doujin→Bangumi anchor
-// minted by internal/jobs/doujinbangumi (BGM 竖封轨 Phase 1, refs/proj/56a):
-// title + a corroborating ±1 release year. This backfill pins the PORTRAIT
-// cover only for these high-confidence anchors — probable (rule:bgm-title-only)
-// anchors stay in the confirm bucket and are deliberately excluded (§范围). The
-// string is duplicated (not imported) to keep the job boundary clean; it is a
-// persisted contract value and must stay byte-identical to
-// doujinbangumi.ruleTitleYear.
-const ruleBgmTitleYear = "rule:bgm-title-year"
+// Matched_by tags of the EXACT work→Bangumi anchors this backfill trusts:
+//   - rule:bgm-title-year — minted by internal/jobs/doujinbangumi (BGM 竖封轨
+//     Phase 1, refs/proj/56a): title + a corroborating ±1 release year.
+//   - rule:bgm-type4-gated — the structural birth anchor minted by
+//     internal/platform/catalog/importer (bgmtype4gated): the work was born
+//     FROM that Bangumi subject, so the anchor is exact by construction. These
+//     works were born cover-less (metadata-only import) — 11.4k of them had no
+//     cover at all until refs/proj/56d widened this filter to include them.
+//
+// Probable (rule:bgm-title-only) anchors stay in the confirm bucket and are
+// deliberately excluded. The strings are duplicated (not imported) to keep the
+// job boundary clean; they are persisted contract values and must stay
+// byte-identical to doujinbangumi.ruleTitleYear / importer.ruleBgmType4Gated.
+const (
+	ruleBgmTitleYear  = "rule:bgm-title-year"
+	ruleBgmType4Gated = "rule:bgm-type4-gated"
+)
+
+var trustedRules = []string{ruleBgmTitleYear, ruleBgmType4Gated}
 
 type registry struct {
 	galgameMedium int16
@@ -49,10 +59,10 @@ func loadCandidates(ctx context.Context, db *gorm.DB, reg registry, limit, offse
 		Raw(`SELECT DISTINCT ON (w.id) w.id AS work_id, r.external_id AS subject_id, w.site AS site
 			FROM catalog_work w
 			JOIN catalog_external_ref r ON r.entity_type = ? AND r.entity_id = w.id
-				AND r.source_id = ? AND r.link_kind = ? AND r.matched_by = ?
+				AND r.source_id = ? AND r.link_kind = ? AND r.matched_by IN ?
 			WHERE w.medium_id = ? AND (w.site IS NULL OR w.site = '') AND w.deleted_at IS NULL
 			ORDER BY w.id, r.external_id`,
-			model.EntityTypeWork, reg.bangumiSource, model.LinkKindExact, ruleBgmTitleYear, reg.galgameMedium)
+			model.EntityTypeWork, reg.bangumiSource, model.LinkKindExact, trustedRules, reg.galgameMedium)
 	var out []candidate
 	if err := q.Scan(&out).Error; err != nil {
 		return nil, err

--- a/apps/api/internal/jobs/bangumicovers/write.go
+++ b/apps/api/internal/jobs/bangumicovers/write.go
@@ -50,7 +50,7 @@ func (r *runner) writeCover(ctx context.Context, mirrorRoot string, c candidate,
 		DoNothing: true,
 	}).Create(&model.CatalogWorkCover{
 		WorkID: c.WorkID, ImageHash: res.Hash, SortOrder: 0, Kind: "main",
-		PortraitPinned: !r.pinned[c.WorkID], Sexual: 0, Violence: 0, SourceID: r.sourceID,
+		PortraitPinned: e.portrait() && !r.pinned[c.WorkID], Sexual: 0, Violence: 0, SourceID: r.sourceID,
 	})
 	if tx.Error != nil {
 		r.c.errors++


### PR DESCRIPTION
## Why

The library page shows placeholder cards for ~11.6k unclaimed LIVE galgame works — they have no cover at all. Prod census: **11,446 of the 11,610 cover-less unclaimed galgame works carry an exact `rule:bgm-type4-gated` Bangumi anchor** (the structural birth anchor of the type-4 gated import, which imports metadata only). The `backfill-bangumi-covers` job hardcoded `matched_by = 'rule:bgm-title-year'` (the 56a doujin lane), so the whole bucket was filtered out.

## What

- Widen the trusted `matched_by` set to `{rule:bgm-title-year, rule:bgm-type4-gated}`, still exact-only; probable `rule:bgm-title-only` stays excluded (confirm bucket).
- New `--allow-landscape` flag: these works have no cover at all, so a landscape Bangumi cover beats a placeholder. Landscape rows are written with `portrait_pinned = false` — they can never take the portrait pin. Default off preserves the 56c portrait-only behavior.
- `portrait_pinned` is now computed from the image's actual orientation (`e.portrait() && !pinned`), not assumed.

## Tests

Full package suite against an ephemeral DB (12 tests, all green): candidate widening (type4 admitted, probable/claimed/other-medium/other-rule still excluded), new `TestAllowLandscape` (landscape written unpinned, portrait in the same run still pins), and the existing pin-stealing / idempotency / quota-abort coverage unchanged.

## Ops

No schema change, no migration. Rollout: fetch the ~12.8k subject mirror locally (kun-bangumi-api `fetch-covers`), rsync to prod, run `backfill-bangumi-covers --apply --allow-landscape` via infra-tools. New covers start `sexual=0`; the nightly `image-grade-nightly` cron re-grades per-image.