### PR TITLE
fix(catalog): restore the whole-population default on the v1 works lane

### DIFF
--- a/apps/api/internal/platform/catalog/handler/public_handler.go
+++ b/apps/api/internal/platform/catalog/handler/public_handler.go
@@ -609,6 +609,13 @@ func (h *PublicHandler) WorksList(c fiber.Ctx) error {
 		Include:  service.ParseWorksListInclude(c.Query("include")),
 		Fields:   fieldsQuery(c),
 		Site:     strings.TrimSpace(c.Query("site")),
+		// The zero PublicOLang curates to ja+zh (the calendar's home
+		// population). 2f326114 added the field for v2 and left this
+		// constructor unset, which silently dropped every non-ja/zh work
+		// from the v1 browse and ids= lanes — the forum saw short pages,
+		// and works?ids= contradicted works/search. v1 declares no olang=
+		// parameter: this lane is always the whole population.
+		OLang: service.PublicOLang{All: true},
 	}
 	switch sort := c.Query("sort"); sort {
 	case "", "id":

--- a/apps/api/internal/platform/catalog/handler/public_params_test.go
+++ b/apps/api/internal/platform/catalog/handler/public_params_test.go
@@ -128,6 +128,31 @@ func TestPublicWorksListIDsFilter(t *testing.T) {
 	assert.Equal(t, 200, code, "100 ids is the ceiling, not one past it")
 }
 
+// Pins the incident recorded on WorksList's OLang: for three days the zero
+// PublicOLang gated the whole v1 works lane to ja+zh, so a ko/en work was
+// findable via works/search yet absent from browse and works?ids=.
+func TestPublicWorksListSpansEveryOLang(t *testing.T) {
+	db := openCatalogTestDB(t)
+	seedPublicWorks(t, db, 2)
+	ko := model.CatalogWork{
+		MediumID: 1, OLang: "ko", DisplayName: "Korean Fan Game",
+		ContentRating: model.ContentRatingAllAges, Status: model.WorkStatusLive,
+	}
+	require.NoError(t, db.Create(&ko).Error)
+	app := publicApp(db)
+
+	code, body := getJSON(t, app, "/v1/catalog/works")
+	require.Equal(t, 200, code)
+	assert.Len(t, body["data"].(map[string]any)["items"], 3,
+		"the v1 browse lane is the whole population, every olang")
+
+	code, body = getJSON(t, app, "/v1/catalog/works?ids="+itoa(ko.ID))
+	require.Equal(t, 200, code)
+	items := body["data"].(map[string]any)["items"].([]any)
+	require.Len(t, items, 1)
+	assert.Equal(t, float64(ko.ID), items[0].(map[string]any)["id"])
+}
+
 func seedPublicTags(t *testing.T, db *gorm.DB, n int) []int64 {
 	t.Helper()
 	for _, tbl := range []string{"catalog_tag_intro", "catalog_work_tag", "catalog_tag_source_map", "catalog_tag"} {


### PR DESCRIPTION
Fixes the forum's short-page report: `/api/galgame` pages hydrated through `GET /v1/catalog/works?ids=` came back light (949/960 rows over the first 40 pages), and on the same v1 face `works/search?q=Danganronpa Mauve` found work 47230 while `works?ids=47230` did not.

## Root cause: an 08-24 regression, not a v1 design

`2f326114` (the v2 works-filter wave) added `OLang PublicOLang` to the shared `service.WorksListFilter` and applied its predicate unconditionally in `worksListWhere`. The zero `PublicOLang` curates to `(olang = 'ja' OR olang LIKE 'zh%')` — the calendar's home population. The v2 handler passes `All: true` explicitly; **the v1 fiber handler was never updated**, so its zero value silently flipped the entire `/v1/catalog/works` route — default browse, `ids=` batch-hydrate, and the `status=pending` moderation queue — from "whole population" to "ja+zh only". v1 declares no `olang=` parameter, so callers had no escape hatch.

works/search was unaffected (its own filter defaults to `All: true`), which is why the two v1 faces contradicted each other.

Scale on the current catalog copy: 25,120 live works are outside ja+zh, 168 of them kungal-claimed live — work 47230 is one (olang=`ko`). Every existing v1 list fixture used `OLang: "ja"`, so no test went red when the gate landed.

## Fix

`PublicHandler.WorksList` now sets `OLang: service.PublicOLang{All: true}`, restoring the pre-`2f326114` population — the contract the route's docs still describe, and the same default as the v2 works lane. No wire or spec change: v1 gains no new parameter, `public-openapi.yaml` is untouched.

## Tests

- New `TestPublicWorksListSpansEveryOLang` seeds a `ko` work beside the ja fixtures and pins both arms: the default browse lists it and `ids=` returns it. Verified red on the unfixed handler (both arms empty), green with the fix.
- Full `catalog` + `apiv2` suites green on a fresh ephemeral DB, single writer, `-count=1 -p 1`.

Zero migrations: no model or DDL change.
