### PR TITLE
feat(web): let an admin edit a user, and let you upload your own avatar

### DIFF
--- a/apps/web/app/components/common/AvatarCrop.vue
+++ b/apps/web/app/components/common/AvatarCrop.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+const file = defineModel<Blob | null>('file', { required: true })
+
+defineProps<{ disabled?: boolean }>()
+
+const uploadKey = ref(0)
+
+const onCropped = (blob: Blob) => {
+  file.value = blob
+}
+
+const reset = () => {
+  file.value = null
+  uploadKey.value++
+}
+
+defineExpose({ reset })
+</script>
+
+<template>
+  <div :class="disabled ? 'pointer-events-none opacity-50' : ''">
+    <KunUpload
+      :key="uploadKey"
+      :size="512"
+      :aspect="1"
+      description="点击或拖拽选择图片，可裁剪为正方形"
+      class-name="mx-auto w-48"
+      @set-image="onCropped"
+    />
+  </div>
+</template>

--- a/apps/web/app/components/creator-applications/Container.vue
+++ b/apps/web/app/components/creator-applications/Container.vue
@@ -76,6 +76,9 @@ const formatEvidence = (e: Record<string, unknown> | null): string => {
 
 const approvingId = ref<number | null>(null)
 const handleApprove = async (id: number) => {
+  if (approvingId.value !== null || declineLoading.value) {
+    return
+  }
   approvingId.value = id
   try {
     const res = await api.post(`/admin/creator/applications/${id}/approve`)
@@ -95,12 +98,15 @@ const declineTarget = ref<number | null>(null)
 const declineReason = ref('')
 const declineLoading = ref(false)
 const openDecline = (id: number) => {
+  if (approvingId.value !== null || declineLoading.value) {
+    return
+  }
   declineTarget.value = id
   declineReason.value = ''
   declineOpen.value = true
 }
 const confirmDecline = async () => {
-  if (declineTarget.value === null) {
+  if (declineTarget.value === null || declineLoading.value || approvingId.value !== null) {
     return
   }
   declineLoading.value = true
@@ -112,12 +118,12 @@ const confirmDecline = async () => {
     if (res.code === 0) {
       useKunMessage('已拒绝', 'success')
       refresh()
+      declineOpen.value = false
     } else {
       useKunMessage(res.message || '操作失败', 'error')
     }
   } finally {
     declineLoading.value = false
-    declineOpen.value = false
   }
 }
 </script>
@@ -195,6 +201,7 @@ const confirmDecline = async () => {
           color="danger"
           variant="flat"
           size="sm"
+          :disabled="approvingId !== null || declineLoading"
           @click="openDecline(app.id)"
         >
           拒绝
@@ -202,9 +209,14 @@ const confirmDecline = async () => {
         <KunButton
           color="success"
           size="sm"
-          :disabled="approvingId === app.id"
+          :disabled="approvingId !== null || declineLoading"
           @click="handleApprove(app.id)"
         >
+          <KunIcon
+            v-if="approvingId === app.id"
+            name="lucide:loader-circle"
+            class="mr-1 size-4 animate-spin"
+          />
           通过
         </KunButton>
       </div>
@@ -231,7 +243,12 @@ const confirmDecline = async () => {
           :rows="3"
         />
         <div class="flex justify-end gap-2">
-          <KunButton color="default" variant="flat" @click="declineOpen = false">
+          <KunButton
+            color="default"
+            variant="flat"
+            :disabled="declineLoading"
+            @click="declineOpen = false"
+          >
             取消
           </KunButton>
           <KunButton
@@ -239,6 +256,11 @@ const confirmDecline = async () => {
             :disabled="declineLoading"
             @click="confirmDecline"
           >
+            <KunIcon
+              v-if="declineLoading"
+              name="lucide:loader-circle"
+              class="mr-1 size-4 animate-spin"
+            />
             确认拒绝
           </KunButton>
         </div>

--- a/apps/web/app/components/profile/Edit.vue
+++ b/apps/web/app/components/profile/Edit.vue
@@ -1,31 +1,44 @@
 <script setup lang="ts">
+import { resolveAvatarUrl } from '~~/shared/utils/resolveImage'
 
 const auth = useAuth()
 const user = auth.user
+const userStore = useUserStore()
 
 const name = ref('')
 const bio = ref('')
-const avatar = ref('')
 const error = ref('')
 const success = ref('')
 const isLoading = ref(false)
+
+const avatarFile = ref<Blob | null>(null)
+const avatarCrop = ref<{ reset: () => void } | null>(null)
+const {
+  uploading: avatarUploading,
+  error: avatarError,
+  upload: uploadAvatar,
+} = useAvatarUpload()
+
+const cdnBase = useRuntimeConfig().public.imageCdnBase as string
+const avatarSrc = computed(() =>
+  resolveAvatarUrl(user.value ?? null, { cdnBase, variant: '256' }, '')
+)
 
 watchEffect(() => {
   if (!user.value) return
   name.value = user.value.name ?? ''
   bio.value = user.value.bio ?? ''
-  avatar.value = user.value.avatar ?? ''
 })
 
 const dirty = computed(
   () =>
     !!user.value &&
     (name.value !== (user.value.name ?? '') ||
-      bio.value !== (user.value.bio ?? '') ||
-      avatar.value !== (user.value.avatar ?? ''))
+      bio.value !== (user.value.bio ?? ''))
 )
 
 const handleSubmit = async () => {
+  if (isLoading.value || avatarUploading.value) return
   error.value = ''
   success.value = ''
 
@@ -37,19 +50,14 @@ const handleSubmit = async () => {
     error.value = '个人简介不能超过 107 个字符'
     return
   }
-  if (avatar.value.length > 255) {
-    error.value = '头像链接过长（≤255）'
-    return
-  }
   if (!dirty.value) {
     error.value = '没有任何改动'
     return
   }
 
-  const payload: { name?: string; bio?: string; avatar?: string } = {}
+  const payload: { name?: string; bio?: string } = {}
   if (name.value !== (user.value?.name ?? '')) payload.name = name.value.trim()
   if (bio.value !== (user.value?.bio ?? '')) payload.bio = bio.value
-  if (avatar.value !== (user.value?.avatar ?? '')) payload.avatar = avatar.value
 
   isLoading.value = true
   try {
@@ -65,6 +73,17 @@ const handleSubmit = async () => {
     isLoading.value = false
   }
 }
+
+const handleAvatarUpload = async () => {
+  if (!avatarFile.value || avatarUploading.value || isLoading.value) return
+  const hash = await uploadAvatar(avatarFile.value, '/auth/me/avatar')
+  if (hash && userStore.user) {
+    userStore.setUser({ ...userStore.user, avatar_image_hash: hash })
+    useKunMessage('头像已更新', 'success')
+    avatarCrop.value?.reset()
+    avatarFile.value = null
+  }
+}
 </script>
 
 <template>
@@ -75,19 +94,34 @@ const handleSubmit = async () => {
     </h3>
 
     <form class="space-y-4" @submit.prevent="handleSubmit">
-      <div class="flex items-center gap-4">
+      <div class="space-y-2 text-center">
         <KunAvatar
-          :user="{ id: 0, name: name || '用户', avatar }"
+          :user="{ id: 0, name: name || '用户', avatar: avatarSrc }"
           size="lg"
           :is-navigation="false"
         />
-        <div class="flex-1">
-          <KunInput
-            v-model="avatar"
-            label="头像链接"
-            placeholder="https://example.com/avatar.webp"
-            autocomplete="off"
+        <CommonAvatarCrop
+          ref="avatarCrop"
+          v-model:file="avatarFile"
+          :disabled="avatarUploading || isLoading"
+        />
+        <KunButton
+          type="button"
+          variant="flat"
+          color="primary"
+          size="sm"
+          :disabled="!avatarFile || avatarUploading || isLoading"
+          @click="handleAvatarUpload"
+        >
+          <KunIcon
+            v-if="avatarUploading"
+            name="lucide:loader-circle"
+            class="mr-1 size-4 animate-spin"
           />
+          上传头像
+        </KunButton>
+        <div v-if="avatarError" class="text-danger-600 text-sm">
+          {{ avatarError }}
         </div>
       </div>
 
@@ -118,7 +152,7 @@ const handleSubmit = async () => {
         type="submit"
         color="primary"
         class="w-full"
-        :disabled="isLoading || !dirty"
+        :disabled="isLoading || !dirty || avatarUploading"
       >
         <KunIcon
           v-if="isLoading"

--- a/apps/web/app/components/users/AvatarUploadModal.vue
+++ b/apps/web/app/components/users/AvatarUploadModal.vue
@@ -13,58 +13,24 @@ const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
 const file = ref<Blob | null>(null)
-const uploading = ref(false)
-const errorMsg = ref('')
-const uploadKey = ref(0)
-
-const onCropped = (blob: Blob) => {
-  errorMsg.value = ''
-  file.value = blob
-}
+const crop = ref<{ reset: () => void } | null>(null)
+const { uploading, error, upload } = useAvatarUpload()
 
 const close = () => {
   if (uploading.value) return
   emit('update:open', false)
   setTimeout(() => {
-    file.value = null
-    errorMsg.value = ''
-    uploadKey.value++
+    crop.value?.reset()
+    error.value = ''
   }, 200)
 }
 
 const submit = async () => {
   if (!file.value || !props.user || uploading.value) return
-  uploading.value = true
-  errorMsg.value = ''
-
-  try {
-    const fd = new FormData()
-    fd.append('file', file.value, 'avatar.webp')
-
-    const cfg = useRuntimeConfig()
-    const cookie = useCookie('access_token')
-    const res = await $fetch<{
-      code: number
-      message: string
-      data?: { hash: string }
-    }>(`${cfg.public.apiBase}/admin/users/${props.user.uuid}/avatar`, {
-      method: 'POST',
-      body: fd,
-      headers: cookie.value ? { Authorization: `Bearer ${cookie.value}` } : {},
-      credentials: 'include'
-    })
-
-    if (res.code === 0 && res.data?.hash) {
-      emit('success', res.data.hash)
-      close()
-    } else {
-      errorMsg.value = res.message || '上传失败'
-    }
-  } catch (err) {
-    const e = err as { data?: { message?: string }; statusMessage?: string; message?: string }
-    errorMsg.value = e?.data?.message || e?.statusMessage || e?.message || '网络错误'
-  } finally {
-    uploading.value = false
+  const hash = await upload(file.value, `/admin/users/${props.user.uuid}/avatar`)
+  if (hash) {
+    emit('success', hash)
+    close()
   }
 }
 </script>
@@ -83,17 +49,14 @@ const submit = async () => {
           保留作回退（老用户头像不会被覆盖）。
         </p>
 
-        <KunUpload
-          :key="uploadKey"
-          :size="512"
-          :aspect="1"
-          description="点击或拖拽选择图片，可裁剪为正方形"
-          class-name="mx-auto w-48"
-          @set-image="onCropped"
+        <CommonAvatarCrop
+          ref="crop"
+          v-model:file="file"
+          :disabled="uploading"
         />
 
-        <div v-if="errorMsg" class="text-danger-600 text-sm">
-          {{ errorMsg }}
+        <div v-if="error" class="text-danger-600 text-sm">
+          {{ error }}
         </div>
       </div>
 

--- a/apps/web/app/components/users/Container.vue
+++ b/apps/web/app/components/users/Container.vue
@@ -145,6 +145,22 @@ const handleDetail = (user: { uuid: string; name: string }) => {
   detailTarget.value = user
   detailOpen.value = true
 }
+
+const editOpen = ref(false)
+const editTarget = ref<{ uuid: string; name: string } | null>(null)
+const detailReloadKey = ref(0)
+
+const handleEdit = (user: { uuid: string; name: string }) => {
+  editTarget.value = user
+  editOpen.value = true
+}
+
+const onEditSuccess = () => {
+  refresh()
+  if (detailTarget.value?.uuid === editTarget.value?.uuid) {
+    detailReloadKey.value++
+  }
+}
 </script>
 
 <template>
@@ -189,6 +205,7 @@ const handleDetail = (user: { uuid: string; name: string }) => {
         @roles="handleRoles"
         @site-roles="handleSiteRoles"
         @detail="handleDetail"
+        @edit="handleEdit"
       />
 
       <div v-if="totalPages > 1" class="flex justify-center">
@@ -224,7 +241,17 @@ const handleDetail = (user: { uuid: string; name: string }) => {
       @success="refresh"
     />
 
-    <UsersDetailDrawer v-model:open="detailOpen" :user="detailTarget" />
+    <UsersDetailDrawer
+      v-model:open="detailOpen"
+      :user="detailTarget"
+      :reload-key="detailReloadKey"
+    />
+
+    <UsersEditModal
+      v-model:open="editOpen"
+      :user="editTarget"
+      @success="onEditSuccess"
+    />
 
     <KunModal v-model="banOpen" aria-label="封禁用户">
       <div class="space-y-4">

--- a/apps/web/app/components/users/DetailDrawer.vue
+++ b/apps/web/app/components/users/DetailDrawer.vue
@@ -5,7 +5,10 @@ import { USER_STATUS_MAP } from '~/constants/admin'
 import type { UserDetail } from '~~/shared/types/user'
 
 const open = defineModel<boolean>('open', { required: true })
-const props = defineProps<{ user: { uuid: string; name: string } | null }>()
+const props = defineProps<{
+  user: { uuid: string; name: string } | null
+  reloadKey?: number
+}>()
 
 const api = useApi()
 const cdnBase = useRuntimeConfig().public.imageCdnBase as string
@@ -31,9 +34,12 @@ const load = async () => {
   }
 }
 
-watch(open, (v) => {
-  if (v && props.user) load()
-})
+watch(
+  [open, () => props.user?.uuid, () => props.reloadKey],
+  () => {
+    if (open.value && props.user) load()
+  }
+)
 
 const avatarSrc = computed(() =>
   detail.value

--- a/apps/web/app/components/users/EditModal.vue
+++ b/apps/web/app/components/users/EditModal.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+const open = defineModel<boolean>('open', { required: true })
+const props = defineProps<{
+  user: { uuid: string; name: string } | null
+}>()
+const emit = defineEmits<{ success: [] }>()
+
+const api = useApi()
+
+const name = ref('')
+const email = ref('')
+const bio = ref('')
+const initial = ref<{ name: string; email: string; bio: string } | null>(null)
+
+const loading = ref(false)
+const loadFailed = ref(false)
+const error = ref('')
+const submitting = ref(false)
+
+watch(
+  [open, () => props.user?.uuid],
+  async ([v]) => {
+    if (!v || !props.user) return
+    loading.value = true
+    loadFailed.value = false
+    error.value = ''
+    initial.value = null
+    name.value = ''
+    email.value = ''
+    bio.value = ''
+
+    const res = await api.get<{
+      name: string
+      email: string
+      bio: string
+    }>(`/admin/users/${props.user.uuid}`)
+    if (res.code === 0 && res.data) {
+      name.value = res.data.name ?? ''
+      email.value = res.data.email ?? ''
+      bio.value = res.data.bio ?? ''
+      initial.value = {
+        name: name.value,
+        email: email.value,
+        bio: bio.value
+      }
+    } else {
+      error.value = res.message || '加载用户信息失败'
+      loadFailed.value = true
+    }
+    loading.value = false
+  },
+  { immediate: true }
+)
+
+const dirtyPatch = computed(() => {
+  if (!initial.value) return null
+  const patch: { name?: string; email?: string; bio?: string } = {}
+  if (name.value !== initial.value.name) patch.name = name.value.trim()
+  if (email.value !== initial.value.email) patch.email = email.value.trim()
+  if (bio.value !== initial.value.bio) patch.bio = bio.value
+  return Object.keys(patch).length ? patch : null
+})
+
+const handleSubmit = async () => {
+  if (submitting.value || !props.user || loadFailed.value) return
+  error.value = ''
+
+  const trimmedName = name.value.trim()
+  if (trimmedName.length < 2 || trimmedName.length > 17) {
+    error.value = '用户名长度需为 2–17 个字符'
+    return
+  }
+  if (bio.value.length > 107) {
+    error.value = '个人简介不能超过 107 个字符'
+    return
+  }
+  if (!email.value.trim() || !email.value.includes('@')) {
+    error.value = '请填写有效的邮箱地址'
+    return
+  }
+  const patch = dirtyPatch.value
+  if (!patch) {
+    error.value = '没有任何改动'
+    return
+  }
+
+  submitting.value = true
+  try {
+    const res = await api.patch(`/admin/users/${props.user.uuid}`, patch)
+    if (res.code === 0) {
+      useKunMessage('资料已更新', 'success')
+      emit('success')
+      open.value = false
+    } else {
+      error.value = res.message || '更新失败'
+    }
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <KunModal v-model="open" aria-label="编辑用户资料">
+    <div class="space-y-4">
+      <div>
+        <h2 class="text-xl font-bold text-foreground">编辑用户资料</h2>
+        <p class="text-default-500 mt-1 text-sm">
+          用户
+          <span class="text-foreground font-semibold">{{ user?.name }}</span>
+        </p>
+      </div>
+
+      <div v-if="loading" class="flex justify-center py-8">
+        <KunIcon
+          name="lucide:loader-circle"
+          class="text-primary size-6 animate-spin"
+        />
+      </div>
+
+      <form v-else class="space-y-4" @submit.prevent="handleSubmit">
+        <KunInput
+          v-model="name"
+          label="用户名"
+          placeholder="2–17 个字符"
+          autocomplete="off"
+        />
+
+        <div class="space-y-1">
+          <KunInput
+            v-model="email"
+            type="email"
+            label="邮箱"
+            autocomplete="off"
+          />
+          <p class="text-warning-500 text-xs">
+            管理员改邮箱不会发送验证码，保存后立即生效。
+          </p>
+        </div>
+
+        <KunTextarea
+          v-model="bio"
+          label="个人简介"
+          placeholder="一句话介绍（≤107 字）"
+          :rows="3"
+        />
+
+        <p
+          v-if="error"
+          class="bg-danger-50 text-danger rounded-lg p-3 text-sm"
+        >
+          {{ error }}
+        </p>
+
+        <div class="flex justify-end gap-3">
+          <KunButton
+            color="default"
+            variant="flat"
+            type="button"
+            :disabled="submitting"
+            @click="open = false"
+          >
+            取消
+          </KunButton>
+          <KunButton
+            color="primary"
+            type="submit"
+            :disabled="submitting || loadFailed"
+          >
+            <KunIcon
+              v-if="submitting"
+              name="lucide:loader-circle"
+              class="mr-2 size-4 animate-spin"
+            />
+            {{ submitting ? '保存中...' : '保存' }}
+          </KunButton>
+        </div>
+      </form>
+    </div>
+  </KunModal>
+</template>

--- a/apps/web/app/components/users/Table.vue
+++ b/apps/web/app/components/users/Table.vue
@@ -13,6 +13,7 @@ const emit = defineEmits<{
   roles: [user: { uuid: string; name: string; roles: string[] }]
   siteRoles: [user: { uuid: string; name: string }]
   detail: [user: { uuid: string; name: string }]
+  edit: [user: { uuid: string; name: string }]
 }>()
 
 const cdnBase = useRuntimeConfig().public.imageCdnBase as string
@@ -121,6 +122,14 @@ const isAdmin = (user: User) => !!user.roles?.includes('admin')
                 >
                   <KunIcon name="lucide:eye" class="size-4" />
                   查看详情
+                </button>
+                <button
+                  v-if="!user.is_anonymized"
+                  class="flex w-full items-center gap-2 px-3 py-2 text-sm text-default-500 hover:bg-default-100 hover:text-foreground"
+                  @click="emit('edit', { uuid: user.uuid, name: user.name })"
+                >
+                  <KunIcon name="lucide:user-pen" class="size-4" />
+                  编辑资料
                 </button>
                 <button
                   v-if="user.status === 0 && !user.is_anonymized && !isAdmin(user)"

--- a/apps/web/app/composables/useAvatarUpload.ts
+++ b/apps/web/app/composables/useAvatarUpload.ts
@@ -1,0 +1,56 @@
+interface AvatarUploadResponse {
+  code: number
+  message: string
+  data?: { hash: string }
+}
+
+export const useAvatarUpload = () => {
+  const uploading = ref(false)
+  const error = ref('')
+
+  const upload = async (
+    blob: Blob,
+    endpoint: string
+  ): Promise<string | null> => {
+    if (uploading.value) return null
+    uploading.value = true
+    error.value = ''
+
+    try {
+      const fd = new FormData()
+      fd.append('file', blob, 'avatar.webp')
+
+      const cfg = useRuntimeConfig()
+      const cookie = useCookie('access_token')
+      const res = await $fetch<AvatarUploadResponse>(
+        `${cfg.public.apiBase}${endpoint}`,
+        {
+          method: 'POST',
+          body: fd,
+          headers: cookie.value
+            ? { Authorization: `Bearer ${cookie.value}` }
+            : {},
+          credentials: 'include',
+        }
+      )
+
+      if (res.code === 0 && res.data?.hash) {
+        return res.data.hash
+      }
+      error.value = res.message || '上传失败'
+      return null
+    } catch (err) {
+      const e = err as {
+        data?: { message?: string }
+        statusMessage?: string
+        message?: string
+      }
+      error.value = e?.data?.message || e?.statusMessage || e?.message || '网络错误'
+      return null
+    } finally {
+      uploading.value = false
+    }
+  }
+
+  return { uploading, error, upload }
+}


### PR DESCRIPTION
## What

The oauth service already exposed `PATCH /admin/users/:uuid` and `POST /auth/me/avatar`. The admin console never called them.

- **Admin edit** — the user drawer was read-only. A new `UsersEditModal` GETs the user on open and PATCHes only dirty `name` / `email` / `bio`. Status stays on the existing ban/unban flow; avatar stays on the existing upload modal. Admin email changes skip the verification code, and the form says so.
- **Self avatar** — the profile page asked for a raw URL. It now crops and POSTs to `/auth/me/avatar`, then writes `avatar_image_hash` into the user store (hash already wins in `resolveAvatarUrl`). Admin and self share `useAvatarUpload` + `CommonAvatarCrop`.
- **Creator applications** — a double-click could approve twice. Approve/decline now share an in-flight guard, disable together, show a spinner, and the decline modal stays open on error so the reason is not lost.

Frontend only. No schema change, no OpenAPI, no migration.

## Why these three together

They are the leftover admin-console tail that was already backed by live endpoints. DatePicker / SubNav refresh / oauth type generation are separate and not in this PR.

## Test

- `pnpm exec eslint` on the nine touched files: clean
- `pnpm -F web run typecheck`: clean

Not exercised against a live image service in this session (avatar upload 500s if `KUN_IMAGE_CLIENT_*` is unset, which is existing backend behaviour).