### PR TITLE
fix(catalog): rate-limit the v2 user plane per user, not per egress IP

### DIFF
--- a/apps/api/internal/platform/apiv2/handler/collection.go
+++ b/apps/api/internal/platform/apiv2/handler/collection.go
@@ -208,16 +208,33 @@ func withIdent(ctx context.Context, p *problem.Problem) *problem.Problem {
 }
 
 func credentialLimitIdentity(c fiber.Ctx) (protocol.LimitIdentity, bool) {
-	cred := devapi.CredentialFrom(c)
-	if cred == nil {
-		return protocol.LimitIdentity{}, false
+	if cred := devapi.CredentialFrom(c); cred != nil {
+		rate, unlimited := cred.EffectiveRate()
+		quota, _ := cred.EffectiveQuota()
+		return protocol.LimitIdentity{
+			Key:  "k" + strconv.FormatUint(uint64(cred.KeyID), 10),
+			Rate: rate, Quota: quota, Unlimited: unlimited,
+		}, true
 	}
-	rate, unlimited := cred.EffectiveRate()
-	quota, _ := cred.EffectiveQuota()
-	return protocol.LimitIdentity{
-		Key:  "k" + strconv.FormatUint(uint64(cred.KeyID), 10),
-		Rate: rate, Quota: quota, Unlimited: unlimited,
-	}, true
+	// A user token authenticates but carries no application key, so this used to
+	// fall through to the anonymous per-IP bucket. A first-party backend relays
+	// every logged-in user's /v2/me call from one egress IP, so the whole site
+	// shared one 10k/day quota: the forum's user plane answered "Daily quota
+	// exceeded." from 2026-08-27T22:46Z on, re-tripping after each midnight reset.
+	var uid int64
+	switch id := c.Locals("user_id").(type) {
+	case uint:
+		uid = int64(id)
+	case int64:
+		uid = id
+	}
+	if uid > 0 {
+		return protocol.LimitIdentity{
+			Key:  "u" + strconv.FormatInt(uid, 10),
+			Rate: protocol.RatePerMinute, Quota: protocol.QuotaPerDay,
+		}, true
+	}
+	return protocol.LimitIdentity{}, false
 }
 
 func catalogAuth(lookup func(context.Context, string) (*devapi.Credential, error)) fiber.Handler {

--- a/apps/api/internal/platform/apiv2/handler/limit_identity_test.go
+++ b/apps/api/internal/platform/apiv2/handler/limit_identity_test.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"api/internal/platform/apiv2/protocol"
+	"api/internal/platform/devapi"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func limitIdentityFor(t *testing.T, prepare func(fiber.Ctx)) (protocol.LimitIdentity, bool) {
+	t.Helper()
+	app := fiber.New()
+	var got protocol.LimitIdentity
+	var ok bool
+	app.Get("/probe", func(c fiber.Ctx) error {
+		prepare(c)
+		got, ok = credentialLimitIdentity(c)
+		return c.SendString("done")
+	})
+	resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/probe", nil))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	return got, ok
+}
+
+func TestLimitIdentityUserTokenGetsOwnBucket(t *testing.T) {
+	id, ok := limitIdentityFor(t, func(c fiber.Ctx) {
+		c.Locals("user_id", int64(7))
+	})
+	require.True(t, ok)
+	require.Equal(t, "u7", id.Key)
+	require.Equal(t, protocol.RatePerMinute, id.Rate)
+	require.Equal(t, protocol.QuotaPerDay, id.Quota)
+	require.False(t, id.Unlimited)
+
+	id, ok = limitIdentityFor(t, func(c fiber.Ctx) {
+		c.Locals("user_id", uint(9))
+	})
+	require.True(t, ok)
+	require.Equal(t, "u9", id.Key)
+}
+
+func TestLimitIdentityKeyWinsOverUser(t *testing.T) {
+	id, ok := limitIdentityFor(t, func(c fiber.Ctx) {
+		devapi.WithCredential(c, &devapi.Credential{KeyID: 53, Tier: devapi.TierInternal})
+		c.Locals("user_id", int64(7))
+	})
+	require.True(t, ok)
+	require.Equal(t, "k53", id.Key)
+	require.True(t, id.Unlimited)
+}
+
+func TestLimitIdentityAnonymousStaysDefault(t *testing.T) {
+	_, ok := limitIdentityFor(t, func(fiber.Ctx) {})
+	require.False(t, ok, "no credential and no user: fall to the per-IP default")
+}

--- a/docs/catalog/v2-implementation-notes.md
+++ b/docs/catalog/v2-implementation-notes.md
@@ -115,6 +115,8 @@ Date: 2026-08-24, GA declared 2026-08-25 (stage 9); news write face added 2026-0
 
 46. **`/v2/catalog/tags` honors `has_works=`** (2026-08-27). Deviation 30 restored `has_works=` on the companies lane and left the tags lane behind, though v1 carries it on both and `TagsListFilter.HasWorks` already existed — so the flag was silently ignored (the huma input never declared it) and a tag index drowned in zero-work rows. Declared and wired exactly like companies: `parse.Bool` (bogus → 400), same nsfw-gated `work_count > 0` predicate, total converges with the filter.
 
+47. **User-token traffic is rate-limited per user, not per IP** (2026-08-28). Deviation 29 moved keyed traffic onto per-key tier limits and left "any request that never authenticates" on the per-IP default — but a user access token *does* authenticate and still resolved no limiter identity, so the whole `/v2/me` and `/v2/moderation` plane fell into the anonymous bucket. A first-party backend relays every logged-in user's call from one egress IP: the forum's entire user plane shared a single `100/min + 10k/day` bucket and answered 429 `QUOTA_EXCEEDED` from 2026-08-27T22:46Z, re-tripping after each UTC-midnight reset (`v2:quota:<forum egress IP>` measured 17,848 by 07:35Z the next day). Now `credentialLimitIdentity` falls through to the authenticated uid — key `u<uid>`, the default `100/min + 10,000/day` per user. Anonymous keyless paths (problems, vocabularies, stats, schemas, openapi.json) keep the per-IP default; an application key still wins over a uid when both are present.
+
 ## Stage 6 write
 
 | Route | Bind |


### PR DESCRIPTION
Production incident, ongoing: since 2026-08-27T22:46Z every `/v2/me/*` call through the forum backend answers **429 `QUOTA_EXCEEDED` "Daily quota exceeded."** once the day's bucket fills, re-tripping after each UTC-midnight reset. Verified on prod redis: `v2:quota:10.0.1.110:2026-08-28 = 17848` at 07:35Z, and `10.0.1.110` is `kun-visual-novel-forum-…-kungal-api-1`'s overlay IP.

**Root cause**: deviation 29 (#79) moved keyed traffic onto per-key tier limits and left "any request that never authenticates" on the per-IP default — but a user access token *does* authenticate and still resolved no limiter identity, so the whole `/v2/me` + `/v2/moderation` plane fell into the anonymous bucket. A first-party backend relays every logged-in user from one egress IP (no CF-Connecting-IP on internal S2S, peer fallback), so an entire site shared one `100/min + 10k/day` bucket.

**Fix**: `credentialLimitIdentity` falls through to the authenticated uid — bucket `u<uid>`, default `100/min + 10,000/day` *per user*. An application key still wins when both are present (pinned); anonymous keyless paths (problems, vocabularies, stats, schemas, openapi.json) keep the per-IP default (pinned).

No spec change, no migration. Full `apiv2/...` tree green on a fresh ephemeral DB (`REQUIRE_DB_TESTS=1 -count=1 -p 1`). Deviation 47 in the implementation notes.