### PR TITLE
feat(catalog): declare the changes feed as the display-axis mirror channel

### DIFF
--- a/apps/api/internal/jobs/releasemeta/changes_feed_test.go
+++ b/apps/api/internal/jobs/releasemeta/changes_feed_test.go
@@ -1,0 +1,48 @@
+package releasemeta
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/repository"
+	"api/internal/platform/catalog/service"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// content_rating is half of the public display verdict, and this job is the one
+// writer of it that never goes through editspec. Downstream mirrors poll
+// /v2/catalog/changes for that axis, so a rating filled here has to move
+// updated_at or the flip reaches nobody until the next full sweep.
+func TestFillRatingSurfacesOnTheChangesFeed(t *testing.T) {
+	clean(t)
+	ctx := context.Background()
+	medium := galgameMedium(t)
+
+	filled := mkWork(t, medium, "rating-mirror", nil, nil, 0)
+	bystander := mkWork(t, medium, "rating-bystander", nil, nil, 0)
+
+	require.NoError(t, testDB.Exec(`UPDATE catalog_work SET updated_at = now() - interval '1 hour'`).Error)
+	pub := service.NewPublicService(testDB, service.NewReadService(testDB),
+		service.NewResolveService(repository.NewRedirectRepository(testDB)), "")
+	tip, err := pub.Changes(ctx, "", 500)
+	require.NoError(t, err)
+
+	w := &writer{db: testDB, stats: &Stats{}}
+	w.fillRating(ctx, filled, model.ContentRatingR18, true)
+	require.Equal(t, 1, w.stats.RatingFilled)
+
+	require.NoError(t, testDB.Exec(`UPDATE catalog_work SET updated_at = updated_at - interval '10 seconds'`).Error)
+	page, err := pub.Changes(ctx, tip.NextCursor, 500)
+	require.NoError(t, err)
+
+	ids := make([]int64, 0, len(page.Items))
+	for _, it := range page.Items {
+		ids = append(ids, it.ID)
+		assert.False(t, it.Gone, "work %d is still live", it.ID)
+	}
+	assert.Equal(t, []int64{filled}, ids)
+	assert.NotContains(t, ids, bystander)
+}

--- a/apps/api/internal/platform/apiv2/handler/catalog_feed.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_feed.go
@@ -42,9 +42,14 @@ func (c *Catalog) ListChanges(ctx context.Context, q collect.Query) (repr.List[r
 		if target == "label" {
 			target = "company"
 		}
-		items = append(items, repr.Change{
+		ch := repr.Change{
 			Object: "change", TargetObject: target, ID: repr.ID(it.ID), UpdatedAt: it.Updated,
-		})
+		}
+		if it.Gone {
+			gone := true
+			ch.Gone = &gone
+		}
+		items = append(items, ch)
 	}
 	var next *string
 	if len(data.Items) == limit && data.NextCursor != "" {

--- a/apps/api/internal/platform/apiv2/handler/catalog_feed_routes.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_feed_routes.go
@@ -44,7 +44,11 @@ func registerCatalogFeeds(api huma.API, cat *Catalog) {
 		Method:             http.MethodGet,
 		Path:               "/v2/catalog/changes",
 		Summary:            "Catalog changes feed",
-		Description:        "Works updated recently, oldest first. Keyset-paginated. Requires an application key. ids= is not accepted.",
+		Description: "Works updated recently, oldest first. Keyset-paginated. Requires an application key. ids= is not accepted.\n\n" +
+			"**This is the mirror channel.** If you cache any catalog-owned fact per work — above all the editorial display axis `content_limit`, whose verdict is `claimed_by.content_limit` when the claim block is present and otherwise `nsfw` when `content_rating` is `r18`, `sfw` otherwise — poll this feed instead of sweeping the catalog. Every write that changes a work's claim state, its display axis (the editorial NSFW flag or its content rating), or its existence bumps `updated_at` and surfaces the id here.\n\n" +
+			"Bootstrap from an empty cursor: the feed enumerates the whole population oldest-updated-first, so the first drain IS the full inventory. Hydrate each page against /v2/catalog/works with ids= in batches of at most 100, with both gates open (nsfw=true and no content_limit), then keep the cursor and poll it at your own cadence.\n\n" +
+			"gone: an entry carrying `gone: true` has left the public population — drop the mirrored row. Merged-away ids appear here as gone AND in /v2/catalog/redirects, which names the id that replaced them; repoint rather than delete when the redirect exists.\n\n" +
+			"Everything else a work serves — covers, tags, titles, intros, ratings — surfaces best-effort: most of those writers touch the work too, but only claim state, the display axis and existence are promised.",
 		Tags:               catalog,
 		Errors:             errs,
 		SkipValidateParams: true,

--- a/apps/api/internal/platform/apiv2/handler/setup.go
+++ b/apps/api/internal/platform/apiv2/handler/setup.go
@@ -51,7 +51,7 @@ func SetupWith(app *fiber.App, opt Options) huma.API {
 	app.Use(userAuth(opt.LookupUser, opt.LookupSite))
 	app.Use(protocol.RateLimit(opt.Store, credentialLimitIdentity))
 
-	cfg := huma.DefaultConfig("NextMoe Public API v2", "2.0.0")
+	cfg := huma.DefaultConfig("NextMoe Public API v2", "2.1.0")
 	cfg.OpenAPIPath = ""
 	cfg.DocsPath = ""
 	cfg.SchemasPath = ""

--- a/apps/api/internal/platform/apiv2/repr/feed.go
+++ b/apps/api/internal/platform/apiv2/repr/feed.go
@@ -5,7 +5,8 @@ type Change struct {
 	Object       string   `json:"object" enum:"change" doc:"Type discriminant. Always change."`
 	TargetObject string   `json:"target_object" enum:"work,release,character,credit_name,person,company,tag,engine" doc:"Family of the row that changed."`
 	ID           string   `json:"id" pattern:"^[0-9]+$" minLength:"1" maxLength:"20" doc:"Catalog id of the changed row."`
-	UpdatedAt    string   `json:"updated_at" format:"date-time" maxLength:"32" doc:"RFC 3339 UTC."`
+	UpdatedAt    string   `json:"updated_at" format:"date-time" maxLength:"32" doc:"RFC 3339 UTC. The moment the row last changed, and the value the cursor resumes from."`
+	Gone         *bool    `json:"gone,omitempty" doc:"Present and true when the id has left the public population: merged away, or otherwise no longer served. Absent means the id is still live — never sent as false. Drop the mirrored row; if it was merged, /v2/catalog/redirects names the id that replaced it."`
 }
 
 type Redirect struct {

--- a/apps/api/internal/platform/catalog/dto/public_dto.go
+++ b/apps/api/internal/platform/catalog/dto/public_dto.go
@@ -509,6 +509,7 @@ type PublicChangeItem struct {
 	EntityType string `json:"entity_type"`
 	ID         int64  `json:"id"`
 	Updated    string `json:"updated"`
+	Gone       bool   `json:"gone,omitempty"`
 }
 
 type PublicChangesData struct {

--- a/apps/api/internal/platform/catalog/service/merge_execute.go
+++ b/apps/api/internal/platform/catalog/service/merge_execute.go
@@ -151,7 +151,11 @@ func retireSource(tx *gorm.DB, entityType int16, src int64) error {
 	case model.EntityTypeCharacter:
 		return tx.Delete(&model.CatalogCharacter{}, src).Error
 	case model.EntityTypeWork:
-		if err := tx.Exec(`UPDATE catalog_work SET status = ?, site = NULL, product_work_id = NULL WHERE id = ?`,
+		// The updated_at bump is what puts the retired id on the changes feed as
+		// a gone entry. GORM's soft delete below writes deleted_at only, so
+		// without it the merge source left the public population without ever
+		// surfacing, and downstream mirrors kept the dead id until a full sweep.
+		if err := tx.Exec(`UPDATE catalog_work SET status = ?, site = NULL, product_work_id = NULL, updated_at = now() WHERE id = ?`,
 			model.WorkStatusMerged, src).Error; err != nil {
 			return err
 		}

--- a/apps/api/internal/platform/catalog/service/merge_touch_test.go
+++ b/apps/api/internal/platform/catalog/service/merge_touch_test.go
@@ -198,9 +198,8 @@ func TestMergeWorkTouchesTargetAndRelationOtherEnd(t *testing.T) {
 		"a work with no edge to either side must stay out of the feed")
 
 	ids := changesSince(t, cursor)
-	assert.ElementsMatch(t, []int64{dst.ID, aSide.ID, bSide.ID, dupSide.ID}, ids,
-		"the feed carries the target and the rewritten neighbours, nothing else")
-	assert.NotContains(t, ids, src.ID, "a merged-away source must never enter the changes feed")
+	assert.ElementsMatch(t, []int64{src.ID, dst.ID, aSide.ID, bSide.ID, dupSide.ID}, ids,
+		"the feed carries the retired source, the target and the rewritten neighbours, nothing else")
 }
 
 func TestMergeIdentityLayerTouchesNoWork(t *testing.T) {
@@ -257,5 +256,6 @@ func TestMergeWorkClaimTransferTouchesTarget(t *testing.T) {
 	assert.True(t, workUpdatedAt(t, dst.ID).After(before), "the target now carries the claim")
 
 	ids := changesSince(t, cursor)
-	assert.Equal(t, []int64{dst.ID}, ids, "only the claim's new owner enters the feed")
+	assert.ElementsMatch(t, []int64{src.ID, dst.ID}, ids,
+		"the claim's new owner and the id it left enter the feed together")
 }

--- a/apps/api/internal/platform/catalog/service/public_changes_mirror_test.go
+++ b/apps/api/internal/platform/catalog/service/public_changes_mirror_test.go
@@ -1,0 +1,168 @@
+package service
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"api/internal/platform/catalog/editspec"
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/repository"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// changesFrom is changesSince with the gone bit kept: the whole point of these
+// tests is which ids come back AND whether each is still part of the population.
+func changesFrom(t *testing.T, cursor string) map[int64]bool {
+	t.Helper()
+	require.NoError(t, testDB.Exec(`UPDATE catalog_work SET updated_at = updated_at - interval '10 seconds'`).Error)
+	page, err := newPublicSvc().Changes(t.Context(), cursor, 500)
+	require.NoError(t, err)
+	out := make(map[int64]bool, len(page.Items))
+	for _, it := range page.Items {
+		out[it.ID] = it.Gone
+	}
+	return out
+}
+
+func TestChangesFeedSurfacesDisplayAxisEdit(t *testing.T) {
+	cleanTables(t)
+	edited := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "display-axis")
+	bystander := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "bystander")
+	settleWorks(t)
+	cursor := drainChanges(t)
+
+	require.NoError(t, editspec.ApplyWorkFields(t.Context(), testDB, edited.ID,
+		map[string]any{editspec.FieldWorkDisplayNSFW: true}))
+
+	got := changesFrom(t, cursor)
+	require.Contains(t, got, edited.ID, "an editor's display_nsfw flip is what the mirror channel exists for")
+	assert.False(t, got[edited.ID], "the work is still served, only its display verdict moved")
+	assert.NotContains(t, got, bystander.ID)
+}
+
+func TestChangesFeedSurfacesContentRatingEdit(t *testing.T) {
+	cleanTables(t)
+	edited := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "rating-axis")
+	bystander := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "bystander")
+	settleWorks(t)
+	cursor := drainChanges(t)
+
+	require.NoError(t, editspec.ApplyWorkFields(t.Context(), testDB, edited.ID,
+		map[string]any{editspec.FieldWorkContentRating: float64(model.ContentRatingR18)}))
+
+	got := changesFrom(t, cursor)
+	require.Contains(t, got, edited.ID, "content_rating decides the verdict for unclaimed works")
+	assert.NotContains(t, got, bystander.ID)
+}
+
+func TestChangesFeedSurfacesClaimTransition(t *testing.T) {
+	s := newLifecycle(t)
+	work := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "claimed")
+	bystander := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "bystander")
+	product := int64(9001)
+	act(t, s, work.ID, ClaimActionClaim, ClaimActionParams{Site: "kungal", ProductWorkID: &product, ActorUID: 7})
+
+	settleWorks(t)
+	cursor := drainChanges(t)
+
+	act(t, s, work.ID, ClaimActionSubmit, ClaimActionParams{Site: "kungal", ActorUID: 7})
+
+	got := changesFrom(t, cursor)
+	require.Contains(t, got, work.ID, "the claim block is half of the display verdict")
+	assert.False(t, got[work.ID])
+	assert.NotContains(t, got, bystander.ID)
+}
+
+func TestChangesFeedMarksVanishedRowsGone(t *testing.T) {
+	cleanTables(t)
+	deleted := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "deleted")
+	retired := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "retired")
+	live := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "live")
+	settleWorks(t)
+	cursor := drainChanges(t)
+
+	require.NoError(t, testDB.Exec(
+		`UPDATE catalog_work SET deleted_at = now(), updated_at = now() WHERE id = ?`, deleted.ID).Error)
+	require.NoError(t, testDB.Exec(
+		`UPDATE catalog_work SET status = ?, updated_at = now() WHERE id = ?`,
+		model.WorkStatusMerged, retired.ID).Error)
+	require.NoError(t, repository.TouchWorks(t.Context(), testDB, []int64{live.ID}))
+
+	got := changesFrom(t, cursor)
+	assert.True(t, got[deleted.ID], "a soft-deleted work is gone")
+	assert.True(t, got[retired.ID], "gone is the complement of the served population, not just deleted_at")
+	require.Contains(t, got, live.ID)
+	assert.False(t, got[live.ID])
+}
+
+func TestChangesFeedSurfacesMergedSourceAsGone(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+	dst := createWork(t, "merge-target")
+	src := createWork(t, "merge-source")
+	settleWorks(t)
+	cursor := drainChanges(t)
+
+	p, err := testMerge.ProposeMerge(ctx, model.EntityTypeWork, src.ID, dst.ID, 7, "same work")
+	require.NoError(t, err)
+	approveAndForceExecutable(t, p.ID)
+	require.NoError(t, testMerge.ExecuteMerge(ctx, p.ID, nil))
+
+	got := changesFrom(t, cursor)
+	require.Contains(t, got, src.ID, "an executed merge retires an id downstream still holds")
+	assert.True(t, got[src.ID])
+	require.Contains(t, got, dst.ID)
+	assert.False(t, got[dst.ID])
+
+	items, _, err := testResolve.RedirectsSince(ctx, nil, repository.RedirectCursor{}, 100)
+	require.NoError(t, err)
+	found := false
+	for _, it := range items {
+		if it.EntityType == model.EntityTypeWork && it.OldID == src.ID && it.CurrentID == dst.ID {
+			found = true
+		}
+	}
+	assert.True(t, found, "a gone entry must be repointable through the redirects feed")
+}
+
+func TestChangesFeedDoesNotRepeatUntouchedWorks(t *testing.T) {
+	cleanTables(t)
+	quiet := createWork(t, "quiet")
+	touched := createWork(t, "touched")
+	settleWorks(t)
+	cursor := drainChanges(t)
+
+	assert.Empty(t, changesFrom(t, cursor), "nothing was written, so the feed has nothing to say")
+
+	require.NoError(t, repository.TouchWorks(t.Context(), testDB, []int64{touched.ID}))
+	got := changesFrom(t, cursor)
+	assert.Equal(t, map[int64]bool{touched.ID: false}, got,
+		"the same cursor now yields exactly the written row")
+	assert.NotContains(t, got, quiet.ID)
+}
+
+func TestChangesCursorMintedBeforeGoneStillResumes(t *testing.T) {
+	cleanTables(t)
+	first := createWork(t, "first")
+	second := createWork(t, "second")
+	settleWorks(t)
+
+	var ts time.Time
+	require.NoError(t, testDB.Raw(`SELECT updated_at FROM catalog_work WHERE id = ?`, first.ID).Scan(&ts).Error)
+	// Hand-built rather than round-tripped through encodePublicCursor: the point
+	// is that a cursor a consumer minted before this wave still decodes.
+	legacy := base64.RawURLEncoding.EncodeToString([]byte(
+		fmt.Sprintf(`{"s":"changes","id":%d,"u":%q}`, first.ID, ts.UTC().Format(time.RFC3339Nano))))
+
+	page, err := newPublicSvc().Changes(t.Context(), legacy, 500)
+	require.NoError(t, err)
+	ids := make([]int64, 0, len(page.Items))
+	for _, it := range page.Items {
+		ids = append(ids, it.ID)
+	}
+	assert.Equal(t, []int64{second.ID}, ids, "an old cursor resumes where it left off")
+}

--- a/apps/api/internal/platform/catalog/service/public_works_list.go
+++ b/apps/api/internal/platform/catalog/service/public_works_list.go
@@ -240,8 +240,11 @@ func (s *PublicService) Changes(ctx context.Context, cursor string, limit int) (
 	} else if limit > 500 {
 		limit = 500
 	}
-	where := []string{"deleted_at IS NULL", "status = ?", "medium_id = ?",
-		"updated_at < now() - interval '5 seconds'"}
+	// The population is every galgame row, not just the live ones: a mirror
+	// that only ever hears about live works can never learn that a row left,
+	// and the downstream lists kept showing merged-away and deleted ids until
+	// their next full sweep.
+	where := []string{"medium_id = ?", "updated_at < now() - interval '5 seconds'"}
 	args := []any{model.WorkStatusLive, galgameMediumID}
 	if cur.Updated != "" {
 		ts, perr := time.Parse(time.RFC3339Nano, cur.Updated)
@@ -251,12 +254,13 @@ func (s *PublicService) Changes(ctx context.Context, cursor string, limit int) (
 		where = append(where, "(updated_at, id) > (?, ?)")
 		args = append(args, ts, cur.ID)
 	}
-	q := `SELECT id, updated_at FROM catalog_work WHERE ` + strings.Join(where, " AND ") +
-		` ORDER BY updated_at ASC, id ASC LIMIT ?`
+	q := `SELECT id, updated_at, (deleted_at IS NOT NULL OR status <> ?) AS gone FROM catalog_work WHERE ` +
+		strings.Join(where, " AND ") + ` ORDER BY updated_at ASC, id ASC LIMIT ?`
 	args = append(args, limit)
 	var rows []struct {
 		ID        int64
 		UpdatedAt time.Time
+		Gone      bool
 	}
 	if err := s.db.WithContext(ctx).Raw(q, args...).Scan(&rows).Error; err != nil {
 		return dto.PublicChangesData{}, err
@@ -265,7 +269,7 @@ func (s *PublicService) Changes(ctx context.Context, cursor string, limit int) (
 	next := cur
 	for i, r := range rows {
 		out.Items[i] = dto.PublicChangeItem{
-			EntityType: "work", ID: r.ID, Updated: r.UpdatedAt.UTC().Format(time.RFC3339),
+			EntityType: "work", ID: r.ID, Updated: r.UpdatedAt.UTC().Format(time.RFC3339), Gone: r.Gone,
 		}
 		next = publicCursor{Sort: "changes", ID: r.ID, Updated: r.UpdatedAt.UTC().Format(time.RFC3339Nano)}
 	}

--- a/apps/api/internal/platform/catalog/service/watermark_test.go
+++ b/apps/api/internal/platform/catalog/service/watermark_test.go
@@ -184,6 +184,6 @@ func TestMergeRehangOfCoverTouchesTarget(t *testing.T) {
 
 	assert.True(t, workUpdatedAt(t, dst.ID).After(before),
 		"the target gained a cover it did not render before")
-	assert.Equal(t, []int64{dst.ID}, changesSince(t, cursor),
-		"only the surviving work enters the feed")
+	assert.ElementsMatch(t, []int64{src.ID, dst.ID}, changesSince(t, cursor),
+		"the survivor enters the feed, and so does the id that stopped being served")
 }

--- a/apps/developer/app/generated/docs-model.ts
+++ b/apps/developer/app/generated/docs-model.ts
@@ -5496,7 +5496,7 @@ export const docsModel: DocsModel = {
               "method": "get",
               "path": "/v2/catalog/changes",
               "summary": "Catalog changes feed",
-              "description": "Works updated recently, oldest first. Keyset-paginated. Requires an application key. ids= is not accepted.",
+              "description": "Works updated recently, oldest first. Keyset-paginated. Requires an application key. ids= is not accepted.\n\n**This is the mirror channel.** If you cache any catalog-owned fact per work — above all the editorial display axis `content_limit`, whose verdict is `claimed_by.content_limit` when the claim block is present and otherwise `nsfw` when `content_rating` is `r18`, `sfw` otherwise — poll this feed instead of sweeping the catalog. Every write that changes a work's claim state, its display axis (the editorial NSFW flag or its content rating), or its existence bumps `updated_at` and surfaces the id here.\n\nBootstrap from an empty cursor: the feed enumerates the whole population oldest-updated-first, so the first drain IS the full inventory. Hydrate each page against /v2/catalog/works with ids= in batches of at most 100, with both gates open (nsfw=true and no content_limit), then keep the cursor and poll it at your own cadence.\n\ngone: an entry carrying `gone: true` has left the public population — drop the mirrored row. Merged-away ids appear here as gone AND in /v2/catalog/redirects, which names the id that replaced them; repoint rather than delete when the redirect exists.\n\nEverything else a work serves — covers, tags, titles, intros, ratings — surfaces best-effort: most of those writers touch the work too, but only claim state, the display axis and existence are promised.",
               "scope": "catalog:read",
               "params": [
                 {
@@ -5626,6 +5626,11 @@ export const docsModel: DocsModel = {
                           "type": "object",
                           "children": [
                             {
+                              "name": "gone",
+                              "doc": "Present and true when the id has left the public population: merged away, or otherwise no longer served. Absent means the id is still live — never sent as false. Drop the mirrored row; if it was merged, /v2/catalog/redirects names the id that replaced it.",
+                              "type": "boolean"
+                            },
+                            {
                               "name": "id",
                               "required": true,
                               "doc": "Catalog id of the changed row.",
@@ -5659,7 +5664,7 @@ export const docsModel: DocsModel = {
                             {
                               "name": "updated_at",
                               "required": true,
-                              "doc": "RFC 3339 UTC.",
+                              "doc": "RFC 3339 UTC. The moment the row last changed, and the value the cursor resumes from.",
                               "format": "date-time",
                               "type": "string"
                             }

--- a/apps/developer/public/docs/v2/listCatalogChanges.md
+++ b/apps/developer/public/docs/v2/listCatalogChanges.md
@@ -15,6 +15,14 @@ Catalog changes feed
 
 Works updated recently, oldest first. Keyset-paginated. Requires an application key. ids= is not accepted.
 
+**This is the mirror channel.** If you cache any catalog-owned fact per work — above all the editorial display axis `content_limit`, whose verdict is `claimed_by.content_limit` when the claim block is present and otherwise `nsfw` when `content_rating` is `r18`, `sfw` otherwise — poll this feed instead of sweeping the catalog. Every write that changes a work's claim state, its display axis (the editorial NSFW flag or its content rating), or its existence bumps `updated_at` and surfaces the id here.
+
+Bootstrap from an empty cursor: the feed enumerates the whole population oldest-updated-first, so the first drain IS the full inventory. Hydrate each page against /v2/catalog/works with ids= in batches of at most 100, with both gates open (nsfw=true and no content_limit), then keep the cursor and poll it at your own cadence.
+
+gone: an entry carrying `gone: true` has left the public population — drop the mirrored row. Merged-away ids appear here as gone AND in /v2/catalog/redirects, which names the id that replaced them; repoint rather than delete when the redirect exists.
+
+Everything else a work serves — covers, tags, titles, intros, ratings — surfaces best-effort: most of those writers touch the work too, but only claim state, the display axis and existence are promised.
+
 - 所属 API：Public API v2（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…
 - scope：catalog:read

--- a/apps/developer/public/llms-full.txt
+++ b/apps/developer/public/llms-full.txt
@@ -210,6 +210,14 @@ Catalog changes feed
 
 Works updated recently, oldest first. Keyset-paginated. Requires an application key. ids= is not accepted.
 
+**This is the mirror channel.** If you cache any catalog-owned fact per work — above all the editorial display axis `content_limit`, whose verdict is `claimed_by.content_limit` when the claim block is present and otherwise `nsfw` when `content_rating` is `r18`, `sfw` otherwise — poll this feed instead of sweeping the catalog. Every write that changes a work's claim state, its display axis (the editorial NSFW flag or its content rating), or its existence bumps `updated_at` and surfaces the id here.
+
+Bootstrap from an empty cursor: the feed enumerates the whole population oldest-updated-first, so the first drain IS the full inventory. Hydrate each page against /v2/catalog/works with ids= in batches of at most 100, with both gates open (nsfw=true and no content_limit), then keep the cursor and poll it at your own cadence.
+
+gone: an entry carrying `gone: true` has left the public population — drop the mirrored row. Merged-away ids appear here as gone AND in /v2/catalog/redirects, which names the id that replaced them; repoint rather than delete when the redirect exists.
+
+Everything else a work serves — covers, tags, titles, intros, ratings — surfaces best-effort: most of those writers touch the work too, but only claim state, the display axis and existence are promised.
+
 - 所属 API：Public API v2（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…
 - scope：catalog:read

--- a/docs/catalog/01-service-and-contract.md
+++ b/docs/catalog/01-service-and-contract.md
@@ -16,7 +16,7 @@ catalog **不存**产品展示体:简介、封面/截图字节、评分、点赞
 
 来源注册表(节选):`source` `2=vndb 3=bangumi 4=dlsite 5=erogamescape 20=howlongtobeat 1=user`;`medium` `1=galgame 5=asmr`;`content_rating` `0=all_ages 1=sensitive 2=r18`。完整注册表由 `cmd/migrate catalog` 的 seed 落库。
 
-⚠️ **`content_rating` 是年龄轴,不是展示轴**(A2-R5,doc 106 §38 事故)。这一列答的是「**游戏本体**是什么分级」;「我要**渲染的素材**(封面/截图/简介)能不能摆上公开页」是**另一个问题**,由**编辑展示轴**回答——公开面 `claimed_by.content_limit`(词表 `sfw|nsfw`),认领作品读 **`catalog_work.display_nsfw`**(人工编辑判定;**W1-pre 本体化**前是读时桥接 wiki 正文的 `galgame.content_limit`,refs/proj/140 §5b 把该判定物化成 registry 自己的列,wiki 表族退役后由 catalog 编辑面持有),未认领行按年龄轴回落(该列对未认领行恒 false 且从不被读)。生产实测两轴在 5,568 部作品上不一致(r18 游戏 × 编辑判定 sfw),**互不是对方的放宽或收紧**;把年龄轴当展示门正是那次 SEO 塌缩的根因。语义源 = `model.DisplayLimitKey`,契约与闸参见 [developer-platform/02 §3.2.8](../developer-platform/02-public-api.md#328-编辑展示轴-content_limit闸a2-r5)。
+⚠️ **`content_rating` 是年龄轴,不是展示轴**(A2-R5,doc 106 §38 事故)。这一列答的是「**游戏本体**是什么分级」;「我要**渲染的素材**(封面/截图/简介)能不能摆上公开页」是**另一个问题**,由**编辑展示轴**回答——公开面 `claimed_by.content_limit`(词表 `sfw|nsfw`),认领作品读 **`catalog_work.display_nsfw`**(人工编辑判定;**W1-pre 本体化**前是读时桥接 wiki 正文的 `galgame.content_limit`,refs/proj/140 §5b 把该判定物化成 registry 自己的列,wiki 表族退役后由 catalog 编辑面持有),未认领行按年龄轴回落(该列对未认领行恒 false 且从不被读)。生产实测两轴在 5,568 部作品上不一致(r18 游戏 × 编辑判定 sfw),**互不是对方的放宽或收紧**;把年龄轴当展示门正是那次 SEO 塌缩的根因。语义源 = `model.DisplayLimitKey`,契约与闸参见 [developer-platform/02 §3.2.8](../developer-platform/02-public-api.md#328-编辑展示轴-content_limit闸a2-r5)。**把这条判定缓存到本地列的消费站,同步信道见本篇 §8(`/v2/catalog/changes` 是镜像信道)。**
 
 **release 粒度自 wave 174 起有了公开读面**:`GET /v1/catalog/releases`(发售动态时间线)把**每一行带日期的 release** 当作一个条目按其**自身日期**排序,认领与未认领同规;人口 = LIVE galgame 作品的 release 且日期**至少精确到月**(只到年与无日期者不入本面,它们仍归日历的 pending / tba 两桶)。它是**日历的下一粒度**:日历按作品的**最早**发行日安放作品、一部作品只出现一次,故移植版/复刻版/本地化版在那里**构造上不可见**;本面的 `is_first`(该行是否为该作品最早的带日期 release)正是把二者分开的那一位。`kind` 缺省**排除 trial / patch**(发售动态问的是「东西出了」),`lang` 按 `COALESCE(release.lang, work.olang)` 匹配(dlsite/getchu 泳道的店铺 SKU 不记语言,构造上即作品原语),`official` 视**缺键为 official**(只有 VNDB 泳道写这个旗,写 `false` 即民间汉化/非官方版)。契约见 [developer-platform/02 §3.2](../developer-platform/02-public-api.md)。
 
@@ -518,3 +518,25 @@ wave 176-179 把人类的**写**搬完了;本波搬的是搬完写之后还留�
 - ⚠️ **导入类 cmd 不随部署自动跑**:`reconcile-galgame-works` / `import-*` / `reindex-catalog` 等是手动运维工具(经 `tools` 镜像 + env-file),**部署不会触发**。跑完批量导入后需**手动** `reindex-catalog` 重建搜索索引(批量脚本不走写穿钩子)。
 - **主库变更提醒**:`oauth_clients.catalog_site` 列落在**主库 `kun_galgame_infra`**(经 `cmd/migrate` AutoMigrate)——见工程侧变更时的迁移铁则。
 - **服务拓扑**:catalog 内网端口 9281,产品后端经 `http://catalog:9281` 走 dokploy-network(无公开域名);web(oauth admin 前端)SSR 经 `NUXT_CATALOG_API_BASE_SSR=http://catalog:9281/api/v1`。
+
+## 8. 展示轴镜像:`/v2/catalog/changes` 是镜像信道
+
+产品站会把 catalog 的编辑展示判定(§1 的 `content_limit`)缓存成自己的一列,好在 SQL 里过滤列表页。此前**没有任何 feed 被声明**承载这个字段——论坛的代码里留着原话:「There is no feed for that field — the claim-event feed carries claim state only — so a full sweep is the only way an editor's flip reaches the local lists.」于是论坛与 moyu 各自退回夜间全量扫(约 300 次请求扫 ~7.8k 行),编辑翻一个标志最坏要等一整夜才到本地列表。**信道其实一直在**:`GET /v2/catalog/changes` 按 `(updated_at, id)` 升序翻 `catalog_work`。本节把它声明成契约。
+
+**不变量**:凡改动作品的 **claim 状态**、**编辑展示轴**(`display_nsfw` / `content_rating`)或**作品存在性**的写路径,都会 bump `catalog_work.updated_at`,因而必在本 feed 现身。当前这些写路径是:编辑面 `applyWorkColumn`、claim 生命周期八动作、周跑 `releasemeta` 评级泳道、合并的认领转移与来源退役、导入(只 INSERT,新行自带新时间戳),以及子资源写路径统一走的 `repository.TouchWorks`。**其余字段(封面/标签/标题/简介/评分)尽力而为**——它们多数也会 touch 作品,但只有上面三项是承诺。
+
+**判定配方**(与 §1 同一条,服务端语义源 `model.DisplayLimitKey(site, product_work_id, display_nsfw, content_rating)`):
+
+```
+content_limit = claimed_by.content_limit          若 claimed_by 块存在(仅已认领作品渲染)
+              = content_rating == "r18" ? nsfw : sfw   否则
+```
+
+**镜像回路**:
+
+1. **冷启动**:从空游标翻本 feed。它按「最旧更新优先」枚举**整个人口**,所以第一次翻完就是一次全量清点——不需要另一个「列全部 id」的面。每页拿到的 id 以 **≤100 一批**打 `/v2/catalog/works?ids=`,**两道闸全开**(`nsfw=true`,且**不传** `content_limit`),否则被闸掉的作品会在本地留成空洞。
+2. **稳态**:存下 `next_cursor`,按自己的节奏轮询;游标是不透明串,原样回传。注意 feed 有 5 秒的在途事务水位,刚写的行会晚一拍出现——这不是丢失。
+3. **`gone: true`**:该 id 已离开公开人口(被合并,或不再被服务),删掉本地行。
+4. **被合并的 id** 同时出现在 `/v2/catalog/redirects`,那里给出接替它的规范 id——有 redirect 就**重指**而不是删除。
+
+**本地谓词写法**:缓存列用可空列,`NULL` 表示「尚未同步」并且**放行**,例如 `WHERE content_limit IS NULL OR content_limit = 'sfw'`。冷启动期间未水合的行因此照常可见而不是整站空白;真正的权威始终是水合时 catalog 自己的闸,本地列只是列表页的快筛。

--- a/docs/catalog/README.md
+++ b/docs/catalog/README.md
@@ -29,6 +29,7 @@
 - **S2S per-client site 绑定** —— 写端点 `claim` 要求认证 client 的 `oauth_clients.catalog_site` 非空**且** == 请求 site,否则 403;读端点不受限。
 - **署名 vs 归属两种 work↔实体边** —— credit(个人署名:谁演/担任什么)与 work_label(组织归属:哪个社团/发行方负责)并存;消费拉动落地(D-01,DLsite 社团归属首用)。
 - **迁移不随服务跑** —— `cmd/migrate catalog` 是唯一 schema 入口(随部署自动跑);**导入类 cmd(reconcile/import/reindex)不随部署自动跑**,需手动执行。
+- **展示轴镜像信道** —— 把 `content_limit` 缓存到本地列的消费站,轮询 `GET /v2/catalog/changes`(claim 状态 / 展示轴 / 存在性三项承诺 bump `updated_at`;`gone` 条目即删本地行),别再夜间全量扫。见 [01 §8](./01-service-and-contract.md)。
 
 ## 非目标
 

--- a/docs/catalog/v2-implementation-notes.md
+++ b/docs/catalog/v2-implementation-notes.md
@@ -434,3 +434,53 @@ editing the column by hand. The guard would also not be a privilege boundary on
 in two more calls with or without `Trusted`. Adding the check would mean
 widening `Options.LookupSite` to carry the client's owner, for a fence that is
 already open next door.
+
+## Wave — the changes feed is the display-axis mirror channel (2026-08-28)
+
+Downstream mirrors of the editorial display verdict (`content_limit`) had no
+declared change channel, so both the forum and moyu fell back to a nightly full
+sweep — ~300 requests over ~7.8k rows to learn about a handful of editor flips.
+The forum's code carries the lament verbatim: *"There is no feed for that field
+— the claim-event feed carries claim state only — so a full sweep is the only
+way an editor's flip reaches the local lists."* The channel already existed:
+`GET /v2/catalog/changes` keysets `catalog_work` on `(updated_at, id)`. This
+wave declares it, and closes the two holes that stopped it from being usable.
+
+**Spec is 2.1.0.** Additive only: one optional response property, one longer
+operation description, zero new operations (88 stays 88), **zero migrations**.
+
+**Hole 1 — disappearances were invisible.** `PublicService.Changes` filtered
+`deleted_at IS NULL AND status = live`, so a work that left the population left
+the feed too and downstream kept the dead id until its next sweep. The
+population is now every galgame row, with `gone = (deleted_at IS NOT NULL OR
+status <> live)` computed per row and rendered as an **optional** `gone`
+property — present only when true, following the repr package's pointer +
+`omitempty` house style. `gone` is now exactly the complement of the works face:
+the `ids=` lane serves live, non-deleted works regardless of claim state. The
+widened query still rides `idx_catalog_work_updated_id` (a full index on
+`(updated_at, id)`); EXPLAIN on the 229k-row dev catalog shows the same Index
+Scan as before, with one fewer filter.
+
+**Hole 2 — the one retirement write that did not bump.** `retireSource` in
+`merge_execute.go` set `status = merged, site = NULL, product_work_id = NULL`
+without touching `updated_at`, and the GORM soft delete that follows writes
+`deleted_at` only — so an executed merge retired an id in total silence. It now
+carries `updated_at = now()`. Every other recurring writer of the promised axis
+was audited and already bumps: `editspec.applyWorkColumn` (GORM `Model.Update`,
+`display_nsfw` / `content_rating`), the claim lifecycle's `Model.Updates` on
+`catalog_work`, `releasemeta`'s rating lane (explicit `updated_at = now()`),
+survivorship's claim move (explicit `now()`), importers (INSERT-only for these
+columns), and `repository.TouchWorks` for every subresource write. The
+survivorship merge of `display_name` / `olang` writes through
+`tx.Table("catalog_work")`, which has no schema and therefore no auto
+`updated_at` — it is covered because `ExecuteMerge` appends the target to
+`TouchWorks`.
+
+**What is promised, and what is not.** Claim state, the display axis and
+existence surface here by contract. Covers, tags, titles, intros and ratings
+surface best-effort — most of those writers touch the work as well, but no
+touch-audit was done for them and the feed does not promise them.
+
+Consumer recipe (bootstrap from an empty cursor, hydrate `ids=` in ≤100 batches
+with both gates open, `gone` → drop, redirects → repoint, `NULL` cache column
+means not-synced-yet and passes): [01 §8](./01-service-and-contract.md).

--- a/docs/catalog/v2-openapi.yaml
+++ b/docs/catalog/v2-openapi.yaml
@@ -270,6 +270,9 @@ components:
     Change:
       additionalProperties: true
       properties:
+        gone:
+          description: "Present and true when the id has left the public population: merged away, or otherwise no longer served. Absent means the id is still live — never sent as false. Drop the mirrored row; if it was merged, /v2/catalog/redirects names the id that replaced it."
+          type: boolean
         id:
           description: Catalog id of the changed row.
           maxLength: 20
@@ -296,7 +299,7 @@ components:
           type: string
           x-vocabulary-closed: true
         updated_at:
-          description: RFC 3339 UTC.
+          description: RFC 3339 UTC. The moment the row last changed, and the value the cursor resumes from.
           format: date-time
           maxLength: 32
           type: string
@@ -6308,7 +6311,7 @@ components:
 info:
   description: "NextMoe public API v2. Public since 2026-08-25: any application mints its own nmk_ key in the developer portal, no approval required. The shape evolves additively; a breaking change to this document fails CI."
   title: NextMoe Public API v2
-  version: 2.0.0
+  version: 2.1.0
   x-stability: stable
 openapi: 3.1.0
 paths:
@@ -6509,7 +6512,16 @@ paths:
         - catalog
   /v2/catalog/changes:
     get:
-      description: Works updated recently, oldest first. Keyset-paginated. Requires an application key. ids= is not accepted.
+      description: |-
+        Works updated recently, oldest first. Keyset-paginated. Requires an application key. ids= is not accepted.
+
+        **This is the mirror channel.** If you cache any catalog-owned fact per work — above all the editorial display axis `content_limit`, whose verdict is `claimed_by.content_limit` when the claim block is present and otherwise `nsfw` when `content_rating` is `r18`, `sfw` otherwise — poll this feed instead of sweeping the catalog. Every write that changes a work's claim state, its display axis (the editorial NSFW flag or its content rating), or its existence bumps `updated_at` and surfaces the id here.
+
+        Bootstrap from an empty cursor: the feed enumerates the whole population oldest-updated-first, so the first drain IS the full inventory. Hydrate each page against /v2/catalog/works with ids= in batches of at most 100, with both gates open (nsfw=true and no content_limit), then keep the cursor and poll it at your own cadence.
+
+        gone: an entry carrying `gone: true` has left the public population — drop the mirrored row. Merged-away ids appear here as gone AND in /v2/catalog/redirects, which names the id that replaced them; repoint rather than delete when the redirect exists.
+
+        Everything else a work serves — covers, tags, titles, intros, ratings — surfaces best-effort: most of those writers touch the work too, but only claim state, the display axis and existence are promised.
       operationId: listCatalogChanges
       parameters:
         - description: Opaque keyset cursor from a prior next_cursor. Must start with cur_.


### PR DESCRIPTION
## Why

Two downstream sites mirror catalog's **editorial display verdict** (`content_limit`: `sfw` / `nsfw`) into a local cache column so their list pages can filter in SQL. Neither had a change channel for it, so both fell back to a **nightly full sweep** — ~300 HTTP requests over ~7.8k rows to learn about a handful of editor flips. The forum's code carries the lament verbatim:

> There is no feed for that field — the claim-event feed carries claim state only — so a full sweep is the only way an editor's flip reaches the local lists.

The channel already existed: `GET /v2/catalog/changes` keysets `catalog_work` on `(updated_at, id)`. It was simply never **declared**, and it had two holes. This PR declares it and closes them.

## Writer audit

Every recurring writer of the promised axis was checked. All but one already bump `catalog_work.updated_at`:

| Writer | Bump |
|---|---|
| `editspec.applyWorkColumn` (`display_nsfw` / `content_rating`) | GORM `Model.Update` — yes |
| claim lifecycle (`site` / `product_work_id` / `claim_state`, soft delete) | GORM `Model.Updates` / `Update` — yes |
| `releasemeta` weekly rating lane | explicit `updated_at = now()` — yes |
| survivorship claim move | explicit `now()` — yes |
| importers | INSERT-only for these columns; fresh rows carry fresh timestamps |
| `repository.TouchWorks` (every subresource write) | explicit `now()` — yes |
| survivorship `display_name` / `olang` merge onto the target | writes through `tx.Table("catalog_work")`, which has no schema and so no auto `updated_at` — covered because `ExecuteMerge` appends the target to `TouchWorks` |
| **`retireSource` (`merge_execute.go`)** | **no — fixed here** |

`retireSource` set `status = merged, site = NULL, product_work_id = NULL` without touching `updated_at`, and the GORM soft delete that follows writes `deleted_at` only (confirmed against `gorm.io/gorm@v1.31.1` `SoftDeleteDeleteClause`, which never runs the update callback's auto-timestamp path). So an executed merge retired an id in total silence. It now carries `updated_at = now()`.

## gone semantics

`PublicService.Changes` filtered `deleted_at IS NULL AND status = live`, so a work that left the population left the feed with it. The population is now **every** `catalog_work` row of the galgame medium (medium filter, 5-second in-flight-tx watermark, keyset and 500 limit cap all unchanged), with

```
gone = (deleted_at IS NOT NULL OR status <> live)
```

computed per row and rendered as an **optional** `gone` property — pointer + `omitempty`, present only when true, never sent as `false` (the repr package's house style, enforced by `TestOmitemptyOnlyOnPointers`).

That makes `gone` exactly the complement of the public works face: the `ids=` lane serves live, non-deleted works regardless of claim state (hidden claims are served with their state visible and filtered downstream). A `gone` entry means "drop the mirrored row"; if the id was merged away it also appears in `/v2/catalog/redirects`, which names the id that replaced it, so the right action there is repoint, not delete.

**No migration.** `idx_catalog_work_updated_id` is a full index on `(updated_at, id)` and the widened query still rides it. EXPLAIN on the 229,255-row dev catalog, resumed cursor:

```
Limit  (cost=0.42..203.38 rows=500 width=17)
  ->  Index Scan using idx_catalog_work_updated_id on catalog_work  (cost=0.42..27603.46 rows=68003 width=17)
        Index Cond: ((updated_at < (now() - '00:00:05'::interval)) AND (ROW(updated_at, id) > ROW(...)))
        Filter: (medium_id = 1)
```

Same plan as before, one fewer filter. The empty-cursor bootstrap plan is the same Index Scan.

## Spec

`2.0.0 → 2.1.0`, additive. One optional response property, a rewritten `listCatalogChanges` description that states the contract (mirror channel, verdict recipe, what bumps `updated_at`, bootstrap-then-poll loop, `gone`, and that everything beyond the promised axis is best-effort), and richer `Change` field docs. **No new operation** — the portal still reports 1 face / 88 operations.

All four spec/portal gate arms enumerated from `.github/workflows/` and run locally, all clean:

1. `test.yml` spec-sync — all 10 `gen-openapi` flags + `gen-v2-portal`, then `git diff --exit-code`
2. `openapi-types.yml` — the 5 `pnpm -F web gen:types:*` pairs (v2 has no TS pairing; run anyway, no drift)
3. `spec-breaking.yml` — pinned oasdiff 1.21.0 over all 9 gated specs vs `origin/main`, `rc=0`
4. `docs-model.yml` — `node apps/developer/scripts/sync-specs.mjs`, then `git diff --exit-code`

Plus `pnpm docs:check` / `docs:verify` from `../kungal-docs` (run against this worktree): 0 errors, same 2 pre-existing warnings as `main`.

## Test net

DB-backed, in the packages that already own the relevant harness. All start from a cursor taken at the feed tip (`settleWorks` + `drainChanges`, the existing pattern in `merge_touch_test.go`):

- `TestChangesFeedSurfacesDisplayAxisEdit` — `editspec.ApplyWorkFields` flipping `display_nsfw`
- `TestChangesFeedSurfacesContentRatingEdit` — the other half of the verdict
- `TestChangesFeedSurfacesClaimTransition` — a real `ClaimLifecycleService.Act` transition
- `TestFillRatingSurfacesOnTheChangesFeed` (`internal/jobs/releasemeta`) — the real `writer.fillRating`, not a copy of its SQL
- `TestChangesFeedMarksVanishedRowsGone` — soft-deleted and non-live rows both report `gone: true`; a live row in the same page reports nothing
- `TestChangesFeedSurfacesMergedSourceAsGone` — `ExecuteMerge` surfaces the source with `gone: true` **and** the pair is in the redirects feed
- `TestChangesFeedDoesNotRepeatUntouchedWorks` — negative control, paired with a positive one so an always-empty feed cannot pass it
- `TestChangesCursorMintedBeforeGoneStillResumes` — a hand-built cursor in the literal pre-change wire format still parses and resumes

Three existing assertions changed, because the contract they pinned is the one this wave inverts: `TestMergeWorkTouchesTargetAndRelationOtherEnd` ("a merged-away source must never enter the changes feed"), `TestMergeWorkClaimTransferTouchesTarget` and `TestMergeRehangOfCoverTouchesTarget` now expect the retired source alongside the survivor.

`go build ./... && go vet ./...` clean; full `go test -count=1 -p 1 ./...` against an ephemeral Postgres with `REQUIRE_DB_TESTS=1` — exit 0, 162 packages ok.

## Docs

`docs/catalog/01-service-and-contract.md` §8 (new) — the invariant, the verdict recipe (`claimed_by.content_limit` when present, else `content_rating == r18 ? nsfw : sfw`; server-side source `model.DisplayLimitKey`), the mirror loop (bootstrap from an empty cursor, which enumerates the whole population oldest-updated-first; hydrate `ids=` in ≤100 batches with **both gates open** — `nsfw=true` and no `content_limit`; then poll the cursor), `gone` → drop, redirects → repoint, and the recommended local predicate where a `NULL` cache column means not-synced-yet and passes while catalog's own gate at hydrate stays the authority. Cross-referenced from the §1 display-axis warning and from the README quick-reference. A wave note is appended to `v2-implementation-notes.md`.

Catalog docs have no downstream mirrors, so no `docs:sync` step is needed.

## Out of scope

- **No touch-audit or touch-extension for the cover / tag / intro jobs.** The feed stays best-effort beyond the promised axis (claim state, display axis, existence). Most of those writers do touch the work, but nothing here promises it.
- **No downstream repo changes.** Forum and moyu still have to adopt the loop.
- **No claim-events feed changes.**
- **Zero DB migrations.** The index already exists and the widened query rides it; nothing here adds or alters a column.

## Migrations

None. Nothing in this PR touches a GORM model, a column, a constraint or an index.
