### PR TITLE
feat(catalog): derive the age axis from source evidence at claim mint and in the weekly rating lane

### DIFF
--- a/apps/api/internal/jobs/releasemeta/backfill_test.go
+++ b/apps/api/internal/jobs/releasemeta/backfill_test.go
@@ -2,6 +2,7 @@ package releasemeta
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -11,19 +12,21 @@ import (
 	"api/internal/platform/catalog/model"
 	"api/internal/platform/catalog/seed"
 	srcb "api/internal/platform/catalog/srcbangumi"
+	srcv "api/internal/platform/catalog/srcvndb"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
 var (
-	testDB      *gorm.DB
-	testDSN     string
-	dlTestDSN   string
-	egTestDSN   string
+	testDB    *gorm.DB
+	testDSN   string
+	dlTestDSN string
+	egTestDSN string
 )
 
 func TestMain(m *testing.M) {
@@ -48,11 +51,16 @@ func TestMain(m *testing.M) {
 		fmt.Fprintf(os.Stderr, "SKIP: src_bangumi schema failed: %v\n", err)
 		os.Exit(0)
 	}
+	if err := srcv.EnsureSchema(db); err != nil {
+		fmt.Fprintf(os.Stderr, "SKIP: src_vndb schema failed: %v\n", err)
+		os.Exit(0)
+	}
 	for _, ddl := range []string{
 		`CREATE SCHEMA IF NOT EXISTS releasemeta_dl`,
 		`CREATE TABLE IF NOT EXISTS releasemeta_dl.works (workno text PRIMARY KEY, regist_date timestamptz, age_category text)`,
 		`CREATE SCHEMA IF NOT EXISTS releasemeta_eg`,
 		`CREATE TABLE IF NOT EXISTS releasemeta_eg.games (id int PRIMARY KEY, sellday text)`,
+		`ALTER TABLE releasemeta_eg.games ADD COLUMN IF NOT EXISTS erogame boolean`,
 	} {
 		if err := db.Exec(ddl).Error; err != nil {
 			fmt.Fprintf(os.Stderr, "SKIP: fixture schema failed: %v\n", err)
@@ -69,6 +77,7 @@ func clean(t *testing.T) {
 	t.Helper()
 	for _, table := range []string{
 		"catalog_external_ref", "catalog_release", "catalog_work", "src_bangumi.subject",
+		"src_vndb.releases", "src_vndb.releases_vn",
 		"releasemeta_dl.works", "releasemeta_eg.games",
 	} {
 		require.NoError(t, testDB.Exec("TRUNCATE "+table+" RESTART IDENTITY CASCADE").Error)
@@ -125,6 +134,25 @@ func mkSubject(t *testing.T, id int64, date string, nsfw bool) {
 	}).Error)
 }
 
+func mkSubjectMeta(t *testing.T, id int64, nsfw bool, meta ...string) {
+	t.Helper()
+	tags, err := json.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, testDB.Create(&srcb.Subject{
+		ID: id, Type: 4, Name: fmt.Sprintf("subject-%d", id),
+		NSFW: nsfw, MetaTags: datatypes.JSON(tags),
+		ParserVersion: srcb.ParserVersion, IngestedAt: time.Now(),
+	}).Error)
+}
+
+func mkVndbRelease(t *testing.T, vid, rid string, minage *int16, hasEro, patch bool) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&srcv.Release{
+		ID: rid, OLang: "ja", MinAge: minage, HasEro: hasEro, Patch: patch,
+	}).Error)
+	require.NoError(t, testDB.Create(&srcv.ReleaseVN{ID: rid, VID: vid, RType: "complete"}).Error)
+}
+
 func mkDlWork(t *testing.T, workno, regist, age string) {
 	t.Helper()
 	require.NoError(t, testDB.Exec(
@@ -135,6 +163,12 @@ func mkDlWork(t *testing.T, workno, regist, age string) {
 func mkEgGame(t *testing.T, id int64, sellday string) {
 	t.Helper()
 	require.NoError(t, testDB.Exec(`INSERT INTO releasemeta_eg.games (id, sellday) VALUES (?, ?)`, id, sellday).Error)
+}
+
+func mkEgErogame(t *testing.T, id int64, erogame bool) {
+	t.Helper()
+	require.NoError(t, testDB.Exec(
+		`INSERT INTO releasemeta_eg.games (id, sellday, erogame) VALUES (?, '', ?)`, id, erogame).Error)
 }
 
 func relDate(t *testing.T, id int64) (y, m, d *int16) {
@@ -301,7 +335,6 @@ func TestBackfillReleaseMeta(t *testing.T) {
 	mkReleaseAnchor(t, relRDlAll, "RJ000103", reg.dlsiteSource)
 	mkDlWork(t, "RJ000103", "", "1")
 
-
 	rBgm := mkWork(t, medium, "rating-bgm-nsfw", nil, nil, 0)
 	mkWorkAnchor(t, rBgm, "708", reg.bangumiSource, model.LinkKindExact)
 	mkSubject(t, 708, "", true)
@@ -314,6 +347,44 @@ func TestBackfillReleaseMeta(t *testing.T) {
 	relRRated := mkRelease(t, rRated, 2000, 1, 1)
 	mkReleaseAnchor(t, relRRated, "RJ000104", reg.dlsiteSource)
 	mkDlWork(t, "RJ000104", "", "2")
+
+	age18 := int16(18)
+	age0 := int16(0)
+
+	rVndb18 := mkWork(t, medium, "rating-vndb-minage", nil, nil, 0)
+	mkWorkAnchor(t, rVndb18, "v901", reg.vndbSource, model.LinkKindExact)
+	mkVndbRelease(t, "v901", "r901", &age18, false, false)
+
+	rVndbEro := mkWork(t, medium, "rating-vndb-ero", nil, nil, 0)
+	mkWorkAnchor(t, rVndbEro, "v902", reg.vndbSource, model.LinkKindExact)
+	mkVndbRelease(t, "v902", "r902", nil, true, false)
+
+	rVndbPatch := mkWork(t, medium, "rating-vndb-patch-only", nil, nil, 0)
+	mkWorkAnchor(t, rVndbPatch, "v903", reg.vndbSource, model.LinkKindExact)
+	mkVndbRelease(t, "v903", "r903", &age18, true, true)
+
+	rVndbSafe := mkWork(t, medium, "rating-vndb-all-ages", nil, nil, 0)
+	mkWorkAnchor(t, rVndbSafe, "v904", reg.vndbSource, model.LinkKindExact)
+	mkVndbRelease(t, "v904", "r904", &age0, false, false)
+
+	rVndbBeatsDl := mkWork(t, medium, "rating-vndb-beats-dl-allages", nil, nil, 0)
+	relVndbBeatsDl := mkRelease(t, rVndbBeatsDl, 2000, 1, 1)
+	mkReleaseAnchor(t, relVndbBeatsDl, "RJ000105", reg.dlsiteSource)
+	mkDlWork(t, "RJ000105", "", "1")
+	mkWorkAnchor(t, rVndbBeatsDl, "v905", reg.vndbSource, model.LinkKindExact)
+	mkVndbRelease(t, "v905", "r905", &age18, true, false)
+
+	rEgTrue := mkWork(t, medium, "rating-eg-erogame", nil, nil, 0)
+	mkWorkAnchor(t, rEgTrue, "611", reg.egSource, model.LinkKindExact)
+	mkEgErogame(t, 611, true)
+
+	rEgFalse := mkWork(t, medium, "rating-eg-not-erogame", nil, nil, 0)
+	mkWorkAnchor(t, rEgFalse, "612", reg.egSource, model.LinkKindExact)
+	mkEgErogame(t, 612, false)
+
+	rBgmMeta := mkWork(t, medium, "rating-bgm-meta-tag", nil, nil, 0)
+	mkWorkAnchor(t, rBgmMeta, "710", reg.bangumiSource, model.LinkKindExact)
+	mkSubjectMeta(t, 710, false, "游戏", "R18")
 
 	st, err := Run(ctx, runOpts(false))
 	require.NoError(t, err)
@@ -334,13 +405,15 @@ func TestBackfillReleaseMeta(t *testing.T) {
 	assert.Equal(t, 1, st.BgmDateBadDate)
 	assert.Equal(t, 1, st.BgmDatePartial)
 	assert.Equal(t, 2, st.BgmDatePlanned, "wBgmClaimed + wBgmPartial")
-	assert.Equal(t, 24, st.RatingCandidates, "every rating-0 work; rRated excluded")
+	assert.Equal(t, 32, st.RatingCandidates, "every rating-0 work; rRated excluded")
+	assert.Equal(t, 3, st.RatingVndbR18, "minage + has_ero + the dl-allages preemption")
 	assert.Equal(t, 1, st.RatingDlR18)
 	assert.Equal(t, 1, st.RatingDlSensitive)
 	assert.Equal(t, 1, st.RatingDlAllAges, "explicit all-ages verdict keeps the row at 0")
-	assert.Equal(t, 1, st.RatingBgmR18)
-	assert.Equal(t, 20, st.RatingNoVerdict)
-	assert.Equal(t, 3, st.RatingPlanned, "rDlAdult + rDlR15 + rBgm")
+	assert.Equal(t, 1, st.RatingEgR18)
+	assert.Equal(t, 2, st.RatingBgmR18, "nsfw flag + R18 meta_tag")
+	assert.Equal(t, 23, st.RatingNoVerdict)
+	assert.Equal(t, 8, st.RatingPlanned)
 	assert.Zero(t, st.DlDateFilled+st.EgDateFilled+st.BgmDateFilled+st.RatingFilled+
 		st.DlDateSkippedNonEmpty+st.EgDateSkippedNonEmpty+st.BgmDateSkippedNonEmpty+
 		st.RatingSkippedNonEmpty+st.Errors)
@@ -353,7 +426,7 @@ func TestBackfillReleaseMeta(t *testing.T) {
 	assert.Equal(t, 2, st.DlDateFilled)
 	assert.Equal(t, 4, st.EgDateFilled)
 	assert.Equal(t, 2, st.BgmDateFilled)
-	assert.Equal(t, 3, st.RatingFilled)
+	assert.Equal(t, 8, st.RatingFilled)
 	assert.Zero(t, st.DlDateSkippedNonEmpty+st.EgDateSkippedNonEmpty+st.BgmDateSkippedNonEmpty+
 		st.RatingSkippedNonEmpty+st.Errors)
 
@@ -377,13 +450,22 @@ func TestBackfillReleaseMeta(t *testing.T) {
 	assert.Equal(t, model.ContentRatingR18, workRating(t, rBgm))
 	assert.Equal(t, int16(0), workRating(t, rBgmFalse), "nsfw=false never infers a rating")
 	assert.Equal(t, model.ContentRatingR18, workRating(t, rRated), "non-zero rating untouched")
+	assert.Equal(t, model.ContentRatingR18, workRating(t, rVndb18))
+	assert.Equal(t, model.ContentRatingR18, workRating(t, rVndbEro))
+	assert.Equal(t, int16(0), workRating(t, rVndbPatch), "an 18+ patch is not the work's rating")
+	assert.Equal(t, int16(0), workRating(t, rVndbSafe))
+	assert.Equal(t, model.ContentRatingR18, workRating(t, rVndbBeatsDl),
+		"work-level vndb verdict outranks the 全年齢版 SKU's dlsite age")
+	assert.Equal(t, model.ContentRatingR18, workRating(t, rEgTrue))
+	assert.Equal(t, int16(0), workRating(t, rEgFalse), "erogame=false never infers a rating")
+	assert.Equal(t, model.ContentRatingR18, workRating(t, rBgmMeta))
 
 	st, err = Run(ctx, runOpts(true))
 	require.NoError(t, err)
 	assert.Equal(t, 3, st.DlDateCandidates, "only the unfillable three remain")
 	assert.Equal(t, 2, st.EgDateCandidates, "bad-date + missing-mirror remain")
 	assert.Equal(t, 2, st.BgmDateCandidates, "no-date + garbage remain")
-	assert.Equal(t, 21, st.RatingCandidates, "the three filled works left the set")
+	assert.Equal(t, 24, st.RatingCandidates, "the eight filled works left the set")
 	assert.Zero(t, st.DlDatePlanned+st.EgDatePlanned+st.BgmDatePlanned+st.RatingPlanned,
 		"second pass plans zero")
 	assert.Zero(t, st.DlDateFilled+st.EgDateFilled+st.BgmDateFilled+st.RatingFilled+st.Errors,

--- a/apps/api/internal/jobs/releasemeta/rating.go
+++ b/apps/api/internal/jobs/releasemeta/rating.go
@@ -3,6 +3,7 @@ package releasemeta
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"api/internal/platform/catalog/editspec"
 	"api/internal/platform/catalog/model"
@@ -11,7 +12,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func runRatingLane(ctx context.Context, db, dlDB *gorm.DB, w *writer, reg registry, opts Opts) error {
+func runRatingLane(ctx context.Context, db, dlDB, egDB *gorm.DB, w *writer, reg registry, opts Opts) error {
 	cands, err := loadRatingCandidates(ctx, db, opts.Limit, opts.Offset)
 	if err != nil {
 		return fmt.Errorf("load rating candidates: %w", err)
@@ -26,15 +27,27 @@ func runRatingLane(ctx context.Context, db, dlDB *gorm.DB, w *writer, reg regist
 	if err != nil {
 		return fmt.Errorf("load rating dlsite anchors: %w", err)
 	}
-	bgmNSFW, err := loadRatingBgmNSFW(ctx, db, reg)
+	vndbR18, err := loadRatingVndbR18(ctx, db, reg)
 	if err != nil {
-		return fmt.Errorf("load rating bgm nsfw: %w", err)
+		return fmt.Errorf("load rating vndb r18: %w", err)
+	}
+	egAnchors, err := loadRatingEgAnchors(ctx, db, reg)
+	if err != nil {
+		return fmt.Errorf("load rating eg anchors: %w", err)
+	}
+	bgmR18, err := loadRatingBgmR18(ctx, db, reg)
+	if err != nil {
+		return fmt.Errorf("load rating bgm r18: %w", err)
 	}
 
 	worknoSet := map[string]bool{}
+	egIDSet := map[int64]bool{}
 	for _, c := range cands {
 		if wn, ok := dlAnchors[c.WorkID]; ok {
 			worknoSet[wn] = true
+		}
+		for _, id := range egAnchors[c.WorkID] {
+			egIDSet[id] = true
 		}
 	}
 	worknos := make([]string, 0, len(worknoSet))
@@ -44,6 +57,14 @@ func runRatingLane(ctx context.Context, db, dlDB *gorm.DB, w *writer, reg regist
 	dlAges, err := loadDlsiteAges(ctx, dlDB, worknos)
 	if err != nil {
 		return fmt.Errorf("load dlsite mirror ages: %w", err)
+	}
+	egIDs := make([]int64, 0, len(egIDSet))
+	for id := range egIDSet {
+		egIDs = append(egIDs, id)
+	}
+	egErogame, err := loadEgErogame(ctx, egDB, egIDs)
+	if err != nil {
+		return fmt.Errorf("load eg mirror erogame: %w", err)
 	}
 
 	ratingWorkIDs := make([]int64, 0, len(cands))
@@ -63,7 +84,7 @@ func runRatingLane(ctx context.Context, db, dlDB *gorm.DB, w *writer, reg regist
 			st.RatingCuratedOverride++
 			continue
 		}
-		rating, source, ext, ok := decideRating(c, dlAnchors, dlAges, bgmNSFW, st)
+		rating, source, ext, ok := decideRating(c, dlAnchors, dlAges, vndbR18, egAnchors, egErogame, bgmR18, st)
 		if !ok {
 			st.RatingNoVerdict++
 			continue
@@ -78,8 +99,18 @@ func runRatingLane(ctx context.Context, db, dlDB *gorm.DB, w *writer, reg regist
 	return nil
 }
 
+// VNDB outranks the DLsite storefront age: the dlsite anchor is release-level,
+// so a 全年齢版 SKU's age "1" describes that edition, while the vndb verdict is
+// the work-level "an 18+ release exists". With dlsite first, such a work took
+// an all-ages verdict (written as nothing) and stayed 0 forever.
 func decideRating(c ratingCandidate, dlAnchors map[int64]string, dlAges map[string]string,
-	bgmNSFW map[int64]bool, st *Stats) (int16, string, string, bool) {
+	vndbR18 map[int64]bool, egAnchors map[int64][]int64, egErogame map[int64]bool,
+	bgmR18 map[int64]bool, st *Stats) (int16, string, string, bool) {
+
+	if vndbR18[c.WorkID] {
+		st.RatingVndbR18++
+		return model.ContentRatingR18, "vndb", "", true
+	}
 
 	if wn, ok := dlAnchors[c.WorkID]; ok {
 		switch dlAges[wn] {
@@ -95,15 +126,20 @@ func decideRating(c ratingCandidate, dlAnchors map[int64]string, dlAges map[stri
 		}
 	}
 
-	// ② was the wiki's editorial age_limit, read from galgame.age_limit for
-	// claimed works. Wave 149 dropped that table, so the lane is gone rather
-	// than merely unfilled. It had in fact stopped producing verdicts earlier:
-	// its claim test pinned site == "galgame_wiki", the literal wave 161
-	// renamed, so it silently matched nothing from then on. Removing it is
-	// behaviour-neutral; the numbering below keeps ③ so the priority ladder
-	// still reads against the spec.
+	// The wiki's editorial age_limit lane used to sit here, read from
+	// galgame.age_limit for claimed works. Wave 149 dropped that table, so the
+	// lane is gone rather than merely unfilled. It had in fact stopped
+	// producing verdicts earlier: its claim test pinned site == "galgame_wiki",
+	// the literal wave 161 renamed, so it silently matched nothing from then on.
 
-	if bgmNSFW[c.WorkID] {
+	for _, id := range egAnchors[c.WorkID] {
+		if egErogame[id] {
+			st.RatingEgR18++
+			return model.ContentRatingR18, "erogamescape", strconv.FormatInt(id, 10), true
+		}
+	}
+
+	if bgmR18[c.WorkID] {
 		st.RatingBgmR18++
 		return model.ContentRatingR18, "bangumi", "", true
 	}

--- a/apps/api/internal/jobs/releasemeta/releasemeta.go
+++ b/apps/api/internal/jobs/releasemeta/releasemeta.go
@@ -67,9 +67,11 @@ type Stats struct {
 	BgmDateSkippedNonEmpty int
 
 	RatingCandidates      int
+	RatingVndbR18         int
 	RatingDlR18           int
 	RatingDlSensitive     int
 	RatingDlAllAges       int
+	RatingEgR18           int
 	RatingBgmR18          int
 	RatingNoVerdict       int
 	RatingPlanned         int
@@ -129,7 +131,7 @@ func Run(ctx context.Context, opts Opts) (*Stats, error) {
 	if err := runBgmDateLane(ctx, db, w, reg, opts, maxYear, planned); err != nil {
 		return nil, err
 	}
-	if err := runRatingLane(ctx, db, dlDB, w, reg, opts); err != nil {
+	if err := runRatingLane(ctx, db, dlDB, egDB, w, reg, opts); err != nil {
 		return nil, err
 	}
 	if err := w.touch(ctx); err != nil {
@@ -150,8 +152,10 @@ func Run(ctx context.Context, opts Opts) (*Stats, error) {
 		"bgm_date_partial", st.BgmDatePartial, "bgm_date_planned", st.BgmDatePlanned,
 		"bgm_date_filled", st.BgmDateFilled, "bgm_date_skipped_non_empty", st.BgmDateSkippedNonEmpty,
 		"rating_candidates", st.RatingCandidates,
+		"rating_vndb_r18", st.RatingVndbR18,
 		"rating_dl_r18", st.RatingDlR18, "rating_dl_sensitive", st.RatingDlSensitive,
 		"rating_dl_all_ages", st.RatingDlAllAges,
+		"rating_eg_r18", st.RatingEgR18,
 		"rating_bgm_r18", st.RatingBgmR18,
 		"rating_no_verdict", st.RatingNoVerdict, "rating_planned", st.RatingPlanned,
 		"rating_filled", st.RatingFilled, "rating_skipped_non_empty", st.RatingSkippedNonEmpty,

--- a/apps/api/internal/jobs/releasemeta/source.go
+++ b/apps/api/internal/jobs/releasemeta/source.go
@@ -15,6 +15,7 @@ type registry struct {
 	bangumiSource int16
 	dlsiteSource  int16
 	egSource      int16
+	vndbSource    int16
 }
 
 func resolveRegistry(ctx context.Context, db *gorm.DB) (registry, error) {
@@ -26,14 +27,15 @@ func resolveRegistry(ctx context.Context, db *gorm.DB) (registry, error) {
 		{"bangumi", &r.bangumiSource},
 		{"dlsite", &r.dlsiteSource},
 		{"erogamescape", &r.egSource},
+		{"vndb", &r.vndbSource},
 	} {
 		if err := db.WithContext(ctx).Raw(`SELECT id FROM catalog_source WHERE key = ?`, s.key).Scan(s.dst).Error; err != nil {
 			return r, fmt.Errorf("resolve %s source: %w", s.key, err)
 		}
 	}
-	if r.bangumiSource == 0 || r.dlsiteSource == 0 || r.egSource == 0 {
-		return r, fmt.Errorf("registry not seeded (bangumi=%d, dlsite=%d, erogamescape=%d)",
-			r.bangumiSource, r.dlsiteSource, r.egSource)
+	if r.bangumiSource == 0 || r.dlsiteSource == 0 || r.egSource == 0 || r.vndbSource == 0 {
+		return r, fmt.Errorf("registry not seeded (bangumi=%d, dlsite=%d, erogamescape=%d, vndb=%d)",
+			r.bangumiSource, r.dlsiteSource, r.egSource, r.vndbSource)
 	}
 	return r, nil
 }
@@ -182,26 +184,111 @@ func loadRatingDlsiteAnchors(ctx context.Context, db *gorm.DB, reg registry) (ma
 	return out, nil
 }
 
-func loadRatingBgmNSFW(ctx context.Context, db *gorm.DB, reg registry) (map[int64]bool, error) {
+// The nsfw flag alone is close to blind on the doujin tail: of 492 unclaimed
+// works whose only covers were explicit, ZERO carried nsfw=true while 117
+// carried the wiki-curated "R18" meta_tag (2026-08 census). Both signals are
+// positive-only; neither absent asserts all-ages.
+func loadRatingBgmR18(ctx context.Context, db *gorm.DB, reg registry) (map[int64]bool, error) {
 	var rows []struct {
 		WorkID int64 `gorm:"column:work_id"`
-		NSFW   bool  `gorm:"column:nsfw"`
+		R18    bool  `gorm:"column:r18"`
 	}
 	if err := db.WithContext(ctx).
-		Raw(`SELECT DISTINCT ON (w.id) w.id AS work_id, sub.nsfw AS nsfw
+		Raw(`SELECT w.id AS work_id,
+				bool_or(sub.nsfw OR sub.meta_tags @> '["R18"]'::jsonb) AS r18
 			FROM catalog_work w
 			JOIN catalog_external_ref r ON r.entity_type = ? AND r.entity_id = w.id
 				AND r.source_id = ? AND r.link_kind = ?
 			JOIN src_bangumi.subject sub ON sub.id = r.external_id::bigint
 			WHERE w.deleted_at IS NULL AND w.content_rating = 0
-			ORDER BY w.id, sub.id`,
+			GROUP BY w.id`,
 			model.EntityTypeWork, reg.bangumiSource, model.LinkKindExact).
 		Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	out := make(map[int64]bool, len(rows))
 	for _, r := range rows {
-		out[r.WorkID] = r.NSFW
+		out[r.WorkID] = r.R18
+	}
+	return out, nil
+}
+
+// Same shape as buildVNDBWorkPoolQuery's r18 column: releases carry the age,
+// the vn row does not, and patch releases are excluded because an 18+ patch
+// for an all-ages VN is exactly the case where the release's rating is not
+// the work's.
+func loadRatingVndbR18(ctx context.Context, db *gorm.DB, reg registry) (map[int64]bool, error) {
+	var rows []struct {
+		WorkID int64 `gorm:"column:work_id"`
+		R18    bool  `gorm:"column:r18"`
+	}
+	if err := db.WithContext(ctx).
+		Raw(`SELECT w.id AS work_id, bool_or(EXISTS (
+				SELECT 1 FROM src_vndb.releases_vn rv
+				JOIN src_vndb.releases rel ON rel.id = rv.id
+				WHERE rv.vid = r.external_id AND rel.patch = false
+					AND (rel.minage >= 18 OR rel.has_ero))) AS r18
+			FROM catalog_work w
+			JOIN catalog_external_ref r ON r.entity_type = ? AND r.entity_id = w.id
+				AND r.source_id = ? AND r.link_kind = ?
+			WHERE w.deleted_at IS NULL AND w.content_rating = 0
+			GROUP BY w.id`,
+			model.EntityTypeWork, reg.vndbSource, model.LinkKindExact).
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[int64]bool, len(rows))
+	for _, r := range rows {
+		out[r.WorkID] = r.R18
+	}
+	return out, nil
+}
+
+func loadRatingEgAnchors(ctx context.Context, db *gorm.DB, reg registry) (map[int64][]int64, error) {
+	var rows []struct {
+		WorkID     int64  `gorm:"column:work_id"`
+		ExternalID string `gorm:"column:external_id"`
+	}
+	if err := db.WithContext(ctx).
+		Raw(`SELECT w.id AS work_id, r.external_id AS external_id
+			FROM catalog_work w
+			JOIN catalog_external_ref r ON r.entity_type = ? AND r.entity_id = w.id
+				AND r.source_id = ? AND r.link_kind = ?
+			WHERE w.deleted_at IS NULL AND w.content_rating = 0
+			ORDER BY w.id, r.external_id`,
+			model.EntityTypeWork, reg.egSource, model.LinkKindExact).
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[int64][]int64, len(rows))
+	for _, r := range rows {
+		id, err := strconv.ParseInt(r.ExternalID, 10, 64)
+		if err != nil {
+			continue
+		}
+		out[r.WorkID] = append(out[r.WorkID], id)
+	}
+	return out, nil
+}
+
+// erogame=false is not an all-ages assertion: EG rosters 全年齢版 re-releases
+// and plain non-ero games as false, so only true carries a verdict.
+func loadEgErogame(ctx context.Context, egDB *gorm.DB, ids []int64) (map[int64]bool, error) {
+	out := make(map[int64]bool, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	var rows []struct {
+		ID      int64 `gorm:"column:id"`
+		Erogame bool  `gorm:"column:erogame"`
+	}
+	if err := egDB.WithContext(ctx).
+		Raw(`SELECT id, erogame FROM games WHERE id IN ? AND erogame IS NOT NULL`, ids).
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.ID] = r.Erogame
 	}
 	return out, nil
 }

--- a/apps/api/internal/platform/apiv2/handler/me_claims.go
+++ b/apps/api/internal/platform/apiv2/handler/me_claims.go
@@ -200,6 +200,10 @@ func (c *Catalog) CreateClaim(ctx context.Context, workID, siteWorkID, displayNa
 			editspec.FieldWorkDisplayName: displayName,
 			editspec.FieldWorkLinks:       links,
 		}
+		crefs := make([]catsvc.ClaimRef, 0, len(refs))
+		for _, r := range refs {
+			crefs = append(crefs, catsvc.ClaimRef{Source: r.Source, ExternalID: r.ExternalID})
+		}
 		product := int64(0)
 		if siteWorkID != "" {
 			if n, ok := repr.ParseID(siteWorkID); ok {
@@ -207,7 +211,8 @@ func (c *Catalog) CreateClaim(ctx context.Context, workID, siteWorkID, displayNa
 			}
 		}
 		res, serr := c.Claims.SubmitWork(ctx, catsvc.SubmitWorkParams{
-			Site: site, ProductWorkID: product, ActorUID: uid, Fields: fields,
+			Site: site, ProductWorkID: product, ActorUID: uid,
+			ContentRating: c.Claims.DeriveContentRating(ctx, crefs), Fields: fields,
 		})
 		if serr != nil {
 			return repr.ClaimRecord{}, claimWriteErr(serr)

--- a/apps/api/internal/platform/catalog/service/claim_rating.go
+++ b/apps/api/internal/platform/catalog/service/claim_rating.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"api/internal/platform/catalog/model"
+
+	"gorm.io/gorm"
+)
+
+type ClaimRef struct {
+	Source     string
+	ExternalID string
+}
+
+// DeriveContentRating asks the src_* staging schemas whether the refs a claim
+// was minted with describe an adult work. Best-effort by design: a claim must
+// mint even where the staging schemas are absent (dev/test databases), so a
+// query error logs and yields no verdict rather than failing the claim.
+// The claim wave that predated this left 16 adult works listed as all_ages —
+// stubs mint with content_rating 0 and nothing downstream could rate them,
+// because a v2 claim turns refs into links, not anchors, and the weekly
+// releasemeta rating lane only reads anchors.
+func (s *ClaimLifecycleService) DeriveContentRating(ctx context.Context, refs []ClaimRef) int16 {
+	for _, ref := range refs {
+		if sourceRefR18(ctx, s.db, ref.Source, ref.ExternalID) {
+			return model.ContentRatingR18
+		}
+	}
+	return model.ContentRatingAllAges
+}
+
+func (s *WorkService) deriveAnchorRating(ctx context.Context, anchors []ExternalAnchor) int16 {
+	var rows []struct {
+		ID  int16  `gorm:"column:id"`
+		Key string `gorm:"column:key"`
+	}
+	if err := s.db.WithContext(ctx).
+		Raw(`SELECT id, key FROM catalog_source WHERE key IN ('vndb', 'bangumi')`).
+		Scan(&rows).Error; err != nil {
+		slog.Warn("derive claim content_rating: resolve sources", "err", err)
+		return model.ContentRatingAllAges
+	}
+	keyByID := make(map[int16]string, len(rows))
+	for _, r := range rows {
+		keyByID[r.ID] = r.Key
+	}
+	for _, a := range anchors {
+		if sourceRefR18(ctx, s.db, keyByID[a.SourceID], a.ExternalID) {
+			return model.ContentRatingR18
+		}
+	}
+	return model.ContentRatingAllAges
+}
+
+func sourceRefR18(ctx context.Context, db *gorm.DB, source, externalID string) bool {
+	id := strings.TrimSpace(externalID)
+	if id == "" {
+		return false
+	}
+	var r18 bool
+	var err error
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "vndb":
+		if strings.HasPrefix(id, "r") {
+			err = db.WithContext(ctx).Raw(`SELECT EXISTS (
+					SELECT 1 FROM src_vndb.releases rel
+					WHERE rel.id = ? AND rel.patch = false
+						AND (rel.minage >= 18 OR rel.has_ero))`, id).Scan(&r18).Error
+			break
+		}
+		err = db.WithContext(ctx).Raw(`SELECT EXISTS (
+				SELECT 1 FROM src_vndb.releases_vn rv
+				JOIN src_vndb.releases rel ON rel.id = rv.id
+				WHERE rv.vid = ? AND rel.patch = false
+					AND (rel.minage >= 18 OR rel.has_ero))`, id).Scan(&r18).Error
+	case "bangumi":
+		err = db.WithContext(ctx).Raw(`SELECT COALESCE(bool_or(
+				sub.nsfw OR sub.meta_tags @> '["R18"]'::jsonb), false)
+				FROM src_bangumi.subject sub WHERE sub.id::text = ?`, id).Scan(&r18).Error
+	default:
+		return false
+	}
+	if err != nil {
+		slog.Warn("derive claim content_rating", "source", source, "err", err)
+		return false
+	}
+	return r18
+}

--- a/apps/api/internal/platform/catalog/service/claim_rating_test.go
+++ b/apps/api/internal/platform/catalog/service/claim_rating_test.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"api/internal/platform/catalog/editspec"
+	"api/internal/platform/catalog/model"
+	srcb "api/internal/platform/catalog/srcbangumi"
+	srcv "api/internal/platform/catalog/srcvndb"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+func seedRatingSources(t *testing.T) {
+	t.Helper()
+	require.NoError(t, testDB.Exec(
+		`TRUNCATE src_vndb.releases, src_vndb.releases_vn, src_bangumi.subject RESTART IDENTITY CASCADE`).Error)
+	age18, age0 := int16(18), int16(0)
+	for _, r := range []srcv.Release{
+		{ID: "r1", OLang: "ja", MinAge: &age18},
+		{ID: "r2", OLang: "ja", MinAge: &age18, Patch: true},
+		{ID: "r3", OLang: "ja", MinAge: &age0},
+	} {
+		require.NoError(t, testDB.Create(&r).Error)
+	}
+	for _, rv := range []srcv.ReleaseVN{
+		{ID: "r1", VID: "v1", RType: "complete"},
+		{ID: "r2", VID: "v2", RType: "complete"},
+		{ID: "r3", VID: "v3", RType: "complete"},
+	} {
+		require.NoError(t, testDB.Create(&rv).Error)
+	}
+	for _, sub := range []srcb.Subject{
+		{ID: 801, Type: 4, Name: "sub-801", NSFW: true,
+			ParserVersion: srcb.ParserVersion, IngestedAt: time.Now()},
+		{ID: 802, Type: 4, Name: "sub-802", MetaTags: datatypes.JSON([]byte(`["游戏", "R18"]`)),
+			ParserVersion: srcb.ParserVersion, IngestedAt: time.Now()},
+		{ID: 803, Type: 4, Name: "sub-803", MetaTags: datatypes.JSON([]byte(`["游戏", "全年龄"]`)),
+			ParserVersion: srcb.ParserVersion, IngestedAt: time.Now()},
+	} {
+		require.NoError(t, testDB.Create(&sub).Error)
+	}
+}
+
+func TestDeriveContentRatingFromRefs(t *testing.T) {
+	cleanTables(t)
+	seedRatingSources(t)
+	s := NewClaimLifecycleService(testDB)
+	ctx := t.Context()
+
+	cases := []struct {
+		name string
+		refs []ClaimRef
+		want int16
+	}{
+		{"vndb minage 18", []ClaimRef{{Source: "vndb", ExternalID: "v1"}}, model.ContentRatingR18},
+		{"vndb 18+ patch only", []ClaimRef{{Source: "vndb", ExternalID: "v2"}}, 0},
+		{"vndb all ages", []ClaimRef{{Source: "vndb", ExternalID: "v3"}}, 0},
+		{"vndb release-level ref", []ClaimRef{{Source: "vndb", ExternalID: "r1"}}, model.ContentRatingR18},
+		{"bangumi nsfw flag", []ClaimRef{{Source: "bangumi", ExternalID: "801"}}, model.ContentRatingR18},
+		{"bangumi R18 meta_tag", []ClaimRef{{Source: "bangumi", ExternalID: "802"}}, model.ContentRatingR18},
+		{"bangumi plain", []ClaimRef{{Source: "bangumi", ExternalID: "803"}}, 0},
+		{"unknown source", []ClaimRef{{Source: "dlsite", ExternalID: "RJ01"}}, 0},
+		{"second ref decides", []ClaimRef{{Source: "vndb", ExternalID: "v3"}, {Source: "bangumi", ExternalID: "801"}}, model.ContentRatingR18},
+		{"no refs", nil, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, s.DeriveContentRating(ctx, c.refs))
+		})
+	}
+}
+
+func TestSubmitWorkCarriesDerivedRating(t *testing.T) {
+	s := newLifecycle(t)
+	res, err := s.SubmitWork(t.Context(), SubmitWorkParams{
+		Site: submitSite, ProductWorkID: 90055, ActorUID: 7,
+		ContentRating: model.ContentRatingR18,
+		Fields:        map[string]any{editspec.FieldWorkDisplayName: "派生分级"},
+	})
+	require.NoError(t, err)
+	var w model.CatalogWork
+	require.NoError(t, testDB.First(&w, res.WorkID).Error)
+	assert.Equal(t, model.ContentRatingR18, w.ContentRating)
+}
+
+func TestClaimWorkDerivesRatingFromAnchors(t *testing.T) {
+	cleanTables(t)
+	seedRatingSources(t)
+	ctx := t.Context()
+	var vndbID int16
+	require.NoError(t, testDB.Raw(`SELECT id FROM catalog_source WHERE key = 'vndb'`).Scan(&vndbID).Error)
+
+	id, created, err := testWork.ClaimWork(ctx, ClaimWorkParams{
+		MediumID: 1, Site: "kungal", ProductWorkID: 4242, DisplayName: "derived",
+		Anchors: []ExternalAnchor{{SourceID: vndbID, ExternalID: "v1", MatchedBy: "rule:test", EntityType: model.EntityTypeWork}},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+	var w model.CatalogWork
+	require.NoError(t, testDB.First(&w, id).Error)
+	assert.Equal(t, model.ContentRatingR18, w.ContentRating)
+
+	id2, created2, err := testWork.ClaimWork(ctx, ClaimWorkParams{
+		MediumID: 1, Site: "kungal", ProductWorkID: 4243, DisplayName: "caller wins",
+		ContentRating: model.ContentRatingSensitive,
+		Anchors:       []ExternalAnchor{{SourceID: vndbID, ExternalID: "v2", MatchedBy: "rule:test", EntityType: model.EntityTypeWork}},
+	})
+	require.NoError(t, err)
+	require.True(t, created2)
+	var w2 model.CatalogWork
+	require.NoError(t, testDB.First(&w2, id2).Error)
+	assert.Equal(t, model.ContentRatingSensitive, w2.ContentRating,
+		"an explicit caller rating is never re-derived")
+}

--- a/apps/api/internal/platform/catalog/service/service_test.go
+++ b/apps/api/internal/platform/catalog/service/service_test.go
@@ -11,6 +11,7 @@ import (
 	"api/internal/platform/catalog/repository"
 	"api/internal/platform/catalog/seed"
 	srcb "api/internal/platform/catalog/srcbangumi"
+	srcv "api/internal/platform/catalog/srcvndb"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -49,6 +50,10 @@ func TestMain(m *testing.M) {
 	}
 	if err := srcb.EnsureSchema(db); err != nil {
 		fmt.Fprintf(os.Stderr, "SKIP: src_bangumi schema failed: %v\n", err)
+		os.Exit(0)
+	}
+	if err := srcv.EnsureSchema(db); err != nil {
+		fmt.Fprintf(os.Stderr, "SKIP: src_vndb schema failed: %v\n", err)
 		os.Exit(0)
 	}
 

--- a/apps/api/internal/platform/catalog/service/work_service.go
+++ b/apps/api/internal/platform/catalog/service/work_service.go
@@ -114,13 +114,17 @@ func (s *WorkService) ClaimWork(ctx context.Context, params ClaimWorkParams) (in
 			return nil
 		}
 
+		rating := params.ContentRating
+		if rating == 0 && len(params.Anchors) > 0 {
+			rating = s.deriveAnchorRating(ctx, params.Anchors)
+		}
 		w := model.CatalogWork{
 			MediumID:        params.MediumID,
 			Site:            &params.Site,
 			ProductWorkID:   &params.ProductWorkID,
 			OLang:           params.OLang,
 			DisplayName:     params.DisplayName,
-			ContentRating:   params.ContentRating,
+			ContentRating:   rating,
 			Status:          model.WorkStatusLive,
 			Extra:           []byte(`{}`),
 			FieldProvenance: []byte(`{}`),

--- a/apps/api/internal/platform/catalog/service/work_submit.go
+++ b/apps/api/internal/platform/catalog/service/work_submit.go
@@ -20,6 +20,10 @@ type SubmitWorkParams struct {
 	Site          string
 	ProductWorkID int64
 	ActorUID      int64
+	// Source-derived, written straight to the column with no provenance stamp
+	// so the weekly releasemeta lane and human edits both still own the field;
+	// a rating in Fields goes through editspec and stamps curated instead.
+	ContentRating int16
 	Fields        map[string]any
 	Released      ReleaseDate
 }
@@ -181,6 +185,7 @@ func (s *ClaimLifecycleService) SubmitWork(ctx context.Context, p SubmitWorkPara
 			ClaimState:      &pending,
 			OLang:           model.OLangDefault,
 			Status:          model.WorkStatusLive,
+			ContentRating:   p.ContentRating,
 			Extra:           []byte(`{}`),
 			FieldProvenance: []byte(`{}`),
 		}

--- a/docs/catalog/01-service-and-contract.md
+++ b/docs/catalog/01-service-and-contract.md
@@ -392,6 +392,7 @@ catalog 的**第三张脸**,也是「用户写面」的起点。教义一句话:
 - **`mine` 无 uid 参数**:uid 与 site 全部取自令牌,故它天然只答「我的」。`claim_state` 用与全站一致的闭合词表解析器(非法值 → **400**,message 为同一句),`before` = 上一页末行的 `last_event_id`,`total` 即该用户的统计值(「我发布的」= `claim_state=live&limit=1`)。
 - **S2S 认领面剩下的全是读**(wave 185 删掉两条写之后),不是过渡期的残留:`listCatalogClaimsByUser`(**读别人的**认领,forum 的个人资料页靠它)在用户面**故意没有对应 op**——`mine` 是本人的列表、不是任何人的;`listCatalogClaimEvents` / `listCatalogEditRevisions` 两条游标 feed(产品侧对账 cron 的面)、`revisions` / `diff` 两条版本史读、各类第三人称统计投影与 staff 审核队列**仍只在 S2S / admin 面**——它们要么是机器消费者的面、没有「令牌本人」可言,要么是公共读、本就不问是谁。wave 180 后**人类写与人类只读均已在用户面齐备**,wave 181 与 185 依次删掉了 S2S 上残留的孪生:S2S 面上**不再有任何写**,更没有任何需要断言 uid 的人类动作。
 - 错误映射沿用 S2S 面:非法迁移 → **409**(带 `ClaimTransitionInfo`),重复投稿 → **409**(带 `WorkSubmitConflictInfo`),作品不存在 → **404**,未知 action → **400**,`decline` 缺 reason / `claim` 缺 `product_work_id` / 投稿缺 `display_name` → **422**,越权(条目属于他人、跨租户、无审核权)→ **403**。
+- **铸造时年龄轴按 refs/anchors 派生(2026-08-26 起)**:铸造 stub 的每条路(v2 `POST /v2/me/claims` 带 refs、S2S `works/claim` 带 anchors 且未显式给 `content_rating`)在落行前查 `src_vndb`(非补丁 release `minage>=18 OR has_ero`)与 `src_bangumi`(`nsfw` 或 wiki 维护的「R18」meta_tag),命中即铸 `content_rating=2`;查不到或 staging schema 缺席(dev/test)→ 照旧铸 0,**永不因派生失败拒绝认领**。派生值直写列、不盖 provenance 戳,人工编辑随时可改。兜底 = 每周三 `backfill-release-meta` 的分级车道,证据阶梯 **vndb → dlsite age → erogamescape `erogame` → bangumi(nsfw/meta_tag)**,只填 `content_rating=0` 的行;成因:认领波曾铸出 16 部年龄轴空默认 0 的成人作品,而 v2 认领把 refs 只转成 links 不落锚,周车道也救不了它们。
 
 ### 4.4 用户令牌只读面(wave 180)
 


### PR DESCRIPTION
## Why

Two writers minted adult works as `content_rating=0` (all_ages) with nothing downstream able to correct them:

1. **Claim-minted stubs are born 0.** The v2 claim payload has no rating field, and its refs become `links`, not anchors — so the weekly `releasemeta` rating lane (anchors-only) never sees those works either. The kungal claim wave left **16 adult works** (every one with VNDB `minage=18` on all releases) listed as all_ages.
2. **The weekly rating lane was blind to two evidence sources.** Census over the 517 unclaimed explicit-cover works: their bangumi subjects carry `nsfw=true` on **0** of 492, while the wiki-curated **R18 meta_tag** catches 117; 991 cr=0 works globally carry exact VNDB anchors with an adult verdict; 935 carry EG anchors.

## What

- **Claim mint derivation** (`service.DeriveContentRating` / `WorkService.deriveAnchorRating`): v2 `POST /v2/me/claims` (refs) and S2S `works/claim` (anchors, only when `content_rating` is omitted) consult `src_vndb` (non-patch release `minage>=18 OR has_ero` — the vndbworks importer's own predicate) and `src_bangumi` (`nsfw` OR R18 meta_tag). Best-effort: absent staging schemas (dev/test) log a warning and mint 0, never fail the claim. The derived value is written straight to the column with **no provenance stamp**, so human edits and the weekly lane keep ownership.
- **releasemeta rating lane**: gains a **vndb** lane and an **erogamescape** lane (`erogame=true`); the bangumi lane widens to `nsfw OR meta_tags ∋ "R18"`. Ladder order is now **vndb → dlsite → eg → bangumi**: the dlsite anchor is release-level, so a 全年齢版 SKU's age "1" used to take an all-ages verdict and pin a work with an 18+ original at 0 forever.
- `docs/catalog/01` §4.3 records the derivation and the ladder.

## Impact

- Zero wire-shape changes (no OpenAPI/spec deltas), zero migrations.
- Next Wednesday's `bgm-refresh` cron run (or a manual `backfill-release-meta --apply`) rates ~1,200+ currently-all_ages adult works R18 from evidence, including the 16 claimed ones.

## Tests

- `releasemeta`: vndb minage / has_ero / patch-exclusion / all-ages, EG erogame true/false, bangumi meta_tag, vndb-beats-dlsite-all-ages — full suite green on an ephemeral DB (2.6s real run).
- `catalog/service`: new `claim_rating_test.go` (ref/anchor derivation matrix, caller-supplied rating never re-derived, SubmitWork carries the derived value) — full suite green (82s real run).
- `apiv2/*` green.