### PR TITLE
feat(catalog): standing work-dedup pipeline, mint-lane dup guard, hardened import gate

### DIFF
--- a/apps/api/cmd/work-dedup/census.go
+++ b/apps/api/cmd/work-dedup/census.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"api/internal/platform/catalog/service"
+
+	"gorm.io/gorm"
+)
+
+type pairRow struct {
+	A              int64      `gorm:"column:a"`
+	B              int64      `gorm:"column:b"`
+	SharedNorm     string     `gorm:"column:shared_norm"`
+	SharedNorms    int        `gorm:"column:shared_norms"`
+	LaneA          string     `gorm:"column:lane_a"`
+	LaneB          string     `gorm:"column:lane_b"`
+	AnchorsA       int        `gorm:"column:anchors_a"`
+	AnchorsB       int        `gorm:"column:anchors_b"`
+	SiteA          *string    `gorm:"column:site_a"`
+	SiteB          *string    `gorm:"column:site_b"`
+	NameA          string     `gorm:"column:name_a"`
+	NameB          string     `gorm:"column:name_b"`
+	AnchorConflict bool       `gorm:"column:anchor_conflict"`
+	RelConflict    bool       `gorm:"column:release_conflict"`
+	RefOverlap     bool       `gorm:"column:ref_overlap"`
+	DateA          *time.Time `gorm:"column:date_a"`
+	DateB          *time.Time `gorm:"column:date_b"`
+	LabelOverlap   bool       `gorm:"column:label_overlap"`
+}
+
+// pairQuerySQL is the standing duplicate detector: every pair of live works
+// sharing a folded official-title/display_name norm, scored with the
+// corroborating facts the verdict needs. Work-level identity anchors drive
+// lanes and conflicts; dlsite identity lives on releases (entity_type 6), so
+// the dlsite lane and the release-level conflict/overlap read through
+// catalog_release — a work-level-only read files the whole dlsite family
+// under 'other' and misses every edition split.
+func pairQuerySQL() string {
+	return `
+WITH lw AS (
+  SELECT id, site, display_name FROM catalog_work WHERE deleted_at IS NULL
+),
+norms AS (
+  SELECT DISTINCT work_id, n FROM (` + service.WorkDupeCorpusSQL() + `) c
+),
+pairs AS (
+  SELECT a.work_id AS a, b.work_id AS b, min(a.n) AS shared_norm, count(*) AS shared_norms
+  FROM norms a JOIN norms b ON a.n = b.n AND a.work_id < b.work_id
+  WHERE length(a.n) >= 4
+  GROUP BY a.work_id, b.work_id
+),
+wanchor AS (
+  SELECT entity_id AS work_id, source_id, external_id
+  FROM catalog_external_ref
+  WHERE entity_type = 5 AND link_kind = 0 AND dead_at IS NULL
+),
+ranchor AS (
+  SELECT rel.work_id, r.source_id, r.external_id
+  FROM catalog_external_ref r
+  JOIN catalog_release rel ON rel.id = r.entity_id AND rel.deleted_at IS NULL
+  WHERE r.entity_type = 6 AND r.link_kind = 0 AND r.dead_at IS NULL
+),
+lane AS (
+  SELECT lw.id,
+    CASE WHEN lw.site IS NOT NULL AND lw.site <> '' THEN 'kungal'
+         WHEN EXISTS (SELECT 1 FROM wanchor x WHERE x.work_id = lw.id AND x.source_id = 2) THEN 'vndb'
+         WHEN EXISTS (SELECT 1 FROM wanchor x WHERE x.work_id = lw.id AND x.source_id = 3) THEN 'bgm'
+         WHEN EXISTS (SELECT 1 FROM wanchor x WHERE x.work_id = lw.id AND x.source_id = 5) THEN 'eg'
+         WHEN EXISTS (SELECT 1 FROM ranchor x WHERE x.work_id = lw.id AND x.source_id = 4) THEN 'dlsite'
+         ELSE 'other' END AS lane,
+    (SELECT count(*) FROM wanchor x WHERE x.work_id = lw.id) AS anchors
+  FROM lw
+),
+wdate AS (
+  SELECT work_id, min(make_date(released_y, coalesce(nullif(released_m,0),1), coalesce(nullif(released_d,0),1))) AS d
+  FROM catalog_release
+  WHERE deleted_at IS NULL AND released_y IS NOT NULL
+  GROUP BY work_id
+),
+bgmdate AS (
+  SELECT r.work_id, min(s.date::date) AS d
+  FROM wanchor r
+  JOIN src_bangumi.subject s ON s.id = r.external_id::bigint
+  WHERE r.source_id = 3 AND s.date ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+  GROUP BY r.work_id
+)
+SELECT p.a, p.b, p.shared_norm, p.shared_norms,
+  la.lane AS lane_a, lb.lane AS lane_b,
+  la.anchors AS anchors_a, lb.anchors AS anchors_b,
+  wa.site AS site_a, wb.site AS site_b,
+  wa.display_name AS name_a, wb.display_name AS name_b,
+  EXISTS (SELECT 1 FROM wanchor x JOIN wanchor y ON y.source_id = x.source_id AND y.external_id <> x.external_id
+          WHERE x.work_id = p.a AND y.work_id = p.b) AS anchor_conflict,
+  (EXISTS (SELECT 1 FROM ranchor x JOIN ranchor y ON y.source_id = x.source_id AND y.external_id <> x.external_id
+           WHERE x.work_id = p.a AND y.work_id = p.b)
+   AND NOT EXISTS (SELECT 1 FROM ranchor x JOIN ranchor y ON y.source_id = x.source_id AND y.external_id = x.external_id
+                   WHERE x.work_id = p.a AND y.work_id = p.b)) AS release_conflict,
+  (EXISTS (SELECT 1 FROM catalog_external_ref x
+           JOIN catalog_external_ref y ON y.source_id = x.source_id AND y.external_id = x.external_id
+           WHERE x.entity_type = 5 AND x.entity_id = p.a AND x.dead_at IS NULL
+             AND y.entity_type = 5 AND y.entity_id = p.b AND y.dead_at IS NULL)
+   OR EXISTS (SELECT 1 FROM ranchor x JOIN ranchor y ON y.source_id = x.source_id AND y.external_id = x.external_id
+              WHERE x.work_id = p.a AND y.work_id = p.b)) AS ref_overlap,
+  coalesce(da.d, ba.d) AS date_a,
+  coalesce(dbb.d, bb.d) AS date_b,
+  EXISTS (SELECT 1 FROM catalog_work_label x JOIN catalog_work_label y ON y.label_id = x.label_id
+          WHERE x.work_id = p.a AND y.work_id = p.b) AS label_overlap
+FROM pairs p
+JOIN lane la ON la.id = p.a
+JOIN lane lb ON lb.id = p.b
+JOIN lw wa ON wa.id = p.a
+JOIN lw wb ON wb.id = p.b
+LEFT JOIN wdate da ON da.work_id = p.a
+LEFT JOIN wdate dbb ON dbb.work_id = p.b
+LEFT JOIN bgmdate ba ON ba.work_id = p.a
+LEFT JOIN bgmdate bb ON bb.work_id = p.b
+ORDER BY p.a, p.b`
+}
+
+type census struct {
+	rows     []pairRow
+	verdicts []bucket
+	groups   []mergeGroup
+}
+
+func buildCensus(ctx context.Context, db *gorm.DB) (*census, error) {
+	var rows []pairRow
+	if err := db.WithContext(ctx).Raw(pairQuerySQL()).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	verdicts, groups := classify(rows)
+	return &census{rows: rows, verdicts: verdicts, groups: groups}, nil
+}
+
+func (c *census) verdictByPair() map[[2]int64]bucket {
+	out := make(map[[2]int64]bucket, len(c.rows))
+	for i := range c.rows {
+		out[[2]int64{c.rows[i].A, c.rows[i].B}] = c.verdicts[i]
+	}
+	return out
+}
+
+func (c *census) rowByPair() map[[2]int64]pairRow {
+	out := make(map[[2]int64]pairRow, len(c.rows))
+	for _, r := range c.rows {
+		out[[2]int64{r.A, r.B}] = r
+	}
+	return out
+}

--- a/apps/api/cmd/work-dedup/execute.go
+++ b/apps/api/cmd/work-dedup/execute.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/service"
+
+	"gorm.io/gorm"
+)
+
+func runExecute(ctx context.Context, db *gorm.DB, w io.Writer, merge *service.MergeService,
+	resolve *service.ResolveService, actor int64, note string, limit int, run bool) error {
+	var props []model.CatalogMergeProposal
+	q := db.WithContext(ctx).
+		Where("status = ? AND execute_after <= now() AND note LIKE ? AND entity_type = ?",
+			model.ProposalStatusApproved, "%"+note+"%", model.EntityTypeWork).
+		Order("id")
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+	if err := q.Find(&props).Error; err != nil {
+		return err
+	}
+	var executed, superseded, residual, errs int
+	for _, p := range props {
+		rsrc, srcMoved, err := resolve.Resolve(ctx, p.EntityType, p.SourceEntityID)
+		if err != nil {
+			fmt.Fprintf(w, "  proposal %d: resolve source ERROR %v\n", p.ID, err)
+			errs++
+			continue
+		}
+		rtgt, tgtMoved, err := resolve.Resolve(ctx, p.EntityType, p.TargetEntityID)
+		if err != nil {
+			fmt.Fprintf(w, "  proposal %d: resolve target ERROR %v\n", p.ID, err)
+			errs++
+			continue
+		}
+		switch {
+		case rsrc == rtgt:
+			superseded++
+			if run {
+				if err := merge.RejectMerge(ctx, p.ID, actor, fmt.Sprintf(
+					"chain-superseded: both endpoints resolve to %d — merged by proxy earlier this wave", rsrc)); err != nil {
+					fmt.Fprintf(w, "  proposal %d: reject ERROR %v\n", p.ID, err)
+					superseded--
+					errs++
+				}
+			}
+		case srcMoved || tgtMoved:
+			residual++
+			if run {
+				if err := merge.RejectMerge(ctx, p.ID, actor, fmt.Sprintf(
+					"chain-residual: endpoints moved (%d→%d, %d→%d) — re-covered by the next detect pass on live rows",
+					p.SourceEntityID, rsrc, p.TargetEntityID, rtgt)); err != nil {
+					fmt.Fprintf(w, "  proposal %d: reject ERROR %v\n", p.ID, err)
+					residual--
+					errs++
+				}
+			}
+		default:
+			if run {
+				if err := merge.ExecuteMerge(ctx, p.ID, &actor); err != nil {
+					fmt.Fprintf(w, "  proposal %d: execute ERROR %v\n", p.ID, err)
+					errs++
+					continue
+				}
+			}
+			executed++
+		}
+	}
+	mode := "DRY-RUN (pass -run to execute)"
+	if run {
+		mode = "APPLIED"
+	}
+	fmt.Fprintf(w, "%s [execute] note=%s cooled=%d executed=%d chain_superseded=%d chain_residual=%d errors=%d\n",
+		mode, note, len(props), executed, superseded, residual, errs)
+	if errs > 0 {
+		return fmt.Errorf("%d executions failed", errs)
+	}
+	return nil
+}

--- a/apps/api/cmd/work-dedup/main.go
+++ b/apps/api/cmd/work-dedup/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"api/internal/infrastructure/database"
+	"api/internal/platform/catalog/repository"
+	"api/internal/platform/catalog/service"
+	"api/pkg/config"
+	"api/pkg/logger"
+
+	"github.com/joho/godotenv"
+	"gorm.io/gorm"
+)
+
+const waveTagW1 = "rule:work-dedup w1"
+
+// exitNewPairs is watch's -fail-on-new exit code, distinct from 1 (error) so
+// the cron wrapper can tell "the detector found work" from "the detector broke".
+const exitNewPairs = 3
+
+func main() {
+	mode := flag.String("mode", "census", "census | seed | propose | execute | watch")
+	actor := flag.Int64("actor", 0, "operator user id recorded on candidates/proposals (required for seed/propose/execute)")
+	run := flag.Bool("run", false, "write (default: dry-run preview)")
+	limit := flag.Int("limit", 0, "propose: max merge groups this run; execute: max proposals this run (0 = all)")
+	note := flag.String("note", waveTagW1, "wave note tag stamped on proposals and matched by -mode execute")
+	csvPath := flag.String("csv", "", "census: also export the full pair dossier to this CSV path")
+	dsn := flag.String("dsn", "", "catalog DSN override (default: KUN_CATALOG_PG_* env)")
+	failOnNew := flag.Bool("fail-on-new", false, fmt.Sprintf("watch: exit %d when undecided new pairs exist", exitNewPairs))
+	flag.Parse()
+
+	writes := *mode == "seed" || *mode == "propose" || *mode == "execute"
+	if writes && *actor <= 0 {
+		fmt.Fprintln(os.Stderr, "-actor <user-id> is required for seed/propose/execute")
+		os.Exit(2)
+	}
+
+	db, err := openDB(*dsn)
+	if err != nil {
+		slog.Error("catalog db connect", "error", err)
+		os.Exit(1)
+	}
+	ctx := context.Background()
+	resolve := service.NewResolveService(repository.NewRedirectRepository(db))
+	merge := service.NewMergeService(db, resolve,
+		repository.NewProposalRepository(db), repository.NewRevisionRepository(db))
+
+	switch *mode {
+	case "census":
+		err = runCensus(ctx, db, os.Stdout, *csvPath)
+	case "seed":
+		err = runSeed(ctx, db, os.Stdout, *actor, *run)
+	case "propose":
+		err = runPropose(ctx, db, os.Stdout, merge, *actor, *note, *limit, *run)
+	case "execute":
+		err = runExecute(ctx, db, os.Stdout, merge, resolve, *actor, *note, *limit, *run)
+	case "watch":
+		var fresh int
+		fresh, err = runWatch(ctx, db, os.Stdout)
+		if err == nil && *failOnNew && fresh > 0 {
+			os.Exit(exitNewPairs)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown mode %q\n", *mode)
+		os.Exit(2)
+	}
+	if err != nil {
+		slog.Error("work-dedup failed", "mode", *mode, "error", err)
+		os.Exit(1)
+	}
+}
+
+func openDB(dsn string) (*gorm.DB, error) {
+	if dsn != "" {
+		logger.Init("development")
+		return database.OpenJob(dsn)
+	}
+	_ = godotenv.Load("apps/api/.env")
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+	logger.Init(cfg.Server.Env)
+	catalogDB, err := database.NewPostgresDB(cfg.CatalogDatabase)
+	if err != nil {
+		return nil, err
+	}
+	return catalogDB.DB(), nil
+}

--- a/apps/api/cmd/work-dedup/pipeline_test.go
+++ b/apps/api/cmd/work-dedup/pipeline_test.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"api/internal/platform/catalog/migrate"
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/repository"
+	"api/internal/platform/catalog/seed"
+	"api/internal/platform/catalog/service"
+	srcb "api/internal/platform/catalog/srcbangumi"
+	"api/internal/testsupport/dbtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var testDB *gorm.DB
+
+// TestMain keeps running when there is no database: the verdict table tests in
+// this package are pure Go, and exiting early for a missing DSN would drop them
+// from the DB-less `unit` CI job without any tell.
+func TestMain(m *testing.M) {
+	if dsn, ok := dbtest.DSN(); ok {
+		db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "FAIL: cannot connect to the assigned test database")
+			os.Exit(1)
+		}
+		for _, step := range []func(*gorm.DB) error{migrate.Run, seed.Run, srcb.EnsureSchema} {
+			if err := step(db); err != nil {
+				fmt.Fprintf(os.Stderr, "FAIL: catalog test setup: %v\n", err)
+				os.Exit(1)
+			}
+		}
+		testDB = db
+	}
+	os.Exit(m.Run())
+}
+
+func requireDB(t *testing.T) {
+	t.Helper()
+	if testDB == nil {
+		dbtest.Skip(t)
+	}
+}
+
+func cleanPipeline(t *testing.T) {
+	t.Helper()
+	for _, table := range []string{
+		"catalog_match_candidate", "catalog_merge_proposal", "catalog_redirect",
+		"catalog_external_ref", "catalog_revision", "catalog_entity_usage",
+		"catalog_work_label", "catalog_work_title", "catalog_release", "catalog_work",
+		"src_bangumi.subject",
+	} {
+		require.NoError(t, testDB.Exec("TRUNCATE "+table+" RESTART IDENTITY CASCADE").Error)
+	}
+}
+
+func galgameMedium(t *testing.T) int16 {
+	t.Helper()
+	var id int16
+	require.NoError(t, testDB.Raw(`SELECT id FROM catalog_medium WHERE key = 'galgame'`).Scan(&id).Error)
+	require.NotZero(t, id, "galgame medium is not seeded")
+	return id
+}
+
+func mkWork(t *testing.T, medium int16, name string, site *string) int64 {
+	t.Helper()
+	w := &model.CatalogWork{
+		MediumID: medium, OLang: "ja", DisplayName: name,
+		ContentRating: model.ContentRatingAllAges, Status: model.WorkStatusLive,
+	}
+	if site != nil {
+		w.Site = site
+		product := int64(900000 + len(name))
+		w.ProductWorkID = &product
+	}
+	require.NoError(t, testDB.Create(w).Error)
+	return w.ID
+}
+
+func mkTitle(t *testing.T, workID int64, title string) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&model.CatalogWorkTitle{
+		WorkID: workID, Lang: "ja", Title: title, Kind: model.WorkTitleKindOfficial,
+	}).Error)
+}
+
+func mkAnchor(t *testing.T, workID int64, sourceID int16, externalID string) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&model.CatalogExternalRef{
+		EntityType: model.EntityTypeWork, EntityID: workID, SourceID: sourceID,
+		ExternalID: externalID, LinkKind: model.LinkKindExact, MatchedBy: "test:work-dedup",
+	}).Error)
+}
+
+func mkRelease(t *testing.T, workID int64, y, m, d int16) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&model.CatalogRelease{
+		WorkID: workID, Kind: model.ReleaseKindDefault,
+		ReleasedY: &y, ReleasedM: &m, ReleasedD: &d,
+	}).Error)
+}
+
+func candidateStatus(t *testing.T, a, b int64) int16 {
+	t.Helper()
+	var status *int16
+	require.NoError(t, testDB.Raw(
+		`SELECT status FROM catalog_match_candidate WHERE entity_type = ? AND a_id = ? AND b_id = ?`,
+		model.EntityTypeWork, min(a, b), max(a, b)).Scan(&status).Error)
+	require.NotNil(t, status, "no candidate filed for (%d,%d)", a, b)
+	return *status
+}
+
+func countRows(t *testing.T, query string, args ...any) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, testDB.Raw(query, args...).Scan(&n).Error)
+	return n
+}
+
+func TestWorkDedupPipeline(t *testing.T) {
+	requireDB(t)
+	cleanPipeline(t)
+	ctx := context.Background()
+	medium := galgameMedium(t)
+	kungal := "kungal"
+	const actor = int64(4242)
+
+	// K1 is a claim carrying an official title; M1 is the import-minted twin
+	// whose only identity string is a display_name spelled with extra spaces.
+	k1 := mkWork(t, medium, "K1クレーム作品テスト", &kungal)
+	mkTitle(t, k1, "重複タイトルテスト検証")
+	mkRelease(t, k1, 2015, 8, 10)
+	m1 := mkWork(t, medium, "重複 タイトル テスト 検証", nil)
+	mkAnchor(t, m1, 3, "777")
+	mkRelease(t, m1, 2015, 9, 9)
+
+	k2 := mkWork(t, medium, "K2アンカー衝突元作品", nil)
+	mkTitle(t, k2, "衝突アンカー作品検証")
+	mkAnchor(t, k2, 3, "111")
+	m2 := mkWork(t, medium, "M2アンカー衝突先作品", nil)
+	mkTitle(t, m2, "衝突アンカー作品検証")
+	mkAnchor(t, m2, 3, "222")
+
+	k3 := mkWork(t, medium, "K3年違い元作品テスト", nil)
+	mkTitle(t, k3, "年違い作品検証テスト")
+	mkRelease(t, k3, 2015, 5, 1)
+	m3 := mkWork(t, medium, "M3年違い先作品テスト", nil)
+	mkTitle(t, m3, "年違い作品検証テスト")
+	mkRelease(t, m3, 2019, 5, 1)
+
+	c, err := buildCensus(ctx, testDB)
+	require.NoError(t, err)
+	require.Len(t, c.rows, 3, "three pairs: %+v", c.rows)
+	verdicts := c.verdictByPair()
+	assert.Equal(t, bucketAuto, verdicts[[2]int64{k1, m1}])
+	assert.Equal(t, bucketAnchorConflict, verdicts[[2]int64{k2, m2}])
+	assert.Equal(t, bucketDateClash, verdicts[[2]int64{k3, m3}])
+	require.Len(t, c.groups, 1)
+	assert.Equal(t, k1, c.groups[0].survivor, "the claimed work survives")
+
+	resolve := service.NewResolveService(repository.NewRedirectRepository(testDB))
+	merge := service.NewMergeService(testDB, resolve,
+		repository.NewProposalRepository(testDB), repository.NewRevisionRepository(testDB))
+	var out bytes.Buffer
+
+	require.NoError(t, runSeed(ctx, testDB, &out, actor, false))
+	assert.Zero(t, countRows(t, `SELECT count(*) FROM catalog_match_candidate`), "dry seed writes nothing")
+
+	out.Reset()
+	require.NoError(t, runSeed(ctx, testDB, &out, actor, true))
+	assert.Equal(t, model.CandidateStatusPending, candidateStatus(t, k1, m1))
+	assert.Equal(t, model.CandidateStatusNeedsManual, candidateStatus(t, k2, m2))
+	assert.Equal(t, model.CandidateStatusNeedsManual, candidateStatus(t, k3, m3))
+
+	out.Reset()
+	require.NoError(t, runPropose(ctx, testDB, &out, merge, actor, waveTagW1, 0, false))
+	assert.Contains(t, out.String(), fmt.Sprintf("PLAN %d <- %d", k1, m1))
+	assert.Zero(t, countRows(t, `SELECT count(*) FROM catalog_merge_proposal`), "dry propose writes nothing")
+	assert.Equal(t, model.CandidateStatusPending, candidateStatus(t, k1, m1))
+
+	out.Reset()
+	require.NoError(t, runPropose(ctx, testDB, &out, merge, actor, waveTagW1, 0, true))
+	var proposal model.CatalogMergeProposal
+	require.NoError(t, testDB.Where("entity_type = ?", model.EntityTypeWork).First(&proposal).Error)
+	assert.Equal(t, m1, proposal.SourceEntityID)
+	assert.Equal(t, k1, proposal.TargetEntityID)
+	assert.Equal(t, model.ProposalStatusApproved, proposal.Status)
+	assert.NotNil(t, proposal.ExecuteAfter, "approval must arm the 48h cooling window")
+	assert.Contains(t, proposal.Note, waveTagW1)
+	assert.Contains(t, proposal.Note, "ev=date(2015-08-10~2015-09-09)")
+	assert.Contains(t, proposal.Note, "norm=重複タイトルテスト検証")
+	assert.Equal(t, model.CandidateStatusAccepted, candidateStatus(t, k1, m1))
+	assert.Equal(t, model.CandidateStatusNeedsManual, candidateStatus(t, k2, m2))
+	assert.Equal(t, model.CandidateStatusNeedsManual, candidateStatus(t, k3, m3))
+
+	out.Reset()
+	require.NoError(t, runExecute(ctx, testDB, &out, merge, resolve, actor, waveTagW1, 0, true))
+	assert.Contains(t, out.String(), "cooled=0", "an approved proposal must wait out its cooling window")
+
+	require.NoError(t, testDB.Exec(`UPDATE catalog_merge_proposal SET execute_after = now() - interval '1 hour'`).Error)
+	out.Reset()
+	require.NoError(t, runExecute(ctx, testDB, &out, merge, resolve, actor, waveTagW1, 0, true))
+	assert.Equal(t, int64(1), countRows(t,
+		`SELECT count(*) FROM catalog_redirect WHERE entity_type = ? AND old_id = ? AND current_id = ?`,
+		model.EntityTypeWork, m1, k1))
+	assert.Equal(t, int64(1), countRows(t,
+		`SELECT count(*) FROM catalog_work WHERE id = ? AND deleted_at IS NOT NULL`, m1))
+	require.NoError(t, testDB.First(&proposal, proposal.ID).Error)
+	assert.Equal(t, model.ProposalStatusExecuted, proposal.Status)
+
+	out.Reset()
+	fresh, err := runWatch(ctx, testDB, &out)
+	require.NoError(t, err)
+	assert.Zero(t, fresh)
+	assert.Contains(t, out.String(), "pairs=2 new=0 pending=0 needs_manual=2")
+	assert.Contains(t, out.String(), "merged=1")
+
+	out.Reset()
+	require.NoError(t, runPropose(ctx, testDB, &out, merge, actor, waveTagW1, 0, true))
+	assert.Equal(t, int64(1), countRows(t, `SELECT count(*) FROM catalog_merge_proposal`),
+		"a second propose pass must not re-open the merge")
+
+	// ExecuteMerge deletes the pair's own candidate row, so the superseded lane
+	// is reached by a candidate filed AFTER the merge — a detector pass that
+	// still had the pre-merge pair in hand, or an operator re-filing it.
+	require.NoError(t, testDB.Create(&model.CatalogMatchCandidate{
+		EntityType: model.EntityTypeWork, AID: min(k1, m1), BID: max(k1, m1),
+		Reason: model.CandidateReasonNameNormEqual, Status: model.CandidateStatusPending,
+	}).Error)
+	out.Reset()
+	require.NoError(t, runPropose(ctx, testDB, &out, merge, actor, waveTagW1, 0, true))
+	assert.Contains(t, out.String(), "superseded=1")
+	assert.Equal(t, model.CandidateStatusAccepted, candidateStatus(t, k1, m1))
+	assert.Equal(t, int64(1), countRows(t, `SELECT count(*) FROM catalog_merge_proposal`))
+}
+
+func TestWatchReportsUndecidedPairs(t *testing.T) {
+	requireDB(t)
+	cleanPipeline(t)
+	ctx := context.Background()
+	medium := galgameMedium(t)
+
+	a := mkWork(t, medium, "監視対象作品エー", nil)
+	mkTitle(t, a, "監視新規ペア検証")
+	mkAnchor(t, a, 3, "555")
+	b := mkWork(t, medium, "監視対象作品ビー", nil)
+	mkTitle(t, b, "監視 新規 ペア 検証")
+	mkAnchor(t, b, 3, "556")
+
+	var out bytes.Buffer
+	fresh, err := runWatch(ctx, testDB, &out)
+	require.NoError(t, err)
+	assert.Equal(t, 1, fresh, "an unfiled pair is the finding the cron alerts on")
+	assert.Contains(t, out.String(), "pairs=1 new=1")
+	assert.Contains(t, out.String(), fmt.Sprintf("new: %d<->%d", min(a, b), max(a, b)))
+
+	require.NoError(t, runSeed(ctx, testDB, &out, 1, true))
+	out.Reset()
+	fresh, err = runWatch(ctx, testDB, &out)
+	require.NoError(t, err)
+	assert.Zero(t, fresh, "a filed pair is no longer new")
+	assert.Contains(t, out.String(), "needs_manual=1")
+}
+
+func TestProposeLimitLeavesTheRestPending(t *testing.T) {
+	requireDB(t)
+	cleanPipeline(t)
+	ctx := context.Background()
+	medium := galgameMedium(t)
+	kungal := "kungal"
+
+	mk := func(title, spaced string, y int16) (int64, int64) {
+		survivor := mkWork(t, medium, "限度テスト"+title, &kungal)
+		mkTitle(t, survivor, title)
+		mkRelease(t, survivor, y, 3, 1)
+		member := mkWork(t, medium, spaced, nil)
+		mkRelease(t, member, y, 3, 20)
+		return survivor, member
+	}
+	s1, m1 := mk("限度検証作品アルファ", "限度 検証 作品 アルファ", 2016)
+	s2, m2 := mk("限度検証作品ベータ", "限度 検証 作品 ベータ", 2017)
+
+	var out bytes.Buffer
+	require.NoError(t, runSeed(ctx, testDB, &out, 1, true))
+	out.Reset()
+	require.NoError(t, runPropose(ctx, testDB, &out, newMerge(t), 1, waveTagW1, 1, true))
+	assert.Contains(t, out.String(), "left_pending=1")
+	assert.Equal(t, int64(1), countRows(t, `SELECT count(*) FROM catalog_merge_proposal`))
+
+	first := candidateStatus(t, s1, m1)
+	second := candidateStatus(t, s2, m2)
+	assert.Equal(t, model.CandidateStatusAccepted, first)
+	assert.Equal(t, model.CandidateStatusPending, second, "the capped pair keeps its place in the queue")
+}
+
+func newMerge(t *testing.T) *service.MergeService {
+	t.Helper()
+	resolve := service.NewResolveService(repository.NewRedirectRepository(testDB))
+	return service.NewMergeService(testDB, resolve,
+		repository.NewProposalRepository(testDB), repository.NewRevisionRepository(testDB))
+}

--- a/apps/api/cmd/work-dedup/propose.go
+++ b/apps/api/cmd/work-dedup/propose.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/service"
+
+	"gorm.io/gorm"
+)
+
+const (
+	maxRedirectHops = 16
+	noteNormRunes   = 40
+)
+
+type proposeStats struct {
+	proposed, approved, superseded, needsManual, leftPending, skipped, errs int
+}
+
+func runPropose(ctx context.Context, db *gorm.DB, w io.Writer, merge *service.MergeService,
+	actor int64, note string, limit int, run bool) error {
+	c, err := buildCensus(ctx, db)
+	if err != nil {
+		return err
+	}
+	verdicts := c.verdictByPair()
+	rows := c.rowByPair()
+	groups := map[int64]*mergeGroup{}
+	for i := range c.groups {
+		g := &c.groups[i]
+		groups[g.survivor] = g
+		for _, src := range g.sources {
+			groups[src] = g
+		}
+	}
+	redirects, err := loadWorkRedirects(ctx, db)
+	if err != nil {
+		return err
+	}
+	var cands []model.CatalogMatchCandidate
+	if err := db.WithContext(ctx).
+		Where("entity_type = ? AND status = ?", model.EntityTypeWork, model.CandidateStatusPending).
+		Order("a_id, b_id").Find(&cands).Error; err != nil {
+		return err
+	}
+
+	var st proposeStats
+	flip := func(a, b int64, status int16) {
+		if !run {
+			return
+		}
+		if err := flipWorkCandidate(ctx, db, a, b, status, actor); err != nil {
+			fmt.Fprintf(w, "  candidate (%d,%d): flip ERROR %v\n", a, b, err)
+			st.errs++
+		}
+	}
+	for _, cand := range cands {
+		key := [2]int64{cand.AID, cand.BID}
+		if resolveWork(redirects, cand.AID) == resolveWork(redirects, cand.BID) {
+			st.superseded++
+			flip(cand.AID, cand.BID, model.CandidateStatusAccepted)
+			continue
+		}
+		// A pair that has dropped out of the census is NOT auto-rejected: the
+		// title edit that dissolved the collision may itself be the mistake,
+		// and a rejected candidate never comes back on its own.
+		if b, ok := verdicts[key]; !ok || b != bucketAuto {
+			st.needsManual++
+			flip(cand.AID, cand.BID, model.CandidateStatusNeedsManual)
+			continue
+		}
+		g := groups[cand.AID]
+		if g == nil || groups[cand.BID] != g || (cand.AID != g.survivor && cand.BID != g.survivor) {
+			st.leftPending++
+			continue
+		}
+		if limit > 0 && st.proposed >= limit {
+			st.leftPending++
+			continue
+		}
+		member := cand.AID
+		if member == g.survivor {
+			member = cand.BID
+		}
+		full := fmt.Sprintf("%s: norm=%s ev=%s", note,
+			truncateRunes(rows[key].SharedNorm, noteNormRunes), pairEvidence(rows[key]))
+		if !run {
+			fmt.Fprintf(w, "PLAN %d <- %d  %s\n", g.survivor, member, full)
+			st.proposed++
+			st.approved++
+			continue
+		}
+		p, err := merge.ProposeMerge(ctx, model.EntityTypeWork, member, g.survivor, actor, full)
+		if err != nil {
+			if errors.Is(err, service.ErrSameEntity) || errors.Is(err, service.ErrDuplicateOpenProposal) {
+				st.skipped++
+				flip(cand.AID, cand.BID, model.CandidateStatusAccepted)
+				continue
+			}
+			fmt.Fprintf(w, "  %d->%d: propose ERROR %v\n", member, g.survivor, err)
+			st.errs++
+			continue
+		}
+		st.proposed++
+		if err := merge.ApproveMerge(ctx, p.ID, actor); err != nil {
+			fmt.Fprintf(w, "  proposal %d: approve ERROR %v\n", p.ID, err)
+			st.errs++
+			continue
+		}
+		st.approved++
+		flip(cand.AID, cand.BID, model.CandidateStatusAccepted)
+	}
+
+	mode := "DRY-RUN (pass -run to propose+approve)"
+	if run {
+		mode = "APPLIED"
+	}
+	fmt.Fprintf(w, "%s [propose] note=%s pending=%d proposed=%d approved=%d superseded=%d needs_manual=%d left_pending=%d skipped=%d errors=%d\n",
+		mode, note, len(cands), st.proposed, st.approved, st.superseded, st.needsManual, st.leftPending, st.skipped, st.errs)
+	if st.errs > 0 {
+		return fmt.Errorf("%d candidates failed to propose/approve", st.errs)
+	}
+	return nil
+}
+
+func flipWorkCandidate(ctx context.Context, db *gorm.DB, a, b int64, status int16, actor int64) error {
+	return db.WithContext(ctx).Exec(`UPDATE catalog_match_candidate
+		SET status = ?, decided_by = ?, decided_at = now()
+		WHERE entity_type = ? AND a_id = ? AND b_id = ? AND status = ?`,
+		status, actor, model.EntityTypeWork, a, b, model.CandidateStatusPending).Error
+}
+
+func loadWorkRedirects(ctx context.Context, db *gorm.DB) (map[int64]int64, error) {
+	var rows []struct {
+		OldID     int64 `gorm:"column:old_id"`
+		CurrentID int64 `gorm:"column:current_id"`
+	}
+	if err := db.WithContext(ctx).Raw(
+		`SELECT old_id, current_id FROM catalog_redirect WHERE entity_type = ?`,
+		model.EntityTypeWork).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[int64]int64, len(rows))
+	for _, r := range rows {
+		out[r.OldID] = r.CurrentID
+	}
+	return out, nil
+}
+
+func resolveWork(redirects map[int64]int64, id int64) int64 {
+	for range maxRedirectHops {
+		next, ok := redirects[id]
+		if !ok || next == id {
+			return id
+		}
+		id = next
+	}
+	return id
+}
+
+func pairEvidence(r pairRow) string {
+	var parts []string
+	if r.RefOverlap {
+		parts = append(parts, "ref")
+	}
+	if datesNear(r.DateA, r.DateB) {
+		parts = append(parts, fmt.Sprintf("date(%s~%s)", dateStr(r.DateA), dateStr(r.DateB)))
+	}
+	if r.LabelOverlap {
+		parts = append(parts, "label")
+	}
+	if r.SharedNorms >= 2 {
+		parts = append(parts, fmt.Sprintf("norms=%d", r.SharedNorms))
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, "+")
+}
+
+func truncateRunes(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "…"
+}

--- a/apps/api/cmd/work-dedup/report.go
+++ b/apps/api/cmd/work-dedup/report.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+func runCensus(ctx context.Context, db *gorm.DB, w io.Writer, csvPath string) error {
+	c, err := buildCensus(ctx, db)
+	if err != nil {
+		return err
+	}
+	printCensus(c, w)
+	if csvPath != "" {
+		if err := exportCSV(c, csvPath); err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "dossier: %s (%d pairs)\n", csvPath, len(c.rows))
+	}
+	return nil
+}
+
+func printCensus(c *census, w io.Writer) {
+	buckets := map[bucket]int{}
+	lanes := map[string]int{}
+	for i, r := range c.rows {
+		buckets[c.verdicts[i]]++
+		if c.verdicts[i] != bucketOutOfScope {
+			la, lb := r.LaneA, r.LaneB
+			if lb < la {
+				la, lb = lb, la
+			}
+			lanes[la+"×"+lb]++
+		}
+	}
+	fmt.Fprintf(w, "[census] pairs=%d in_scope=%d\n", len(c.rows), len(c.rows)-buckets[bucketOutOfScope])
+	for _, b := range []bucket{bucketAuto, bucketAnchorConflict, bucketRelConflict, bucketDateClash, bucketBare, bucketBothKungal, bucketBridged, bucketOutOfScope} {
+		fmt.Fprintf(w, "  %-16s %d\n", b, buckets[b])
+	}
+	fmt.Fprintf(w, "  merge groups: %d\n", len(c.groups))
+	names := make([]string, 0, len(lanes))
+	for k := range lanes {
+		names = append(names, k)
+	}
+	sort.Slice(names, func(i, j int) bool { return lanes[names[i]] > lanes[names[j]] })
+	for _, k := range names {
+		fmt.Fprintf(w, "  lane %-18s %d\n", k, lanes[k])
+	}
+	for i, g := range c.groups {
+		if i >= 5 {
+			break
+		}
+		fmt.Fprintf(w, "  group sample: %v -> %d (%s)\n", g.sources, g.survivor, g.sample)
+	}
+}
+
+func exportCSV(c *census, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	cw := csv.NewWriter(f)
+	if err := cw.Write([]string{
+		"a", "b", "bucket", "lane_a", "lane_b", "site_a", "site_b", "name_a", "name_b",
+		"shared_norm", "shared_norms", "anchor_conflict", "release_conflict", "ref_overlap",
+		"date_a", "date_b", "label_overlap", "anchors_a", "anchors_b",
+	}); err != nil {
+		return err
+	}
+	str := func(p *string) string {
+		if p == nil {
+			return ""
+		}
+		return *p
+	}
+	for i, r := range c.rows {
+		rec := []string{
+			strconv.FormatInt(r.A, 10), strconv.FormatInt(r.B, 10), string(c.verdicts[i]),
+			r.LaneA, r.LaneB, str(r.SiteA), str(r.SiteB), r.NameA, r.NameB,
+			r.SharedNorm, strconv.Itoa(r.SharedNorms),
+			strconv.FormatBool(r.AnchorConflict), strconv.FormatBool(r.RelConflict), strconv.FormatBool(r.RefOverlap),
+			dateStr(r.DateA), dateStr(r.DateB),
+			strconv.FormatBool(r.LabelOverlap), strconv.Itoa(r.AnchorsA), strconv.Itoa(r.AnchorsB),
+		}
+		if err := cw.Write(rec); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+func dateStr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format("2006-01-02")
+}

--- a/apps/api/cmd/work-dedup/seed.go
+++ b/apps/api/cmd/work-dedup/seed.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"api/internal/platform/catalog/model"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const seedChunk = 1000
+
+var seedBuckets = []bucket{
+	bucketAuto, bucketAnchorConflict, bucketRelConflict, bucketDateClash,
+	bucketBare, bucketBothKungal, bucketBridged,
+}
+
+func seedStatusFor(b bucket) int16 {
+	if b == bucketAuto {
+		return model.CandidateStatusPending
+	}
+	return model.CandidateStatusNeedsManual
+}
+
+func runSeed(ctx context.Context, db *gorm.DB, w io.Writer, actor int64, run bool) error {
+	c, err := buildCensus(ctx, db)
+	if err != nil {
+		return err
+	}
+	planned := map[bucket][]model.CatalogMatchCandidate{}
+	for i, r := range c.rows {
+		b := c.verdicts[i]
+		if b == bucketOutOfScope {
+			continue
+		}
+		planned[b] = append(planned[b], model.CatalogMatchCandidate{
+			EntityType: model.EntityTypeWork, AID: r.A, BID: r.B,
+			Reason: model.CandidateReasonNameNormEqual, Status: seedStatusFor(b),
+		})
+	}
+
+	total, inserted := 0, 0
+	for _, b := range seedBuckets {
+		rows := planned[b]
+		total += len(rows)
+		if !run {
+			fmt.Fprintf(w, "  %-16s %6d -> %s\n", b, len(rows), statusName(seedStatusFor(b)))
+			continue
+		}
+		got, err := insertCandidates(ctx, db, rows)
+		if err != nil {
+			return err
+		}
+		inserted += got
+		fmt.Fprintf(w, "  %-16s %6d -> %-12s inserted=%d already_present=%d\n",
+			b, len(rows), statusName(seedStatusFor(b)), got, len(rows)-got)
+	}
+
+	mode := "DRY-RUN (pass -run to file candidates)"
+	if run {
+		mode = "APPLIED"
+	}
+	fmt.Fprintf(w, "%s [seed] actor=%d in_scope=%d inserted=%d already_present=%d\n",
+		mode, actor, total, inserted, total-inserted)
+	return nil
+}
+
+// insertCandidates never overwrites an existing row: a candidate an operator
+// already decided must survive every later detector pass, and the seed has no
+// way to tell a machine-filed row from a hand-decided one.
+func insertCandidates(ctx context.Context, db *gorm.DB, rows []model.CatalogMatchCandidate) (int, error) {
+	written := 0
+	for start := 0; start < len(rows); start += seedChunk {
+		end := min(start+seedChunk, len(rows))
+		res := db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(rows[start:end])
+		if res.Error != nil {
+			return written, res.Error
+		}
+		written += int(res.RowsAffected)
+	}
+	return written, nil
+}
+
+func statusName(status int16) string {
+	switch status {
+	case model.CandidateStatusPending:
+		return "pending"
+	case model.CandidateStatusAccepted:
+		return "accepted"
+	case model.CandidateStatusRejected:
+		return "rejected"
+	case model.CandidateStatusDeferred:
+		return "deferred"
+	case model.CandidateStatusNeedsManual:
+		return "needs_manual"
+	}
+	return fmt.Sprintf("status%d", status)
+}

--- a/apps/api/cmd/work-dedup/verdict.go
+++ b/apps/api/cmd/work-dedup/verdict.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"sort"
+	"time"
+)
+
+type bucket string
+
+const (
+	bucketAuto           bucket = "auto"
+	bucketOutOfScope     bucket = "out-of-scope"
+	bucketAnchorConflict bucket = "anchor-conflict"
+	bucketRelConflict    bucket = "release-conflict"
+	bucketBothKungal     bucket = "both-kungal"
+	bucketDateClash      bucket = "date-clash"
+	bucketBare           bucket = "bare"
+	bucketBridged        bucket = "bridged"
+)
+
+// dateNearDays tolerates cross-source date drift: sources record different
+// edition dates for the same work (download vs package), measured at up to
+// ~1 month apart on eyeballed true pairs, while true remakes sit years apart.
+const dateNearDays = 62
+
+func datesNear(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	delta := a.Sub(*b)
+	if delta < 0 {
+		delta = -delta
+	}
+	return delta <= dateNearDays*24*time.Hour
+}
+
+type mergeGroup struct {
+	survivor int64
+	sources  []int64
+	sample   string
+}
+
+func classifyPair(r pairRow) bucket {
+	if r.LaneA == "dlsite" && r.LaneB == "dlsite" {
+		return bucketOutOfScope
+	}
+	corroborated := r.RefOverlap || r.LabelOverlap || r.SharedNorms >= 2 || datesNear(r.DateA, r.DateB)
+	dateClash := r.DateA != nil && r.DateB != nil && r.DateA.Year() != r.DateB.Year()
+	switch {
+	case r.AnchorConflict:
+		return bucketAnchorConflict
+	case r.RelConflict:
+		return bucketRelConflict
+	case r.LaneA == "kungal" && r.LaneB == "kungal":
+		return bucketBothKungal
+	case dateClash:
+		return bucketDateClash
+	case !corroborated:
+		return bucketBare
+	}
+	return bucketAuto
+}
+
+// classify buckets every pair, then walks the connected components of the
+// auto pairs to pick one survivor per group. A component holding two claimed
+// kungal works was bridged together by an import mint's titles — merging
+// anything there picks between two claims, so the whole component is demoted
+// to the manual queue.
+func classify(rows []pairRow) ([]bucket, []mergeGroup) {
+	verdicts := make([]bucket, len(rows))
+	uf := map[int64]int64{}
+	var find func(int64) int64
+	find = func(x int64) int64 {
+		r, ok := uf[x]
+		if !ok || r == x {
+			uf[x] = x
+			return x
+		}
+		root := find(r)
+		uf[x] = root
+		return root
+	}
+	union := func(a, b int64) { uf[find(a)] = find(b) }
+
+	type workFacts struct {
+		kungal  bool
+		anchors int
+		name    string
+	}
+	facts := map[int64]workFacts{}
+	for i, r := range rows {
+		verdicts[i] = classifyPair(r)
+		if verdicts[i] != bucketAuto {
+			continue
+		}
+		facts[r.A] = workFacts{kungal: r.LaneA == "kungal", anchors: r.AnchorsA, name: r.NameA}
+		facts[r.B] = workFacts{kungal: r.LaneB == "kungal", anchors: r.AnchorsB, name: r.NameB}
+		union(r.A, r.B)
+	}
+
+	members := map[int64][]int64{}
+	for id := range facts {
+		root := find(id)
+		members[root] = append(members[root], id)
+	}
+	demoted := map[int64]bool{}
+	var groups []mergeGroup
+	for root, ids := range members {
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+		kungal := 0
+		for _, id := range ids {
+			if facts[id].kungal {
+				kungal++
+			}
+		}
+		if kungal > 1 {
+			demoted[root] = true
+			continue
+		}
+		survivor := ids[0]
+		for _, id := range ids[1:] {
+			s, c := facts[survivor], facts[id]
+			if (c.kungal && !s.kungal) || (c.kungal == s.kungal && c.anchors > s.anchors) {
+				survivor = id
+			}
+		}
+		sources := make([]int64, 0, len(ids)-1)
+		for _, id := range ids {
+			if id != survivor {
+				sources = append(sources, id)
+			}
+		}
+		groups = append(groups, mergeGroup{survivor: survivor, sources: sources, sample: facts[survivor].name})
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].survivor < groups[j].survivor })
+
+	for i, r := range rows {
+		if verdicts[i] == bucketAuto && demoted[find(r.A)] {
+			verdicts[i] = bucketBridged
+		}
+	}
+	return verdicts, groups
+}

--- a/apps/api/cmd/work-dedup/verdict_test.go
+++ b/apps/api/cmd/work-dedup/verdict_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func day(t *testing.T, s string) *time.Time {
+	t.Helper()
+	parsed, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return &parsed
+}
+
+func TestClassifyPairBuckets(t *testing.T) {
+	base := pairRow{A: 1, B: 2, LaneA: "kungal", LaneB: "bgm", SharedNorms: 1}
+	cases := []struct {
+		name string
+		row  func(pairRow) pairRow
+		want bucket
+	}{
+		{"bare", func(r pairRow) pairRow { return r }, bucketBare},
+		{"shared ref alone", func(r pairRow) pairRow { r.RefOverlap = true; return r }, bucketAuto},
+		{"label overlap alone", func(r pairRow) pairRow { r.LabelOverlap = true; return r }, bucketAuto},
+		{"two shared norms alone", func(r pairRow) pairRow { r.SharedNorms = 2; return r }, bucketAuto},
+		{"near dates alone", func(r pairRow) pairRow {
+			r.DateA, r.DateB = day(t, "2015-08-10"), day(t, "2015-09-25")
+			return r
+		}, bucketAuto},
+		{"far dates in one year are not corroboration", func(r pairRow) pairRow {
+			r.DateA, r.DateB = day(t, "2015-01-10"), day(t, "2015-12-25")
+			return r
+		}, bucketBare},
+		{"year mismatch vetoes the label corroborator", func(r pairRow) pairRow {
+			r.LabelOverlap = true
+			r.DateA, r.DateB = day(t, "2015-08-10"), day(t, "2019-08-10")
+			return r
+		}, bucketDateClash},
+		{"anchor conflict beats every corroborator", func(r pairRow) pairRow {
+			r.AnchorConflict, r.RefOverlap, r.LabelOverlap = true, true, true
+			return r
+		}, bucketAnchorConflict},
+		{"release conflict beats every corroborator", func(r pairRow) pairRow {
+			r.RelConflict, r.RefOverlap, r.LabelOverlap = true, true, true
+			return r
+		}, bucketRelConflict},
+		{"two claimed works are never machine-merged", func(r pairRow) pairRow {
+			r.LaneB, r.RefOverlap = "kungal", true
+			return r
+		}, bucketBothKungal},
+		{"dlsite edition splits are out of scope", func(r pairRow) pairRow {
+			r.LaneA, r.LaneB, r.AnchorConflict = "dlsite", "dlsite", true
+			return r
+		}, bucketOutOfScope},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyPair(tc.row(base)); got != tc.want {
+				t.Fatalf("classifyPair = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyDemotesBridgedComponents(t *testing.T) {
+	rows := []pairRow{
+		{A: 1, B: 2, LaneA: "kungal", LaneB: "bgm", RefOverlap: true, SharedNorms: 1},
+		{A: 2, B: 3, LaneA: "bgm", LaneB: "kungal", RefOverlap: true, SharedNorms: 1},
+		{A: 10, B: 11, LaneA: "bgm", LaneB: "vndb", RefOverlap: true, SharedNorms: 1},
+	}
+	verdicts, groups := classify(rows)
+	if verdicts[0] != bucketBridged || verdicts[1] != bucketBridged {
+		t.Fatalf("a component holding two claimed works must be demoted: %v", verdicts)
+	}
+	if verdicts[2] != bucketAuto {
+		t.Fatalf("the untouched component must stay auto: %v", verdicts)
+	}
+	if len(groups) != 1 || groups[0].survivor != 10 {
+		t.Fatalf("groups: %+v", groups)
+	}
+}
+
+func TestClassifySurvivorSelection(t *testing.T) {
+	cases := []struct {
+		name string
+		row  pairRow
+		want int64
+	}{
+		{
+			name: "claimed work beats anchor count",
+			row: pairRow{A: 10, B: 11, LaneA: "bgm", LaneB: "kungal",
+				AnchorsA: 5, AnchorsB: 0, RefOverlap: true, SharedNorms: 1},
+			want: 11,
+		},
+		{
+			name: "anchors decide when neither is claimed",
+			row: pairRow{A: 20, B: 21, LaneA: "bgm", LaneB: "vndb",
+				AnchorsA: 1, AnchorsB: 3, RefOverlap: true, SharedNorms: 1},
+			want: 21,
+		},
+		{
+			name: "an anchor tie keeps the lower id",
+			row: pairRow{A: 30, B: 31, LaneA: "bgm", LaneB: "vndb",
+				AnchorsA: 1, AnchorsB: 1, RefOverlap: true, SharedNorms: 1},
+			want: 30,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, groups := classify([]pairRow{tc.row})
+			if len(groups) != 1 {
+				t.Fatalf("groups: %+v", groups)
+			}
+			if groups[0].survivor != tc.want {
+				t.Fatalf("survivor = %d, want %d", groups[0].survivor, tc.want)
+			}
+			if len(groups[0].sources) != 1 || groups[0].sources[0] == tc.want {
+				t.Fatalf("sources: %+v", groups[0].sources)
+			}
+		})
+	}
+}
+
+func TestPairEvidenceNamesTheCorroborators(t *testing.T) {
+	got := pairEvidence(pairRow{
+		RefOverlap: true, SharedNorms: 1,
+		DateA: day(t, "2015-08-10"), DateB: day(t, "2015-09-25"),
+	})
+	if want := "ref+date(2015-08-10~2015-09-25)"; got != want {
+		t.Fatalf("evidence = %q, want %q", got, want)
+	}
+	if got := pairEvidence(pairRow{LabelOverlap: true, SharedNorms: 2}); got != "label+norms=2" {
+		t.Fatalf("evidence = %q, want %q", got, "label+norms=2")
+	}
+	if got := pairEvidence(pairRow{SharedNorms: 1}); got != "none" {
+		t.Fatalf("evidence = %q, want %q", got, "none")
+	}
+}

--- a/apps/api/cmd/work-dedup/watch.go
+++ b/apps/api/cmd/work-dedup/watch.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"api/internal/platform/catalog/model"
+
+	"gorm.io/gorm"
+)
+
+const watchSamples = 10
+
+func runWatch(ctx context.Context, db *gorm.DB, w io.Writer) (int, error) {
+	c, err := buildCensus(ctx, db)
+	if err != nil {
+		return 0, err
+	}
+	cands, err := loadWorkCandidates(ctx, db)
+	if err != nil {
+		return 0, err
+	}
+	proposed, err := loadWorkProposalPairs(ctx, db)
+	if err != nil {
+		return 0, err
+	}
+	redirects, err := loadWorkRedirects(ctx, db)
+	if err != nil {
+		return 0, err
+	}
+
+	// Every pair this pipeline has ever looked at, so that "merged" can be
+	// counted at all: executing a merge soft-deletes the source work AND
+	// deletes the pair's own candidate row (merge_execute step 8), so a
+	// collapsed pair is invisible to both the detector and the queue. Only the
+	// proposal it was executed through still names it.
+	known := make(map[[2]int64]bool, len(c.rows)+len(cands)+len(proposed))
+	for _, r := range c.rows {
+		known[[2]int64{r.A, r.B}] = true
+	}
+	for key := range cands {
+		known[key] = true
+	}
+	for key := range proposed {
+		known[[2]int64{min(key[0], key[1]), max(key[0], key[1])}] = true
+	}
+	merged := 0
+	for key := range known {
+		if resolveWork(redirects, key[0]) == resolveWork(redirects, key[1]) {
+			merged++
+		}
+	}
+
+	byStatus := map[int16]int{}
+	var fresh, inScope, proposedOnly int
+	var samples []pairRow
+	for i, r := range c.rows {
+		if c.verdicts[i] == bucketOutOfScope {
+			continue
+		}
+		inScope++
+		key := [2]int64{r.A, r.B}
+		status, filed := cands[key]
+		switch {
+		case resolveWork(redirects, r.A) == resolveWork(redirects, r.B):
+		case filed:
+			byStatus[status]++
+		case proposed[key]:
+			proposedOnly++
+		default:
+			fresh++
+			if len(samples) < watchSamples {
+				samples = append(samples, r)
+			}
+		}
+	}
+
+	fmt.Fprintf(w, "[watch] pairs=%d new=%d pending=%d needs_manual=%d accepted=%d rejected=%d deferred=%d proposed=%d merged=%d\n",
+		inScope, fresh,
+		byStatus[model.CandidateStatusPending], byStatus[model.CandidateStatusNeedsManual],
+		byStatus[model.CandidateStatusAccepted], byStatus[model.CandidateStatusRejected],
+		byStatus[model.CandidateStatusDeferred], proposedOnly, merged)
+	for _, r := range samples {
+		fmt.Fprintf(w, "  new: %d<->%d lanes=%s×%s a=%q b=%q norm=%q\n",
+			r.A, r.B, r.LaneA, r.LaneB, r.NameA, r.NameB, r.SharedNorm)
+	}
+	return fresh, nil
+}
+
+func loadWorkCandidates(ctx context.Context, db *gorm.DB) (map[[2]int64]int16, error) {
+	var rows []struct {
+		AID    int64 `gorm:"column:a_id"`
+		BID    int64 `gorm:"column:b_id"`
+		Status int16 `gorm:"column:status"`
+	}
+	if err := db.WithContext(ctx).Raw(
+		`SELECT a_id, b_id, status FROM catalog_match_candidate WHERE entity_type = ?`,
+		model.EntityTypeWork).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[[2]int64]int16, len(rows))
+	for _, r := range rows {
+		out[[2]int64{r.AID, r.BID}] = r.Status
+	}
+	return out, nil
+}
+
+func loadWorkProposalPairs(ctx context.Context, db *gorm.DB) (map[[2]int64]bool, error) {
+	var rows []struct {
+		Source int64 `gorm:"column:source_entity_id"`
+		Target int64 `gorm:"column:target_entity_id"`
+	}
+	if err := db.WithContext(ctx).Raw(
+		`SELECT source_entity_id, target_entity_id FROM catalog_merge_proposal WHERE entity_type = ?`,
+		model.EntityTypeWork).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[[2]int64]bool, 2*len(rows))
+	for _, r := range rows {
+		out[[2]int64{r.Source, r.Target}] = true
+		out[[2]int64{r.Target, r.Source}] = true
+	}
+	return out, nil
+}

--- a/apps/api/internal/platform/catalog/importer/bgmtype4gated_gate.go
+++ b/apps/api/internal/platform/catalog/importer/bgmtype4gated_gate.go
@@ -3,6 +3,7 @@ package importer
 import (
 	"math/bits"
 	"math/rand"
+	"strings"
 	"unicode"
 )
 
@@ -42,10 +43,11 @@ func tallySignals(st *BgmGatedStats, p, t, x bool) {
 
 func collide(r poolRow, wt map[string]wtNorm) (BgmGatedCollision, bool) {
 	for _, n := range []string{r.NameNorm, r.NameCNNorm} {
-		if runeLen(n) < bgmGatedMinLen {
+		folded, ok := foldedGateKey(n)
+		if !ok {
 			continue
 		}
-		if w, ok := wt[n]; ok {
+		if w, hit := wt[folded]; hit {
 			return BgmGatedCollision{
 				SubjectID: r.ID, Name: r.Name, NameCN: r.NameCN,
 				CollidedNorm: n, WorkID: w.workID, WorkTitle: w.title,
@@ -55,23 +57,54 @@ func collide(r poolRow, wt map[string]wtNorm) (BgmGatedCollision, bool) {
 	return BgmGatedCollision{}, false
 }
 
+// foldedGateKey reports the space-folded comparison key for a source norm, and
+// whether it is long enough to compare on at all. Both length gates matter: the
+// raw one keeps the pre-fold behaviour, the folded one stops "A B C" from
+// becoming a 3-rune key that collides by genre rather than identity.
+func foldedGateKey(norm string) (string, bool) {
+	if runeLen(norm) < bgmGatedMinLen {
+		return "", false
+	}
+	folded := foldSpace(norm)
+	if runeLen(folded) < bgmGatedMinLen {
+		return "", false
+	}
+	return folded, true
+}
+
+// foldSpace mirrors service.WorkTitleFoldSQL in Go; the two must strip the same
+// runes or the mint guard and the import gate disagree about what a duplicate is.
+func foldSpace(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
 func dropIntraCollisions(cands []candidate, st *BgmGatedStats) []candidate {
 	subjectsPerNorm := make(map[string]map[int64]struct{})
 	note := func(norm string, id int64) {
-		if runeLen(norm) < bgmGatedMinLen {
+		folded, ok := foldedGateKey(norm)
+		if !ok {
 			return
 		}
-		if subjectsPerNorm[norm] == nil {
-			subjectsPerNorm[norm] = make(map[int64]struct{})
+		if subjectsPerNorm[folded] == nil {
+			subjectsPerNorm[folded] = make(map[int64]struct{})
 		}
-		subjectsPerNorm[norm][id] = struct{}{}
+		subjectsPerNorm[folded][id] = struct{}{}
 	}
 	for _, c := range cands {
 		note(c.row.NameNorm, c.row.ID)
 		note(c.row.NameCNNorm, c.row.ID)
 	}
 	dupNorm := func(norm string) bool {
-		return runeLen(norm) >= bgmGatedMinLen && len(subjectsPerNorm[norm]) > 1
+		folded, ok := foldedGateKey(norm)
+		return ok && len(subjectsPerNorm[folded]) > 1
 	}
 	out := cands[:0]
 	for _, c := range cands {

--- a/apps/api/internal/platform/catalog/importer/bgmtype4gated_load.go
+++ b/apps/api/internal/platform/catalog/importer/bgmtype4gated_load.go
@@ -35,24 +35,48 @@ func (im *Importer) loadGatedPool() ([]poolRow, error) {
 	return rows, err
 }
 
+// loadExistingWorkTitleNorms keys the collision corpus on SPACE-FOLDED norms
+// and carries display_name as well as the title rows. The 2026-07 gated wave
+// minted ~4.9k duplicates through exactly those two holes: wiki-claimed works
+// were born with no catalog_work_title rows at all, and a title differing only
+// by an internal space compared unequal.
 func (im *Importer) loadExistingWorkTitleNorms() (map[string]wtNorm, error) {
-	var rows []struct {
+	type normRow struct {
 		Norm   string `gorm:"column:title_norm"`
 		WorkID int64  `gorm:"column:work_id"`
 		Title  string `gorm:"column:title"`
 	}
-	if err := im.catalog.Raw(
+	out := make(map[string]wtNorm)
+	collect := func(query string, args ...any) error {
+		var rows []normRow
+		if err := im.catalog.Raw(query, args...).Scan(&rows).Error; err != nil {
+			return err
+		}
+		for _, r := range rows {
+			folded := foldSpace(r.Norm)
+			if runeLen(folded) < bgmGatedMinLen {
+				continue
+			}
+			if _, ok := out[folded]; !ok {
+				out[folded] = wtNorm{workID: r.WorkID, title: r.Title}
+			}
+		}
+		return nil
+	}
+	if err := collect(
 		`SELECT title_norm, work_id, title FROM catalog_work_title t
 		 WHERE length(title_norm) >= ? AND `+editspec.NotSuppressedWorkTitleSQL("t"),
 		bgmGatedMinLen,
-	).Scan(&rows).Error; err != nil {
+	); err != nil {
 		return nil, err
 	}
-	out := make(map[string]wtNorm, len(rows))
-	for _, r := range rows {
-		if _, ok := out[r.Norm]; !ok {
-			out[r.Norm] = wtNorm{workID: r.WorkID, title: r.Title}
-		}
+	if err := collect(
+		`SELECT lower(normalize(w.display_name, NFKC)) AS title_norm, w.id AS work_id, w.display_name AS title
+		 FROM catalog_work w
+		 WHERE w.deleted_at IS NULL AND length(w.display_name) >= ?`,
+		bgmGatedMinLen,
+	); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/apps/api/internal/platform/catalog/importer/bgmtype4gated_test.go
+++ b/apps/api/internal/platform/catalog/importer/bgmtype4gated_test.go
@@ -155,6 +155,55 @@ func seedVNDBTitle(t *testing.T, id, title string) {
 		VALUES (?, 'ja', false, ?, '')`, id, title).Error)
 }
 
+// The 2026-07 gated wave minted ~4.9k duplicates because these two shapes both
+// read as "no existing work": a wiki claim carries only a display_name, and a
+// title that differs by one internal space compares unequal on raw title_norm.
+func TestBgmType4GatedFoldedCollisions(t *testing.T) {
+	clean(t)
+	require.NoError(t, testDB.Exec(`ALTER TABLE games ADD COLUMN IF NOT EXISTS gamename text`).Error)
+
+	seedSubject(t, 3001, "表示名だけの既存作品", "", `["Galgame","PC","游戏"]`, "", false)
+	seedDisplayOnlyWork(t, "表示名だけの既存作品")
+
+	seedSubject(t, 3002, "空白違いの既存作品", "", `["Galgame","PC","游戏"]`, "", false)
+	seedExistingWork(t, "空白 違いの 既存作品")
+
+	seedSubject(t, 3003, "衝突しない新規作品名", "", `["Galgame","PC","游戏"]`, "", false)
+
+	dry, err := New(testDB, testDB, Options{DryRun: true}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, 3, dry.GatedTotal)
+	assert.Equal(t, 2, dry.SkippedTitleCollision, "display-name-only and space-variant both collide")
+	assert.Equal(t, 1, dry.ToCreate)
+
+	st, err := New(testDB, testDB, Options{}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, 1, st.WorksCreated)
+	assert.Equal(t, int64(1), scalarInt(t, `SELECT count(*) FROM catalog_external_ref
+		WHERE matched_by='rule:bgm-type4-gated' AND external_id='3003'`))
+	assert.Zero(t, scalarInt(t, `SELECT count(*) FROM catalog_external_ref
+		WHERE matched_by='rule:bgm-type4-gated' AND external_id IN ('3001','3002')`))
+}
+
+func TestBgmType4GatedIntraCollisionFoldsSpace(t *testing.T) {
+	clean(t)
+	require.NoError(t, testDB.Exec(`ALTER TABLE games ADD COLUMN IF NOT EXISTS gamename text`).Error)
+
+	seedSubject(t, 3101, "同一プール内衝突作品", "", `["Galgame","PC","游戏"]`, "", false)
+	seedSubject(t, 3102, "同一 プール内 衝突作品", "", `["Galgame","PC","游戏"]`, "", false)
+
+	dry, err := New(testDB, testDB, Options{DryRun: true}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, 2, dry.SkippedIntraCollision, "two pool rows spelling one title must both stand down")
+	assert.Zero(t, dry.ToCreate)
+}
+
+func seedDisplayOnlyWork(t *testing.T, displayName string) {
+	t.Helper()
+	require.NoError(t, testDB.Exec(`INSERT INTO catalog_work (medium_id, olang, display_name, content_rating, status, extra, field_provenance, display_nsfw)
+		VALUES (1,'ja',?,0,0,'{}','{}',false)`, displayName).Error)
+}
+
 func seedExistingWork(t *testing.T, title string) {
 	t.Helper()
 	var wid int64

--- a/apps/api/internal/platform/catalog/service/admin_queue.go
+++ b/apps/api/internal/platform/catalog/service/admin_queue.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"api/internal/platform/catalog/model"
@@ -28,6 +29,15 @@ func (s *AdminQueueService) DetachName(ctx context.Context, creditNameID int64, 
 var ErrExactTaken = fmt.Errorf("catalog: external identity is exact-linked to another entity")
 
 const matchedByCurated = "curated"
+
+// NeedsManual belongs here: it is the status the machine lanes park a pair in
+// precisely because a human has to decide it. Leaving it out made every such
+// candidate permanently undecidable in the console — a queue with no exit.
+var decidableCandidateStatuses = []int16{
+	model.CandidateStatusPending,
+	model.CandidateStatusDeferred,
+	model.CandidateStatusNeedsManual,
+}
 
 type EntitySummary struct {
 	ID          int64  `json:"id"`
@@ -180,7 +190,7 @@ func (s *AdminQueueService) DecideCandidate(ctx context.Context, d CandidateDeci
 	if cand.AID == 0 {
 		return nil, fmt.Errorf("%w: candidate (%d, %d, %d)", ErrNotFound, d.EntityType, d.AID, d.BID)
 	}
-	if cand.Status != model.CandidateStatusPending && cand.Status != model.CandidateStatusDeferred {
+	if !slices.Contains(decidableCandidateStatuses, cand.Status) {
 		return nil, fmt.Errorf("%w: candidate already decided (status %d)", ErrProposalState, cand.Status)
 	}
 
@@ -244,8 +254,7 @@ func (s *AdminQueueService) acceptAsPersonLink(ctx context.Context, d CandidateD
 func (s *AdminQueueService) flipCandidate(db *gorm.DB, d CandidateDecision, status int16) (int64, error) {
 	res := db.Model(&model.CatalogMatchCandidate{}).
 		Where("entity_type = ? AND a_id = ? AND b_id = ? AND status IN ?",
-			d.EntityType, d.AID, d.BID,
-			[]int16{model.CandidateStatusPending, model.CandidateStatusDeferred}).
+			d.EntityType, d.AID, d.BID, decidableCandidateStatuses).
 		Updates(map[string]any{"status": status, "decided_by": d.DecidedBy, "decided_at": time.Now()})
 	return res.RowsAffected, res.Error
 }

--- a/apps/api/internal/platform/catalog/service/admin_queue_test.go
+++ b/apps/api/internal/platform/catalog/service/admin_queue_test.go
@@ -119,6 +119,39 @@ func TestDecideCandidatePaths(t *testing.T) {
 	assert.NotEmpty(t, items[0].A.DisplayName)
 }
 
+func TestDecideCandidateResolvesNeedsManual(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+
+	file := func(a, b int64) CandidateDecision {
+		require.NoError(t, testDB.Create(&model.CatalogMatchCandidate{
+			EntityType: model.EntityTypePerson, AID: min(a, b), BID: max(a, b),
+			Reason: model.CandidateReasonNameNormEqual, Status: model.CandidateStatusNeedsManual,
+		}).Error)
+		return CandidateDecision{EntityType: model.EntityTypePerson, AID: min(a, b), BID: max(a, b), DecidedBy: 9}
+	}
+	statusOf := func(d CandidateDecision) int16 {
+		var cand model.CatalogMatchCandidate
+		require.NoError(t, testDB.Where("a_id = ? AND b_id = ?", d.AID, d.BID).First(&cand).Error)
+		return cand.Status
+	}
+
+	p1, p2 := createPerson(t, "NM1"), createPerson(t, "NM2")
+	accept := file(p1.ID, p2.ID)
+	accept.Action, accept.SourceID, accept.TargetID = "accept", p2.ID, p1.ID
+	outcome, err := testQueues.DecideCandidate(ctx, accept)
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Proposal)
+	assert.Equal(t, model.CandidateStatusAccepted, statusOf(accept))
+
+	p3, p4 := createPerson(t, "NM3"), createPerson(t, "NM4")
+	reject := file(p3.ID, p4.ID)
+	reject.Action = "reject"
+	_, err = testQueues.DecideCandidate(ctx, reject)
+	require.NoError(t, err)
+	assert.Equal(t, model.CandidateStatusRejected, statusOf(reject))
+}
+
 func TestConfirmAndRejectRefs(t *testing.T) {
 	cleanTables(t)
 	ctx := t.Context()

--- a/apps/api/internal/platform/catalog/service/work_dupe.go
+++ b/apps/api/internal/platform/catalog/service/work_dupe.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"strconv"
+
+	"api/internal/platform/catalog/editspec"
+	"api/internal/platform/catalog/model"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// WorkDupeMinRunes is the shortest folded norm the dedup lanes compare on;
+// shorter strings ("PC版", "同人誌") collide by genre, not identity.
+const WorkDupeMinRunes = 4
+
+// WorkTitleFoldSQL folds an already NFKC-lowered SQL text expression for
+// duplicate comparison by removing every whitespace rune. The 2026-07 bgm
+// import wave minted ~4.9k duplicate works past a gate that compared raw
+// title_norm equality; whitespace variants of the same title were one of the
+// two holes, so every dup detector and mint guard compares folded norms
+// through this one definition.
+func WorkTitleFoldSQL(expr string) string {
+	return `regexp_replace(` + expr + `, '[[:space:]　]', '', 'g')`
+}
+
+// WorkDupeCorpusSQL selects every live work's folded identity norms as
+// (work_id, n): official titles plus display_name. display_name must be in
+// the corpus — wiki-claimed works were born with zero title rows, which is
+// the other hole the 2026-07 wave slipped through.
+func WorkDupeCorpusSQL() string {
+	minLen := strconv.Itoa(WorkDupeMinRunes)
+	return `SELECT t.work_id, ` + WorkTitleFoldSQL("t.title_norm") + ` AS n
+		FROM catalog_work_title t
+		JOIN catalog_work tw ON tw.id = t.work_id AND tw.deleted_at IS NULL
+		WHERE t.kind = 0 AND length(t.title_norm) >= ` + minLen + `
+		  AND ` + editspec.NotSuppressedWorkTitleSQL("t") + `
+		UNION
+		SELECT w.id, ` + WorkTitleFoldSQL("lower(normalize(w.display_name, NFKC))") + `
+		FROM catalog_work w
+		WHERE w.deleted_at IS NULL AND length(w.display_name) >= ` + minLen
+}
+
+// recordWorkDupeSuspects files a pending match candidate for every live work
+// sharing a folded identity norm with the freshly minted work. It never
+// blocks the mint — same-name distinct works are real, so the receipt goes
+// to the reconciliation queue instead of the submitter.
+func recordWorkDupeSuspects(tx *gorm.DB, workID int64) error {
+	var hits []int64
+	err := tx.Raw(`
+		WITH corpus AS (`+WorkDupeCorpusSQL()+`)
+		SELECT DISTINCT o.work_id
+		FROM corpus mine
+		JOIN corpus o ON o.n = mine.n AND o.work_id <> mine.work_id
+		WHERE mine.work_id = ? AND length(mine.n) >= ?
+		ORDER BY o.work_id`, workID, WorkDupeMinRunes).Scan(&hits).Error
+	if err != nil || len(hits) == 0 {
+		return err
+	}
+	rows := make([]model.CatalogMatchCandidate, 0, len(hits))
+	for _, hit := range hits {
+		a, b := workID, hit
+		if b < a {
+			a, b = b, a
+		}
+		rows = append(rows, model.CatalogMatchCandidate{
+			EntityType: model.EntityTypeWork, AID: a, BID: b,
+			Reason: model.CandidateReasonNameNormEqual,
+			Status: model.CandidateStatusPending,
+		})
+	}
+	return tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&rows).Error
+}

--- a/apps/api/internal/platform/catalog/service/work_dupe_test.go
+++ b/apps/api/internal/platform/catalog/service/work_dupe_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"testing"
+
+	"api/internal/platform/catalog/model"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubmitWorkFilesSpacingDupeCandidate(t *testing.T) {
+	s := newLifecycle(t)
+	existing := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "既存作品の表示名")
+	require.NoError(t, testDB.Create(&model.CatalogWorkTitle{
+		WorkID: existing.ID, Lang: "ja", Title: "重複検出タイトル", Kind: model.WorkTitleKindOfficial,
+	}).Error)
+
+	res, err := s.SubmitWork(t.Context(), SubmitWorkParams{
+		Site: submitSite, ProductWorkID: 90501, ActorUID: 7,
+		Fields: submitFields("重複 検出 タイトル"),
+	})
+	require.NoError(t, err)
+
+	var cands []model.CatalogMatchCandidate
+	require.NoError(t, testDB.Order("a_id, b_id").Find(&cands).Error)
+	require.Len(t, cands, 1, "the mint must file one receipt, not one per matching norm")
+	got := cands[0]
+	assert.Equal(t, model.EntityTypeWork, got.EntityType)
+	assert.Equal(t, min(existing.ID, res.WorkID), got.AID)
+	assert.Equal(t, max(existing.ID, res.WorkID), got.BID)
+	assert.Equal(t, model.CandidateReasonNameNormEqual, got.Reason)
+	assert.Equal(t, model.CandidateStatusPending, got.Status)
+	assert.Nil(t, got.DecidedBy)
+}
+
+func TestSubmitWorkWithoutCollisionFilesNothing(t *testing.T) {
+	s := newLifecycle(t)
+	createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "全く別の既存作品")
+
+	_, err := s.SubmitWork(t.Context(), SubmitWorkParams{
+		Site: submitSite, ProductWorkID: 90502, ActorUID: 7,
+		Fields: submitFields("衝突しない新規作品"),
+	})
+	require.NoError(t, err)
+
+	var filed int64
+	require.NoError(t, testDB.Model(&model.CatalogMatchCandidate{}).Count(&filed).Error)
+	assert.Zero(t, filed)
+}

--- a/apps/api/internal/platform/catalog/service/work_submit.go
+++ b/apps/api/internal/platform/catalog/service/work_submit.go
@@ -210,6 +210,9 @@ func (s *ClaimLifecycleService) SubmitWork(ctx context.Context, p SubmitWorkPara
 		if err := editspec.ApplyWorkFields(ctx, tx, w.ID, p.Fields); err != nil {
 			return err
 		}
+		if err := recordWorkDupeSuspects(tx, w.ID); err != nil {
+			return err
+		}
 
 		if p.Released.given() {
 			fp, err := mintedReleaseDateProvenance()

--- a/scripts/prod-cron/work-dedup-watch/run.sh
+++ b/scripts/prod-cron/work-dedup-watch/run.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# Weekly duplicate-work watch. Re-runs the standing detector over the live
+# catalog and alerts when it finds a pair that nobody — machine or human — has
+# decided yet. READ-ONLY: `work-dedup -mode watch` writes nothing; the seed /
+# propose / execute lanes are operator-driven and are not run from cron.
+#
+# Exit-code contract of the tool, which this wrapper depends on:
+#   0  detector ran, no undecided new pairs
+#   3  detector ran, new pairs found  -> [DUP] alert, and STILL a success stamp:
+#      the run was healthy and the finding is the alert. Suppressing the stamp
+#      would make the deadman report a working job as dead every week.
+#   *  the detector broke            -> [FAIL] alert, no stamp
+#
+# Not yet registered in scripts/prod-cron/README.md or lib/watchdog.conf (both
+# outside this wave's owned paths). Add, in the same shape as the other weekly
+# jobs:
+#   crontab (root):  20 4 * * 1 /root/work-dedup-watch/run.sh
+#   watchdog.conf:   work-dedup-watch  /root/work-dedup-watch/state/last-success  192
+#
+# Runs from the infra-tools image resolved below; nothing is staged on this
+# host. Canonical copy: scripts/prod-cron/work-dedup-watch/run.sh in
+# kun-galgame-infra — installing or updating it on the box is a manual scp over
+# /root/work-dedup-watch/run.sh, so edit here first and copy it out (two chains
+# once sat on a stale hand-edited copy for a whole cycle).
+set -eu
+BASE=/root/work-dedup-watch
+cd "$BASE"
+mkdir -p logs state
+LOG="logs/run-$(date -u +%F).log"
+exec >>"$LOG" 2>&1
+exec 9>"$BASE/.lock"; flock -n 9 || { echo "another run holds the lock; exit"; exit 0; }
+LOCKED=1
+
+# Two-layer reporting, as in the other maintenance crons: the trap catches a run
+# that failed, and state/last-success lets /root/lib/watchdog.sh catch a job that
+# stopped running at all — the failure no in-script handler can see. The stamp is
+# gated on LOCKED so a run that skipped because a previous one still holds the
+# lock never stamps for work it did not do.
+on_exit() {
+  rc=$?
+  if [ -f env.tmp ]; then shred -u env.tmp; fi
+  if [ "$rc" -eq 0 ] && [ "${LOCKED:-0}" = 1 ]; then
+    date -u '+%F %T' > "$BASE/state/last-success"
+  else
+    echo "=== FAILED (exit $rc) - sending alert ==="
+    /root/lib/alert.sh "[FAIL] work-dedup weekly watch (exit $rc)" "$BASE/$LOG" || echo "alert delivery failed"
+  fi
+}
+trap on_exit EXIT
+echo "=== work-dedup watch start $(date -u '+%F %T')Z ==="
+
+PG=kun-visual-novel-infra-vqvqbc-postgres-1
+CATC=kun-visual-novel-infra-vqvqbc-catalog-1
+
+IMG_TAG=ghcr.io/kunmoe/infra-tools:latest
+docker pull -q "$IMG_TAG" >/dev/null 2>&1 || echo "WARN: image pull failed; using the local copy"
+IMG=$(docker image inspect --format '{{index .RepoDigests 0}}' "$IMG_TAG")
+echo "image: $IMG"
+
+# Fresh env snapshot from the catalog container; the EXIT trap shreds it.
+docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$CATC" > env.tmp
+chmod 600 env.tmp
+
+# The DSN is assembled INSIDE the container from that snapshot, so the password
+# exists only in that process and never in argv on this host. Parallel query is
+# disabled per session: the postgres container runs with the 64MB docker-default
+# /dev/shm and the pair detector is a self-join over every live work title.
+DSNSH='U="${KUN_CATALOG_PG_USER:-$KUN_PG_USER}"; P="${KUN_CATALOG_PG_PASSWORD:-$KUN_PG_PASSWORD}"; CAT="host=127.0.0.1 port=5432 user=$U password=$P dbname=${KUN_CATALOG_PG_DATABASE:-kun_catalog} sslmode=disable options='"'"'-c max_parallel_workers_per_gather=0'"'"'"'
+
+rc=0
+docker run --rm --network "container:$PG" --env-file "$BASE/env.tmp" "$IMG" \
+  sh -c "$DSNSH"'; work-dedup -mode watch -fail-on-new -dsn "$CAT"' || rc=$?
+case "$rc" in
+  0) echo "no new undecided duplicate pairs" ;;
+  3) echo "=== new undecided duplicate pairs - sending alert ==="
+     /root/lib/alert.sh "[DUP] new duplicate work pairs" "$BASE/$LOG" || echo "alert delivery failed" ;;
+  *) echo "FATAL: work-dedup watch exited $rc"; exit "$rc" ;;
+esac
+
+find logs -name 'run-*.log' ! -name "run-$(date -u +%F).log" -exec gzip -qf {} \;
+find logs -name 'run-*.log.gz' -mtime +90 -delete
+echo "=== work-dedup watch done $(date -u '+%F %T')Z ==="


### PR DESCRIPTION
## The incident

The 2026-07 bgm type4-gated import wave minted ~4.9k duplicate works (work
216368 duplicates 448, 216504 duplicates 447, …). Two holes in one gate:

1. **Claimed works were invisible to it.** A wiki-claimed work is born with
   zero `catalog_work_title` rows — its only identity string is
   `display_name` — and the gate's collision corpus read `catalog_work_title`
   only. Every claim therefore looked like "no such work" to the importer.
2. **Whitespace variants slipped past.** The comparison was raw `title_norm`
   equality, so `僕と恋するポンコツアクマ。 すっごいえっち！` and
   `僕と恋するポンコツアクマ。すっごいえっち！` were two different works.

Nothing downstream noticed, because nothing was watching.

## What this adds

**Detect → queue → propose (48h cooling) → execute → watch.**

* `apps/api/cmd/work-dedup` — one binary, five modes:
  * `census` — the standing detector: every pair of live works sharing a
    space-folded official-title/`display_name` norm, scored with the facts a
    verdict needs (lanes, work- and release-level anchor conflicts, release
    dates with a `src_bangumi` fallback, label overlap). `-csv` writes the full
    dossier for review.
  * `seed` — files every in-scope pair as a `catalog_match_candidate`
    (`pending` when the verdict is `auto`, `needs_manual` otherwise). Never
    overwrites an existing row: an operator's decision outranks any later
    detector pass.
  * `propose` — turns pending `auto` pairs into `ProposeMerge` +
    `ApproveMerge` (the standard 48h cooling window), settles the rest:
    already-merged pairs are flipped `accepted` (superseded), pairs that have
    dropped out of the census go to `needs_manual` — never auto-rejected,
    because the title edit that dissolved the collision may itself be the
    mistake. `-limit` caps proposals per run; the remainder stays pending.
  * `execute` — executes cooled proposals, hard-bound to `entity_type = work`
    and the wave note tag, with the same chain-superseded / chain-residual
    handling `catalog-dedup-batch` already proves.
  * `watch` — reports what the detector sees against what the queue holds and
    exits **3** when an undecided pair exists.
* `service/work_dupe.go` + the `SubmitWork` mint lane — the same folded corpus,
  applied at birth: a claim that collides with a live work now files a pending
  work candidate inside the mint transaction. The mint is never blocked
  (same-name distinct works are real); the receipt goes to the reconciliation
  queue, not to the submitter.
* `importer/bgmtype4gated_*` — the gate itself is fixed: the corpus carries
  live works' `display_name` as well as title rows, and every key on both sides
  is space-folded with the same rule `service.WorkTitleFoldSQL` applies in SQL.
  `dropIntraCollisions` folds the same way.
* `scripts/prod-cron/work-dedup-watch/run.sh` — weekly, read-only, from the
  `infra-tools` image. `rc=3` raises a `[DUP]` alert **and still stamps
  last-success** (the run was healthy; the finding is the alert), any other
  nonzero rc is a `[FAIL]` with no stamp.

Merging is deliberately conservative. A conflicting source anchor, a
release-level anchor conflict, a release-**year** mismatch, two claimed works
bridged into one component, or no corroboration at all — each routes to a
human instead of to a proposal. dlsite×dlsite pairs are edition splits and are
out of scope entirely.

## Census against the live catalog (read-only, `kun_catalog`)

```
[census] pairs=35091 in_scope=7216
  auto             3265
  anchor-conflict  2048
  release-conflict 192
  date-clash       1224
  bare             460
  both-kungal      17
  bridged          10
  out-of-scope     27875
  merge groups: 3231
  lane bgm×kungal         4491
  lane eg×kungal          1289
  lane kungal×kungal      953
  lane bgm×bgm            190
  lane bgm×eg             131
  lane dlsite×kungal      97
  lane bgm×vndb           22
  lane bgm×dlsite         21
  lane kungal×vndb        14
  lane eg×vndb            3
  lane dlsite×eg          2
  lane dlsite×vndb        2
  lane eg×eg              1
```

Both known duplicates classify `auto` with the claimed work as survivor:

```
447,216504,auto,kungal,bgm,kungal,,…,1,false,false,false,2016-04-22,2016-05-27,false,3,1
448,216368,auto,kungal,bgm,kungal,,…,1,false,false,true, 2015-08-10,2015-09-25,false,3,1
```

3,265 auto pairs collapse into 3,231 merge groups (~34 pairs are the extra
edges of size-3 components). 3,951 pairs are parked for a human.

**The detector is expensive**: ~24 min wall for the full census on the dev box
(the `wanchor`/`ranchor` CTEs are referenced many times, so Postgres
materialises them and re-scans per pair). That is fine for a weekly watch and
for operator-driven runs; it is not a request-path query, and no route calls
it. Worth a plan pass before anyone puts it on a tighter schedule.

## Admin queue fix

`DecideCandidate` rejected any candidate whose status was not `pending` or
`deferred`, and `flipCandidate` only ever updated those two — so
`needs_manual`, the status the machine lanes park a pair in *precisely because
a human has to decide it*, was undecidable in the console. A queue with no
exit. This wave's seed lane fills it with ~3.9k rows, so it is fixed here.

## Migrations / spec

**Zero migrations. Zero OpenAPI or spec changes.** Every table this touches
(`catalog_match_candidate`, `catalog_merge_proposal`, `catalog_redirect`)
already exists; no model gained or changed a field.

## Not in this PR

* Registering the cron in `scripts/prod-cron/README.md` and
  `lib/watchdog.conf`, and installing `/root/work-dedup-watch/run.sh` on the
  box (manual scp). The script header carries the crontab and watchdog lines.
* Running the pipeline against production. Sketch, for when it is run:
  1. `work-dedup -mode seed -actor <uid> -run`
  2. `work-dedup -mode census -csv dossier.csv` → review the `auto` rows, and
     decide the `needs_manual` backlog in the console
  3. `work-dedup -mode propose -actor <uid> -run` (start with `-limit`)
  4. wait out the 48h cooling window
  5. `work-dedup -mode execute -actor <uid> -run`
  6. `reindex-catalog`, then restart the mcp container (its tool snapshot is
     taken at startup)

## Tests

* `cmd/work-dedup/verdict_test.go` — pure-Go bucket table (each corroborator
  alone, the year-mismatch veto, both conflict classes, bare, out-of-scope),
  bridged demotion, survivor selection, evidence strings.
* `cmd/work-dedup/pipeline_test.go` — the full lane end to end on a real
  database: seed → propose → cooling → execute (redirect written, source
  soft-deleted, proposal executed) → watch, plus `-limit` and idempotency.
* `service/work_dupe_test.go` — a submit colliding only by spacing files
  exactly one pending candidate; a non-colliding submit files none.
* `service/admin_queue_test.go` — a `needs_manual` candidate can be accepted
  and rejected.
* `importer/bgmtype4gated_test.go` — a pool subject colliding with a
  display-name-only work, and one colliding across an internal space, are both
  skipped.
