### PR TITLE
fix(catalog): let the EG erogame verdict outrank a dlsite all-ages SKU

### DIFF
--- a/apps/api/internal/jobs/releasemeta/backfill_test.go
+++ b/apps/api/internal/jobs/releasemeta/backfill_test.go
@@ -382,6 +382,13 @@ func TestBackfillReleaseMeta(t *testing.T) {
 	mkWorkAnchor(t, rEgFalse, "612", reg.egSource, model.LinkKindExact)
 	mkEgErogame(t, 612, false)
 
+	rEgBeatsDl := mkWork(t, medium, "rating-eg-beats-dl-allages", nil, nil, 0)
+	relEgBeatsDl := mkRelease(t, rEgBeatsDl, 2000, 1, 1)
+	mkReleaseAnchor(t, relEgBeatsDl, "RJ000106", reg.dlsiteSource)
+	mkDlWork(t, "RJ000106", "", "1")
+	mkWorkAnchor(t, rEgBeatsDl, "613", reg.egSource, model.LinkKindExact)
+	mkEgErogame(t, 613, true)
+
 	rBgmMeta := mkWork(t, medium, "rating-bgm-meta-tag", nil, nil, 0)
 	mkWorkAnchor(t, rBgmMeta, "710", reg.bangumiSource, model.LinkKindExact)
 	mkSubjectMeta(t, 710, false, "游戏", "R18")
@@ -405,15 +412,15 @@ func TestBackfillReleaseMeta(t *testing.T) {
 	assert.Equal(t, 1, st.BgmDateBadDate)
 	assert.Equal(t, 1, st.BgmDatePartial)
 	assert.Equal(t, 2, st.BgmDatePlanned, "wBgmClaimed + wBgmPartial")
-	assert.Equal(t, 32, st.RatingCandidates, "every rating-0 work; rRated excluded")
+	assert.Equal(t, 33, st.RatingCandidates, "every rating-0 work; rRated excluded")
 	assert.Equal(t, 3, st.RatingVndbR18, "minage + has_ero + the dl-allages preemption")
 	assert.Equal(t, 1, st.RatingDlR18)
 	assert.Equal(t, 1, st.RatingDlSensitive)
 	assert.Equal(t, 1, st.RatingDlAllAges, "explicit all-ages verdict keeps the row at 0")
-	assert.Equal(t, 1, st.RatingEgR18)
+	assert.Equal(t, 2, st.RatingEgR18, "erogame=true + the dl-allages preemption")
 	assert.Equal(t, 2, st.RatingBgmR18, "nsfw flag + R18 meta_tag")
 	assert.Equal(t, 23, st.RatingNoVerdict)
-	assert.Equal(t, 8, st.RatingPlanned)
+	assert.Equal(t, 9, st.RatingPlanned)
 	assert.Zero(t, st.DlDateFilled+st.EgDateFilled+st.BgmDateFilled+st.RatingFilled+
 		st.DlDateSkippedNonEmpty+st.EgDateSkippedNonEmpty+st.BgmDateSkippedNonEmpty+
 		st.RatingSkippedNonEmpty+st.Errors)
@@ -426,7 +433,7 @@ func TestBackfillReleaseMeta(t *testing.T) {
 	assert.Equal(t, 2, st.DlDateFilled)
 	assert.Equal(t, 4, st.EgDateFilled)
 	assert.Equal(t, 2, st.BgmDateFilled)
-	assert.Equal(t, 8, st.RatingFilled)
+	assert.Equal(t, 9, st.RatingFilled)
 	assert.Zero(t, st.DlDateSkippedNonEmpty+st.EgDateSkippedNonEmpty+st.BgmDateSkippedNonEmpty+
 		st.RatingSkippedNonEmpty+st.Errors)
 
@@ -457,6 +464,8 @@ func TestBackfillReleaseMeta(t *testing.T) {
 	assert.Equal(t, model.ContentRatingR18, workRating(t, rVndbBeatsDl),
 		"work-level vndb verdict outranks the 全年齢版 SKU's dlsite age")
 	assert.Equal(t, model.ContentRatingR18, workRating(t, rEgTrue))
+	assert.Equal(t, model.ContentRatingR18, workRating(t, rEgBeatsDl),
+		"work-level EG erogame outranks the 全年齢版 SKU's dlsite age")
 	assert.Equal(t, int16(0), workRating(t, rEgFalse), "erogame=false never infers a rating")
 	assert.Equal(t, model.ContentRatingR18, workRating(t, rBgmMeta))
 
@@ -465,7 +474,7 @@ func TestBackfillReleaseMeta(t *testing.T) {
 	assert.Equal(t, 3, st.DlDateCandidates, "only the unfillable three remain")
 	assert.Equal(t, 2, st.EgDateCandidates, "bad-date + missing-mirror remain")
 	assert.Equal(t, 2, st.BgmDateCandidates, "no-date + garbage remain")
-	assert.Equal(t, 24, st.RatingCandidates, "the eight filled works left the set")
+	assert.Equal(t, 24, st.RatingCandidates, "the nine filled works left the set")
 	assert.Zero(t, st.DlDatePlanned+st.EgDatePlanned+st.BgmDatePlanned+st.RatingPlanned,
 		"second pass plans zero")
 	assert.Zero(t, st.DlDateFilled+st.EgDateFilled+st.BgmDateFilled+st.RatingFilled+st.Errors,

--- a/apps/api/internal/jobs/releasemeta/rating.go
+++ b/apps/api/internal/jobs/releasemeta/rating.go
@@ -99,10 +99,13 @@ func runRatingLane(ctx context.Context, db, dlDB, egDB *gorm.DB, w *writer, reg 
 	return nil
 }
 
-// VNDB outranks the DLsite storefront age: the dlsite anchor is release-level,
-// so a 全年齢版 SKU's age "1" describes that edition, while the vndb verdict is
-// the work-level "an 18+ release exists". With dlsite first, such a work took
-// an all-ages verdict (written as nothing) and stayed 0 forever.
+// VNDB and EG outrank the DLsite storefront age: the dlsite anchor is
+// release-level, so a 全年齢版 SKU's age "1" describes that edition, while the
+// vndb verdict ("a non-patch 18+ release exists") and the EG erogame flag are
+// work-level. With dlsite ahead of them, such a work took an all-ages verdict
+// (written as nothing) and stayed 0 forever — the first prod run confirmed it:
+// eg_r18 counted 0 while 3 un-edited erogame=true works sat in the candidate
+// set, each parked behind a dl age "1" SKU.
 func decideRating(c ratingCandidate, dlAnchors map[int64]string, dlAges map[string]string,
 	vndbR18 map[int64]bool, egAnchors map[int64][]int64, egErogame map[int64]bool,
 	bgmR18 map[int64]bool, st *Stats) (int16, string, string, bool) {
@@ -110,6 +113,13 @@ func decideRating(c ratingCandidate, dlAnchors map[int64]string, dlAges map[stri
 	if vndbR18[c.WorkID] {
 		st.RatingVndbR18++
 		return model.ContentRatingR18, "vndb", "", true
+	}
+
+	for _, id := range egAnchors[c.WorkID] {
+		if egErogame[id] {
+			st.RatingEgR18++
+			return model.ContentRatingR18, "erogamescape", strconv.FormatInt(id, 10), true
+		}
 	}
 
 	if wn, ok := dlAnchors[c.WorkID]; ok {
@@ -126,18 +136,12 @@ func decideRating(c ratingCandidate, dlAnchors map[int64]string, dlAges map[stri
 		}
 	}
 
-	// The wiki's editorial age_limit lane used to sit here, read from
-	// galgame.age_limit for claimed works. Wave 149 dropped that table, so the
-	// lane is gone rather than merely unfilled. It had in fact stopped
-	// producing verdicts earlier: its claim test pinned site == "galgame_wiki",
-	// the literal wave 161 renamed, so it silently matched nothing from then on.
-
-	for _, id := range egAnchors[c.WorkID] {
-		if egErogame[id] {
-			st.RatingEgR18++
-			return model.ContentRatingR18, "erogamescape", strconv.FormatInt(id, 10), true
-		}
-	}
+	// The wiki's editorial age_limit lane used to sit between dlsite and
+	// bangumi, read from galgame.age_limit for claimed works. Wave 149 dropped
+	// that table, so the lane is gone rather than merely unfilled. It had in
+	// fact stopped producing verdicts earlier: its claim test pinned
+	// site == "galgame_wiki", the literal wave 161 renamed, so it silently
+	// matched nothing from then on.
 
 	if bgmR18[c.WorkID] {
 		st.RatingBgmR18++


### PR DESCRIPTION
The first prod run of the widened rating lane counted eg_r18=0 while 3
un-edited erogame=true works sat in the candidate set: each carries a
全年齢版 DLsite SKU whose age "1" produced an all-ages verdict before the
EG evidence was consulted — the same release-level-preempts-work-level
trap the vndb lane fix addressed, one rung lower. The ladder is now
vndb → eg → dlsite → bangumi.
