### PR TITLE
fix(deploy): pass the store shortlink env through to catalog

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -420,6 +420,15 @@ services:
       # connection, no second container). An unreachable kun_news degrades that
       # face to 503 and leaves catalog serving.
       KUN_NEWS_IMAGE_CLIENT_BASE_URL: http://image:9278
+      # w02 (store face) first deploy 2026-08-26: the two shortlink vars were
+      # set in the Dokploy panel and never reached the container — panel vars
+      # only exist inside a service whose compose interpolates them. The base
+      # URL is a deliberate literal: the shortener exposes its S2S face only as
+      # the `shortlink-api` alias on dokploy-network (its web proxy forwards
+      # /api and /s, not /s2s), so the public short-link origin is not a
+      # working value here.
+      KUN_STORE_SHORTLINK_BASE_URL: http://shortlink-api:7845
+      KUN_STORE_SHORTLINK_API_KEY: ${KUN_STORE_SHORTLINK_API_KEY:-}
     # S2S read/admin face stays internal — product backends (wiki/forum/moyu)
     # reach it at http://catalog:9281 over dokploy-network. The ONLY public path
     # is the open-API /v1/catalog projection routed by the labels block below.


### PR DESCRIPTION
Post-deploy verification of the news wave found /v1/store still degraded: the two `KUN_STORE_SHORTLINK_*` vars were set in the Dokploy panel but the catalog service block in `docker-compose.prod.yml` never interpolated them, so they never reached the container (`docker inspect` Config.Env: absent).

The base URL is committed as a literal `http://shortlink-api:7845`: the shortener's prod compose publishes its S2S face only as the `shortlink-api` alias on dokploy-network (verified reachable — an unauthenticated POST answers huma 422), and its public origin (`s.imoe.uk`) deliberately does not route `/s2s/**` (Nitro 404). The API key still comes from the panel.

No code, no migration — compose only. Takes effect on the next Dokploy redeploy.