### PR TITLE
fix(apiv2): close the anonymous read of /v2 and reopen the moderation queue

### DIFF
--- a/apps/api/cmd/catalog/main.go
+++ b/apps/api/cmd/catalog/main.go
@@ -282,6 +282,13 @@ func setupPublicCatalog(
 		return err
 	})
 
+	siteOfClient := func(ctx context.Context, clientID string) (string, error) {
+		cl, err := clientRepo.FindByClientID(ctx, clientID)
+		if err != nil || cl == nil {
+			return "", err
+		}
+		return cl.CatalogSite, nil
+	}
 	v2API := v2handler.SetupWith(application.Fiber, v2handler.Options{
 		Store:            protocol.NewRedisStore(devCache),
 		LookupCredential: mw.Lookup,
@@ -292,13 +299,7 @@ func setupPublicCatalog(
 			}
 			return v2handler.UserIdentity{UID: int64(claims.ID), ClientID: claims.ClientID, Roles: claims.Roles}, nil
 		},
-		LookupSite: func(ctx context.Context, clientID string) (string, error) {
-			cl, err := clientRepo.FindByClientID(ctx, clientID)
-			if err != nil || cl == nil {
-				return "", err
-			}
-			return cl.CatalogSite, nil
-		},
+		LookupSite: siteOfClient,
 		Catalog: &v2handler.Catalog{
 			Public:      publicSvc,
 			Resolve:     resolveSvc,
@@ -314,6 +315,8 @@ func setupPublicCatalog(
 			EditHistory: service.NewEditHistoryService(catalogDB.DB()),
 			Uploads:     v2handler.EditImageUpload(editUpload),
 			Store:       storeSvc,
+
+			SiteOfAppClient: siteOfClient,
 		},
 	})
 	v2spec, err := json.Marshal(v2API.OpenAPI())

--- a/apps/api/cmd/catalog/usage_route_pattern_test.go
+++ b/apps/api/cmd/catalog/usage_route_pattern_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
 	v2handler "api/internal/platform/apiv2/handler"
+	"api/internal/platform/devapi"
 
 	"github.com/gofiber/fiber/v3"
 )
@@ -19,7 +21,8 @@ import (
 //
 // The Authorization header is load-bearing: without it catalogAuth answers 401
 // from a middleware registered at "/" and c.Route().Path is "/" for every path,
-// which would make this test green on nothing.
+// which would make this test green on nothing. A real credential store is
+// load-bearing for the same reason — a nil one now answers 503 there.
 func routePatternApp(seen *[]string) *fiber.App {
 	f := fiber.New()
 	f.Use("/v2", func(c fiber.Ctx) error {
@@ -27,9 +30,27 @@ func routePatternApp(seen *[]string) *fiber.App {
 		*seen = append(*seen, c.Route().Path)
 		return err
 	})
-	v2handler.Setup(f)
+	v2handler.SetupWith(f, v2handler.Options{
+		LookupCredential: func(_ context.Context, raw string) (*devapi.Credential, error) {
+			if raw != probeKey {
+				return nil, nil
+			}
+			return &devapi.Credential{
+				KeyID: 1, ClientID: "probe", Tier: devapi.TierInternal,
+				Scopes: []string{devapi.ScopeCatalogRead, devapi.ScopeStoreRead},
+			}, nil
+		},
+	})
 	return f
 }
+
+var probeKey = func() string {
+	k, err := devapi.GenerateV2Key(true)
+	if err != nil {
+		panic(err)
+	}
+	return k
+}()
 
 func TestUsageRecordsTheRoutePatternNotTheConcretePath(t *testing.T) {
 	for _, tc := range []struct {
@@ -47,7 +68,7 @@ func TestUsageRecordsTheRoutePatternNotTheConcretePath(t *testing.T) {
 		var seen []string
 		f := routePatternApp(&seen)
 		r := httptest.NewRequest(tc.method, tc.path, nil)
-		r.Header.Set("Authorization", "Bearer nmk_live_probe")
+		r.Header.Set("Authorization", "Bearer "+probeKey)
 		if _, err := f.Test(r); err != nil {
 			t.Fatalf("%s %s: %v", tc.method, tc.path, err)
 		}

--- a/apps/api/internal/app/app.go
+++ b/apps/api/internal/app/app.go
@@ -51,11 +51,37 @@ func New(cfg *config.Config, opts Options) (*App, error) {
 	if name == "" {
 		name = "kun-api"
 	}
-	a.Fiber = fiber.New(fiber.Config{
+	a.Fiber = fiber.New(FiberConfig(name))
+	// First on purpose: a recover registered later still lets panics drop the connection with no 500.
+	a.Fiber.Use(middleware.Recover())
+
+	return a, nil
+}
+
+// FiberConfig is exported so a test can build the app the router-hardening
+// guarantee is stated about, instead of a config the test picked itself.
+func FiberConfig(name string) fiber.Config {
+	if name == "" {
+		name = "kun-api"
+	}
+	return fiber.Config{
 		AppName:        name,
 		ServerHeader:   name,
 		ErrorHandler:   errorHandler,
 		ReadBufferSize: 32 * 1024,
+		// Routes are matched on detectionPath, which fiber lowercases while
+		// CaseSensitive is off, and c.Path() returns the raw path. Every /v2
+		// auth gate compares c.Path(), so GET /v2/Catalog/works matched the
+		// route, missed every prefix in the gate and served the whole catalog
+		// surface — claim-events included — with no credential in production
+		// until 2026-08-28.
+		//
+		// StrictRouting stays off: cmd/oauth registers `sites.Get("/")` and
+		// `oauthClients.Get("/")`, i.e. /api/v1/sites/ and /api/v1/oauth/clients/,
+		// while apps/web calls them without the trailing slash. Turning it on
+		// 404s the admin console's site and OAuth-client pages. The /v2 gate
+		// trims trailing slashes itself instead.
+		CaseSensitive: true,
 		// Real client IP behind Cloudflare → Traefik (dokploy). Without this,
 		// c.IP() returns the immediate peer (Traefik, ~10.0.1.x) for EVERY user,
 		// which silently makes the rate limiters global-per-proxy (the strict
@@ -74,11 +100,7 @@ func New(cfg *config.Config, opts Options) (*App, error) {
 		TrustProxyConfig: fiber.TrustProxyConfig{
 			Private: true,
 		},
-	})
-	// First on purpose: a recover registered later still lets panics drop the connection with no 500.
-	a.Fiber.Use(middleware.Recover())
-
-	return a, nil
+	}
 }
 
 func (a *App) Run(host string, port int) error {

--- a/apps/api/internal/platform/apiv2/handler/catalog.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog.go
@@ -32,6 +32,9 @@ type Catalog struct {
 	EditHistory *catsvc.EditHistoryService
 	Uploads     EditImageUpload
 	Store       *storesvc.Service
+	// oauth_clients lives in the infra database, which no catalog service can
+	// reach, so the moderation fence takes its client -> site resolver here.
+	SiteOfAppClient func(ctx context.Context, clientID string) (string, error)
 }
 
 func (c *Catalog) ListWorks(ctx context.Context, q collect.Query) (repr.List[repr.Work], error) {

--- a/apps/api/internal/platform/apiv2/handler/catalog_auth_test.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_auth_test.go
@@ -114,7 +114,7 @@ func TestCatalogAuthLookupStoreFailureIs503(t *testing.T) {
 
 func TestCatalogAuthStubServesNSFWWithoutACapability(t *testing.T) {
 	app := testApp(t)
-	status, p := authGET(t, app, "/v2/catalog/works?nsfw=true", "test")
+	status, p := authGET(t, app, "/v2/catalog/works?nsfw=true", testAPIKey)
 	require.Equal(t, 503, status)
 	require.Equal(t, problem.CodeServiceUnavailable, p.Code)
 }

--- a/apps/api/internal/platform/apiv2/handler/catalog_works_filter.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_works_filter.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -33,7 +34,73 @@ type worksFilter struct {
 	OLang          catsvc.PublicOLang
 }
 
-func parseWorksFilter(in *listWorksInput) (worksFilter, *problem.Problem) {
+var publicClaimStates = []string{
+	catmodel.ClaimStateKeyNone, catmodel.ClaimStateKeyLive, catmodel.ClaimStateKeyDraft,
+}
+
+var moderationClaimStates = []string{
+	catmodel.ClaimStateKeyPending, catmodel.ClaimStateKeyDeclined, catmodel.ClaimStateKeyHidden,
+}
+
+func mentionsModerationClaimState(raw string) bool {
+	for _, tok := range strings.Split(raw, ",") {
+		if slices.Contains(moderationClaimStates, strings.TrimSpace(tok)) {
+			return true
+		}
+	}
+	return false
+}
+
+// moderationClaimStateSite answers the caller's own site when it may read the
+// moderation states, "" when it may not — in which case parseWorksFilter keeps
+// the public three-state vocabulary and the request gets the identical closed
+// -enum 400 it got before, so the wider set stays invisible.
+func (c *Catalog) moderationClaimStateSite(ctx context.Context, rawClaimState string) (string, *problem.Problem) {
+	if !mentionsModerationClaimState(rawClaimState) {
+		return "", nil
+	}
+	if !catalogAuthzFrom(ctx).ModerationRead {
+		return "", nil
+	}
+	if c == nil || c.SiteOfAppClient == nil {
+		return "", problem.New(problem.CodeServiceUnavailable, "", "", "the moderation site resolver is not bound.")
+	}
+	site, err := c.SiteOfAppClient(ctx, catalogAuthzFrom(ctx).ClientID)
+	if err != nil {
+		return "", problem.New(problem.CodeServiceUnavailable, "", "", "the moderation site resolver is unavailable.")
+	}
+	if site == "" {
+		return "", problem.New(problem.CodeSiteNotBound, "", "",
+			"this key's application is not bound to a catalog site, so it has no moderation queue.")
+	}
+	return site, nil
+}
+
+func fenceModerationSite(f worksFilter, ownSite string) *problem.Problem {
+	moderation := false
+	for _, st := range f.ClaimStates {
+		if slices.Contains(moderationClaimStates, st) {
+			moderation = true
+			break
+		}
+	}
+	if !moderation {
+		return nil
+	}
+	if f.Site == "" {
+		p := problem.New(problem.CodeValidationFailed, "", "", "a moderation claim_state needs site= to be unambiguous.")
+		p.Errors = []problem.FieldError{{Parameter: "site", Reason: problem.ReasonRequired,
+			Detail: "moderation states are per-site queues; pass site=" + ownSite}}
+		return p
+	}
+	if f.Site != ownSite {
+		return problem.New(problem.CodePermissionRequired, "", "",
+			"a moderation claim_state is fenced to the caller's own site.")
+	}
+	return nil
+}
+
+func parseWorksFilter(in *listWorksInput, moderationAllowed bool) (worksFilter, *problem.Problem) {
 	f := worksFilter{OLang: catsvc.PublicOLang{All: true}}
 	if in == nil {
 		return f, nil
@@ -53,12 +120,15 @@ func parseWorksFilter(in *listWorksInput) (worksFilter, *problem.Problem) {
 		}
 		f.Claimed = &v
 	}
-	// pending/declined/hidden are moderation-workflow states; v1 kept its pending
-	// queue behind a moderation scope, and the first v2 cut left all six states
-	// open to any catalog:read key. The queue lives on /v2/moderation/claims.
-	states, err := closedCSV(in.ClaimState, "claim_state", []string{
-		catmodel.ClaimStateKeyNone, catmodel.ClaimStateKeyLive, catmodel.ClaimStateKeyDraft,
-	})
+	// R1 closed this to the public three and pointed the queue at
+	// /v2/moderation/claims, but the forum's admin queue reads it from here with
+	// an application key, which that face does not accept — the review queue
+	// answered 400 in production and rendered as "no pending submissions".
+	allowedStates := publicClaimStates
+	if moderationAllowed {
+		allowedStates = append(append([]string{}, publicClaimStates...), moderationClaimStates...)
+	}
+	states, err := closedCSV(in.ClaimState, "claim_state", allowedStates)
 	if err != nil {
 		return worksFilter{}, err
 	}

--- a/apps/api/internal/platform/apiv2/handler/catalog_works_filter_test.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_works_filter_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"testing"
 
 	"api/internal/platform/apiv2/collect"
@@ -10,15 +11,15 @@ import (
 )
 
 func TestParseWorksFilterClosedVocab(t *testing.T) {
-	_, err := parseWorksFilter(&listWorksInput{ContentRating: "r17"})
+	_, err := parseWorksFilter(&listWorksInput{ContentRating: "r17"}, false)
 	if err == nil || err.Code != problem.CodeUnknownEnumValue {
 		t.Fatalf("content_rating: %v", err)
 	}
-	_, err = parseWorksFilter(&listWorksInput{ClaimState: "live,nope"})
+	_, err = parseWorksFilter(&listWorksInput{ClaimState: "live,nope"}, false)
 	if err == nil || err.Code != problem.CodeUnknownEnumValue {
 		t.Fatalf("claim_state: %v", err)
 	}
-	_, err = parseWorksFilter(&listWorksInput{ReleasedAfter: "2024-13-01"})
+	_, err = parseWorksFilter(&listWorksInput{ReleasedAfter: "2024-13-01"}, false)
 	if err == nil {
 		t.Fatal("bad date")
 	}
@@ -26,7 +27,7 @@ func TestParseWorksFilterClosedVocab(t *testing.T) {
 		Q: "千恋", ContentRating: "r18", CompanyID: "12", TagID: "1,2",
 		ReleasedAfter: "2020-01-01", OLang: "ja", Claimed: "true",
 		ClaimState: "live", ContentLimit: "sfw", CompanyRollup: "true",
-	})
+	}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +43,7 @@ func TestParseWorksFilterClosedVocab(t *testing.T) {
 }
 
 func TestParseWorksFilterOLangDefaultAll(t *testing.T) {
-	f, err := parseWorksFilter(&listWorksInput{})
+	f, err := parseWorksFilter(&listWorksInput{}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,17 +100,20 @@ func TestListWorksFilteredQAndIDsExclusive(t *testing.T) {
 	}
 }
 
-// claim_state used to admit all six states to any catalog:read key; pending,
-// declined and hidden are moderation-workflow states and moved behind
-// /v2/moderation/claims.
+// claim_state used to admit all six states to any catalog:read key. R1 closed
+// it to the public three for everyone, which broke the forum's admin queue;
+// the moderation three are now readable, but only behind claim_events:read.
 func TestParseWorksFilterClaimStateIsPublicOnly(t *testing.T) {
 	for _, state := range []string{"pending", "declined", "hidden"} {
-		_, err := parseWorksFilter(&listWorksInput{ClaimState: state})
+		_, err := parseWorksFilter(&listWorksInput{ClaimState: state}, false)
 		if err == nil || err.Code != problem.CodeUnknownEnumValue {
 			t.Fatalf("claim_state=%s: %v", state, err)
 		}
+		if len(err.Errors) != 1 || err.Errors[0].Detail != "allowed values: none, live, draft" {
+			t.Fatalf("claim_state=%s must not advertise the wider set: %+v", state, err.Errors)
+		}
 	}
-	f, err := parseWorksFilter(&listWorksInput{ClaimState: "none,live,draft"})
+	f, err := parseWorksFilter(&listWorksInput{ClaimState: "none,live,draft"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,19 +122,81 @@ func TestParseWorksFilterClaimStateIsPublicOnly(t *testing.T) {
 	}
 }
 
+func TestParseWorksFilterClaimStateModerationAllowed(t *testing.T) {
+	f, err := parseWorksFilter(&listWorksInput{ClaimState: "pending", Site: "kungal"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.ClaimStates) != 1 || f.ClaimStates[0] != catmodel.ClaimStateKeyPending {
+		t.Fatalf("claim_states %+v", f.ClaimStates)
+	}
+	if _, err = parseWorksFilter(&listWorksInput{ClaimState: "nope"}, true); err == nil || err.Code != problem.CodeUnknownEnumValue {
+		t.Fatalf("the wider vocabulary is still closed: %v", err)
+	}
+}
+
+func TestFenceModerationSite(t *testing.T) {
+	if p := fenceModerationSite(worksFilter{ClaimStates: []string{catmodel.ClaimStateKeyLive}}, ""); p != nil {
+		t.Fatalf("public states are unfenced: %v", p)
+	}
+	p := fenceModerationSite(worksFilter{ClaimStates: []string{catmodel.ClaimStateKeyPending}}, "kungal")
+	if p == nil || p.Code != problem.CodeValidationFailed {
+		t.Fatalf("site= is mandatory: %v", p)
+	}
+	p = fenceModerationSite(worksFilter{ClaimStates: []string{catmodel.ClaimStateKeyPending}, Site: "moyu"}, "kungal")
+	if p == nil || p.Code != problem.CodePermissionRequired {
+		t.Fatalf("cross-tenant site= must be refused: %v", p)
+	}
+	if p = fenceModerationSite(worksFilter{ClaimStates: []string{catmodel.ClaimStateKeyPending}, Site: "kungal"}, "kungal"); p != nil {
+		t.Fatalf("own site is allowed: %v", p)
+	}
+}
+
+func TestModerationClaimStateSiteAuthority(t *testing.T) {
+	cat := &Catalog{SiteOfAppClient: func(context.Context, string) (string, error) { return "kungal", nil }}
+
+	site, p := cat.moderationClaimStateSite(t.Context(), "live,draft")
+	if site != "" || p != nil {
+		t.Fatalf("public states resolve no site: %q %v", site, p)
+	}
+	site, p = cat.moderationClaimStateSite(t.Context(), "pending")
+	if site != "" || p != nil {
+		t.Fatalf("no credential means no authority: %q %v", site, p)
+	}
+	ctx := context.WithValue(t.Context(), ctxCatalogAuthz, catalogAuthz{ClientID: "forum", ModerationRead: true})
+	site, p = cat.moderationClaimStateSite(ctx, "pending")
+	if p != nil || site != "kungal" {
+		t.Fatalf("claim_events:read resolves the caller's site: %q %v", site, p)
+	}
+	ctx = context.WithValue(t.Context(), ctxCatalogAuthz, catalogAuthz{ClientID: "forum", ModerationRead: false})
+	site, p = cat.moderationClaimStateSite(ctx, "pending")
+	if site != "" || p != nil {
+		t.Fatalf("catalog:read alone grants nothing: %q %v", site, p)
+	}
+
+	unbound := &Catalog{SiteOfAppClient: func(context.Context, string) (string, error) { return "", nil }}
+	ctx = context.WithValue(t.Context(), ctxCatalogAuthz, catalogAuthz{ClientID: "nosite", ModerationRead: true})
+	if _, p = unbound.moderationClaimStateSite(ctx, "hidden"); p == nil || p.Code != problem.CodeSiteNotBound {
+		t.Fatalf("a key with no catalog site has no queue: %v", p)
+	}
+	if _, p = (&Catalog{}).moderationClaimStateSite(ctx, "hidden"); p == nil || p.Code != problem.CodeServiceUnavailable {
+		t.Fatalf("an unbound resolver must fail closed: %v", p)
+	}
+}
+
 func TestParseWorksFilterOwnerUID(t *testing.T) {
-	_, err := parseWorksFilter(&listWorksInput{OwnerUID: "7"})
+	_, err := parseWorksFilter(&listWorksInput{OwnerUID: "7"}, false)
 	if err == nil || err.Code != problem.CodeValidationFailed {
 		t.Fatalf("owner_uid without site: %v", err)
 	}
 	if len(err.Errors) != 1 || err.Errors[0].Reason != problem.ReasonInconsistentWith {
 		t.Fatalf("owner_uid field error %+v", err.Errors)
 	}
-	_, err = parseWorksFilter(&listWorksInput{OwnerUID: "nope", Site: "kungal"})
+	_, err = parseWorksFilter(&listWorksInput{OwnerUID: "nope", Site: "kungal"}, false)
 	if err == nil || err.Code != problem.CodeInvalidParameter {
 		t.Fatalf("owner_uid non-numeric: %v", err)
 	}
-	f, err := parseWorksFilter(&listWorksInput{OwnerUID: "7", Site: "kungal"})
+	f, err := parseWorksFilter(&listWorksInput{OwnerUID: "7", Site: "kungal"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +207,7 @@ func TestParseWorksFilterOwnerUID(t *testing.T) {
 
 func TestListWorksFilteredRefusesOwnerUIDOnSearch(t *testing.T) {
 	cat := &Catalog{Public: &catsvc.PublicService{}, Searcher: nil}
-	f, perr := parseWorksFilter(&listWorksInput{OwnerUID: "7", Site: "kungal", Q: "kanon"})
+	f, perr := parseWorksFilter(&listWorksInput{OwnerUID: "7", Site: "kungal", Q: "kanon"}, false)
 	if perr != nil {
 		t.Fatal(perr)
 	}

--- a/apps/api/internal/platform/apiv2/handler/catalog_works_moderation_test.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_works_moderation_test.go
@@ -1,0 +1,85 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	kunapp "api/internal/app"
+	"api/internal/platform/apiv2/collect"
+	"api/internal/platform/apiv2/problem"
+	"api/internal/platform/apiv2/repr"
+	"api/internal/platform/devapi"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// The gate publishes its verdict as a fiber Local and the handler reads it back
+// off the huma context; humafiber copies the request's user values across, so
+// the two halves only meet over a real request. Everything below therefore goes
+// through app.Test rather than a hand-built context.
+func moderationQueueApp(t *testing.T, key string, scopes []string, ownSite string) *fiber.App {
+	t.Helper()
+	app := fiber.New(kunapp.FiberConfig("kun-catalog"))
+	SetupWith(app, Options{
+		LookupCredential: func(_ context.Context, raw string) (*devapi.Credential, error) {
+			if raw != key {
+				return nil, nil
+			}
+			return &devapi.Credential{KeyID: 53, ClientID: "forum", Tier: devapi.TierInternal, Scopes: scopes}, nil
+		},
+		// Works is bound and Catalog.Public is not, so a request that clears the
+		// gate, the vocabulary and the fence answers 200 — an unambiguous
+		// "reached the handler" that no 503 can be confused with.
+		Works: func(context.Context, collect.Query) (repr.List[repr.Work], error) {
+			return repr.NewList([]repr.Work{}, nil), nil
+		},
+		Catalog: &Catalog{
+			SiteOfAppClient: func(context.Context, string) (string, error) { return ownSite, nil },
+		},
+	})
+	return app
+}
+
+// The forum's admin submission queue reads this face with an application key
+// and got 400 UNKNOWN_ENUM_VALUE in production, which the page rendered as "no
+// pending submissions".
+func TestModerationClaimStatesNeedTheOperatorScope(t *testing.T) {
+	key := mustV2Key(t)
+	operator := moderationQueueApp(t, key,
+		[]string{devapi.ScopeCatalogRead, devapi.ScopeClaimEventsRead}, "kungal")
+
+	status, code := walkGet(t, operator, "/v2/catalog/works?claimed=true&claim_state=pending&site=kungal&sort=updated", key)
+	require.Equal(t, http.StatusOK, status, "the forum's exact admin-queue query")
+	require.Empty(t, code)
+
+	status, code = walkGet(t, operator, "/v2/catalog/works?claim_state=pending", key)
+	// 422, like the sibling owner_uid-needs-site rule this mirrors.
+	require.Equal(t, http.StatusUnprocessableEntity, status, "site= is mandatory on a moderation state")
+	require.Equal(t, problem.CodeValidationFailed, code)
+
+	status, code = walkGet(t, operator, "/v2/catalog/works?claim_state=pending&site=moyu", key)
+	require.Equal(t, http.StatusForbidden, status, "another tenant's queue")
+	require.Equal(t, problem.CodePermissionRequired, code)
+
+	// Positive control on the public half: the same key still browses normally.
+	status, _ = walkGet(t, operator, "/v2/catalog/works?claim_state=live", key)
+	require.Equal(t, http.StatusOK, status)
+}
+
+// Without the scope the refusal must be the one R1 already gave, so the wider
+// set is not discoverable through a distinguishable error.
+func TestModerationClaimStatesAreInvisibleToAnOrdinaryKey(t *testing.T) {
+	key := mustV2Key(t)
+	plain := moderationQueueApp(t, key, []string{devapi.ScopeCatalogRead}, "kungal")
+
+	for _, state := range []string{"pending", "declined", "hidden"} {
+		status, code := walkGet(t, plain, "/v2/catalog/works?claim_state="+state+"&site=kungal", key)
+		require.Equal(t, http.StatusBadRequest, status, state)
+		require.Equal(t, problem.CodeUnknownEnumValue, code, state)
+	}
+	status, code := walkGet(t, plain, "/v2/catalog/works?claim_state=live", key)
+	require.Equal(t, http.StatusOK, status)
+	require.Empty(t, code)
+}

--- a/apps/api/internal/platform/apiv2/handler/collection.go
+++ b/apps/api/internal/platform/apiv2/handler/collection.go
@@ -67,7 +67,7 @@ type listWorksInput struct {
 	Q              string `query:"q" maxLength:"512" doc:"Work title search. Switches this collection to the search index; sort defaults to relevance. Must not be used as a discriminant."`
 	ContentRating  string `query:"content_rating" maxLength:"16" doc:"Closed: all_ages, sensitive, r18. r18 requires nsfw=true."`
 	Claimed        string `query:"claimed" maxLength:"8" doc:"true or false. Absent = no gate."`
-	ClaimState     string `query:"claim_state" maxLength:"128" doc:"Comma-separated closed states: none, live, draft. Moderation states live on /v2/moderation/claims."`
+	ClaimState     string `query:"claim_state" maxLength:"128" doc:"Comma-separated closed states: none, live, draft. pending, declined and hidden are the per-site moderation queue: they need a key holding claim_events:read and a site= naming the caller's own site, and are otherwise not in the vocabulary."`
 	ContentLimit   string `query:"content_limit" maxLength:"32" doc:"Comma-separated closed editorial axis: sfw, nsfw."`
 	Site           string `query:"site" maxLength:"64" doc:"Claiming site key. Open vocabulary; unknown values match nothing."`
 	OwnerUID       string `query:"owner_uid" maxLength:"20" doc:"The claiming site's own user id of the claim owner. Requires site=. Live registry filter; cannot be combined with q= or search sorts."`
@@ -159,9 +159,16 @@ func listWorks(src WorksFunc, cat *Catalog) func(context.Context, *listWorksInpu
 		if err != nil {
 			return nil, withIdent(ctx, err)
 		}
-		filt, ferr := parseWorksFilter(in)
+		modSite, merr := cat.moderationClaimStateSite(ctx, in.ClaimState)
+		if merr != nil {
+			return nil, withIdent(ctx, merr)
+		}
+		filt, ferr := parseWorksFilter(in, modSite != "")
 		if ferr != nil {
 			return nil, withIdent(ctx, ferr)
+		}
+		if serr := fenceModerationSite(filt, modSite); serr != nil {
+			return nil, withIdent(ctx, serr)
 		}
 		if cat != nil && cat.Public != nil {
 			page, lerr := cat.ListWorksFiltered(ctx, q, filt)
@@ -237,9 +244,38 @@ func credentialLimitIdentity(c fiber.Ctx) (protocol.LimitIdentity, bool) {
 	return protocol.LimitIdentity{}, false
 }
 
+// Fiber routes on detectionPath — c.Path() lowercased while CaseSensitive is
+// off, with trailing slashes trimmed while StrictRouting is off — but c.Path()
+// itself returns the raw path. Reading c.Path() here meant /v2/Catalog/works
+// matched the route, missed every prefix below, fell out the open default arm
+// and answered 200 with no credential; /v2/catalog/claim-events/ likewise
+// missed the operator-scope compare. Both were live in production until
+// 2026-08-28. The gate must key on what fiber matched, not on what was typed.
+func routedPath(raw string) string {
+	p := strings.ToLower(raw)
+	for len(p) > 1 && p[len(p)-1] == '/' {
+		p = p[:len(p)-1]
+	}
+	return p
+}
+
+// The gate resolves the moderation verdict once and the handlers consume it,
+// so no face re-derives policy from raw scopes.
+type catalogAuthz struct {
+	ClientID       string
+	ModerationRead bool
+}
+
+const ctxCatalogAuthz ctxKey = "v2_catalog_authz"
+
+func catalogAuthzFrom(ctx context.Context) catalogAuthz {
+	v, _ := ctx.Value(ctxCatalogAuthz).(catalogAuthz)
+	return v
+}
+
 func catalogAuth(lookup func(context.Context, string) (*devapi.Credential, error)) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		path := c.Path()
+		path := routedPath(c.Path())
 		scope := ""
 		switch {
 		case strings.HasPrefix(path, "/v2/catalog/"):
@@ -267,8 +303,12 @@ func catalogAuth(lookup func(context.Context, string) (*devapi.Credential, error
 			return problem.WriteFiberError(c, problem.New(problem.CodeInvalidCredential, problem.RequestID(c), problem.Instance(c),
 				"Authorization Bearer token is invalid."))
 		}
+		// This arm used to `return c.Next()`: with no credential store wired,
+		// every gated /v2 face answered anonymously. A missing dependency is a
+		// server fault, never a grant.
 		if lookup == nil {
-			return c.Next()
+			return problem.WriteFiberError(c, problem.New(problem.CodeServiceUnavailable, problem.RequestID(c), problem.Instance(c),
+				"credential store is unavailable."))
 		}
 		if devapi.HasV1KeyPrefix(token) {
 			return problem.WriteFiberError(c, problem.New(problem.CodeInvalidCredential, problem.RequestID(c), problem.Instance(c),
@@ -296,6 +336,10 @@ func catalogAuth(lookup func(context.Context, string) (*devapi.Credential, error
 				"this operation additionally requires the claim_events:read scope."))
 		}
 		devapi.WithCredential(c, cred)
+		c.Locals(ctxCatalogAuthz, catalogAuthz{
+			ClientID:       cred.ClientID,
+			ModerationRead: cred.HasScope(devapi.ScopeClaimEventsRead),
+		})
 		return c.Next()
 	}
 }

--- a/apps/api/internal/platform/apiv2/handler/contract_test.go
+++ b/apps/api/internal/platform/apiv2/handler/contract_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -9,15 +10,37 @@ import (
 	"testing"
 
 	"api/internal/platform/apiv2/problem"
+	"api/internal/platform/devapi"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/stretchr/testify/require"
 )
 
+// A nil LookupCredential used to mean "gate open", which is what these tests
+// leaned on when they sent `Bearer test`. It now answers 503, so the shared
+// test app carries a real credential store.
+var testAPIKey = func() string {
+	k, err := devapi.GenerateV2Key(false)
+	if err != nil {
+		panic(err)
+	}
+	return k
+}()
+
+func testCredentialLookup(_ context.Context, raw string) (*devapi.Credential, error) {
+	if raw == testAPIKey {
+		return &devapi.Credential{
+			KeyID: 99, ClientID: "test-app", Tier: devapi.TierInternal,
+			Scopes: []string{devapi.ScopeCatalogRead, devapi.ScopeStoreRead},
+		}, nil
+	}
+	return nil, nil
+}
+
 func testApp(t *testing.T) *fiber.App {
 	t.Helper()
 	app := fiber.New(fiber.Config{ErrorHandler: problem.WriteFiberError})
-	Setup(app)
+	SetupWith(app, Options{LookupCredential: testCredentialLookup})
 	return app
 }
 
@@ -231,13 +254,13 @@ func TestWorksRequiresCredential(t *testing.T) {
 	require.Equal(t, problem.CodeMissingCredential, p.Code)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/catalog/works?limit=101", nil)
-	req.Header.Set("Authorization", "Bearer test")
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, 400, resp.StatusCode)
 
 	req = httptest.NewRequest(http.MethodGet, "/v2/catalog/works?nsfw=true", nil)
-	req.Header.Set("Authorization", "Bearer test")
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
 	resp, err = app.Test(req)
 	require.NoError(t, err)
 	body, err = io.ReadAll(resp.Body)
@@ -248,7 +271,7 @@ func TestWorksRequiresCredential(t *testing.T) {
 	require.Equal(t, problem.CodeServiceUnavailable, p.Code)
 
 	req = httptest.NewRequest(http.MethodGet, "/v2/catalog/works/1?nsfw=yes", nil)
-	req.Header.Set("Authorization", "Bearer test")
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
 	resp, err = app.Test(req)
 	require.NoError(t, err)
 	body, err = io.ReadAll(resp.Body)
@@ -292,7 +315,7 @@ func TestCatalogStatsAndNewsUnauthenticated(t *testing.T) {
 	require.Equal(t, problem.CodeMissingCredential, p.Code)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/catalog/works/1", nil)
-	req.Header.Set("Authorization", "Bearer test")
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	body, err = io.ReadAll(resp.Body)
@@ -302,7 +325,7 @@ func TestCatalogStatsAndNewsUnauthenticated(t *testing.T) {
 	require.Equal(t, problem.CodeServiceUnavailable, p.Code)
 
 	req = httptest.NewRequest(http.MethodGet, "/v2/catalog/companies/1", nil)
-	req.Header.Set("Authorization", "Bearer test")
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
 	resp, err = app.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, 503, resp.StatusCode)
@@ -314,7 +337,7 @@ func TestCatalogStatsAndNewsUnauthenticated(t *testing.T) {
 	require.Equal(t, problem.CodeMissingCredential, p.Code)
 
 	req = httptest.NewRequest(http.MethodGet, "/v2/catalog/companies/1/graph", nil)
-	req.Header.Set("Authorization", "Bearer test")
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
 	resp, err = app.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, 503, resp.StatusCode)
@@ -345,7 +368,7 @@ func TestCatalogCollectionsRequireCredential(t *testing.T) {
 		require.Equal(t, problem.CodeMissingCredential, p.Code, path)
 
 		req := httptest.NewRequest(http.MethodGet, path, nil)
-		req.Header.Set("Authorization", "Bearer test")
+		req.Header.Set("Authorization", "Bearer "+testAPIKey)
 		resp, err := app.Test(req)
 		require.NoError(t, err, path)
 		require.Equal(t, 503, resp.StatusCode, path)
@@ -362,13 +385,13 @@ func TestWorkSubresourcesRequireCredential(t *testing.T) {
 	require.Equal(t, problem.CodeMissingCredential, p.Code)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/catalog/works/1/covers", nil)
-	req.Header.Set("Authorization", "Bearer test")
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
 	resp, err := app.Test(req)
 	require.NoError(t, err)
 	require.Equal(t, 503, resp.StatusCode)
 
 	req = httptest.NewRequest(http.MethodGet, "/v2/catalog/works/1?include=nope", nil)
-	req.Header.Set("Authorization", "Bearer test")
+	req.Header.Set("Authorization", "Bearer "+testAPIKey)
 	resp, err = app.Test(req)
 	require.NoError(t, err)
 	body, err = io.ReadAll(resp.Body)

--- a/apps/api/internal/platform/apiv2/handler/identity.go
+++ b/apps/api/internal/platform/apiv2/handler/identity.go
@@ -93,7 +93,9 @@ type UserIdentity struct {
 
 func userAuth(lookup func(context.Context, string) (UserIdentity, error), lookupSite func(context.Context, string) (string, error)) fiber.Handler {
 	return func(c fiber.Ctx) error {
-		path := c.Path()
+		// Same trap as catalogAuth: c.Path() is not what fiber matched on, so
+		// GET /v2/Me/claims skipped this gate entirely.
+		path := routedPath(c.Path())
 		if !strings.HasPrefix(path, "/v2/me/") && !strings.HasPrefix(path, "/v2/moderation/") {
 			return c.Next()
 		}

--- a/apps/api/internal/platform/apiv2/handler/route_gate_walk_test.go
+++ b/apps/api/internal/platform/apiv2/handler/route_gate_walk_test.go
@@ -1,0 +1,236 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	kunapp "api/internal/app"
+	"api/internal/platform/apiv2/problem"
+	"api/internal/platform/devapi"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// specV2Paths reads the published path table rather than the in-process
+// document: the walk below is a promise about the surface the world is told
+// exists, and it has to keep holding when the two drift.
+func specV2Paths(t *testing.T) []string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "..", "..", "docs", "catalog", "v2-openapi.yaml"))
+	require.NoError(t, err)
+	var doc struct {
+		Paths map[string]yaml.Node `yaml:"paths"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+	out := make([]string, 0, len(doc.Paths))
+	for p := range doc.Paths {
+		out = append(out, p)
+	}
+	require.NotEmpty(t, out)
+	return out
+}
+
+var specPathParams = strings.NewReplacer(
+	"{code}", "RATE_LIMITED",
+	"{name}", "medium",
+	"{id}", "1",
+	"{object}", "work",
+	"{work_id}", "1",
+	"{cover_id}", "1",
+	"{product_id}", "RJ01000000",
+)
+
+func concretePath(t *testing.T, specPath string) string {
+	t.Helper()
+	p := specPathParams.Replace(specPath)
+	require.NotContains(t, p, "{", "unsubstituted path param in %s", specPath)
+	return p
+}
+
+// caseVariantPath flips the first letter of the first segment after /v2 —
+// exactly the production probe that answered 200: GET /v2/Catalog/works.
+func caseVariantPath(p string) (string, bool) {
+	rest, ok := strings.CutPrefix(p, "/v2/")
+	if !ok || rest == "" {
+		return "", false
+	}
+	c := rest[0]
+	switch {
+	case c >= 'a' && c <= 'z':
+		c -= 'a' - 'A'
+	case c >= 'A' && c <= 'Z':
+		c += 'a' - 'A'
+	default:
+		return "", false
+	}
+	return "/v2/" + string(c) + rest[1:], true
+}
+
+func gateWalkApp(t *testing.T, cred *devapi.Credential) *fiber.App {
+	t.Helper()
+	// The production config, not one this test chose: CaseSensitive lives there,
+	// and a test that set its own would prove nothing about the running service.
+	app := fiber.New(kunapp.FiberConfig("kun-catalog"))
+	SetupWith(app, Options{
+		LookupCredential: func(context.Context, string) (*devapi.Credential, error) { return cred, nil },
+	})
+	return app
+}
+
+// walkGet returns the status AND the problem code, because "not a 2xx" is not
+// the question. Every face here is unbound in a unit test, so a request that
+// sails past the gate still answers 503 — an earlier draft of this walk was
+// green against the unfixed gate for exactly that reason. The only safe
+// signal is that the answer is still the gate's own.
+func walkGet(t *testing.T, app *fiber.App, path, bearer string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := app.Test(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var p problem.Problem
+	if len(body) > 0 && json.Unmarshal(body, &p) == nil {
+		return resp.StatusCode, p.Code
+	}
+	return resp.StatusCode, ""
+}
+
+// refusedBeforeTheHandler is true when the gate answered (401 MISSING_CREDENTIAL
+// / 403 SCOPE_REQUIRED) or the router never matched (404 NOT_FOUND). Anything
+// else means the request reached a face it had no credential for.
+func refusedBeforeTheHandler(status int, code string) bool {
+	switch code {
+	case problem.CodeMissingCredential, problem.CodeInvalidCredential, problem.CodeScopeRequired:
+		return true
+	case problem.CodeNotFound, problem.CodeMethodNotAllowed:
+		return status == http.StatusNotFound || status == http.StatusMethodNotAllowed
+	}
+	return false
+}
+
+// The whole /v2/catalog surface answered 200 to an anonymous GET whose first
+// segment after /v2 was capitalised, because the gate read c.Path() while fiber
+// routed on its lowercased detectionPath. This walks every published path in
+// both variant forms so no future face can reintroduce the class.
+func TestNoV2PathVariantIsReachableWithoutCredentials(t *testing.T) {
+	app := gateWalkApp(t, nil)
+	paths := specV2Paths(t)
+
+	gated := 0
+	for _, specPath := range paths {
+		path := concretePath(t, specPath)
+		status, code := walkGet(t, app, path, "")
+		if status != http.StatusUnauthorized || code != problem.CodeMissingCredential {
+			continue
+		}
+		gated++
+
+		variants := []string{path + "/", path + "//"}
+		if v, ok := caseVariantPath(path); ok {
+			variants = append(variants, v)
+		}
+		for _, v := range variants {
+			vs, vc := walkGet(t, app, v, "")
+			if !refusedBeforeTheHandler(vs, vc) {
+				t.Errorf("GET %s answered %d %s with no credential; canonical %s is 401 %s",
+					v, vs, vc, path, problem.CodeMissingCredential)
+			}
+		}
+	}
+
+	// Positive control: a walk that matched nothing would pass green. These two
+	// are the paths production actually served anonymously.
+	status, code := walkGet(t, app, "/v2/catalog/works", "")
+	require.Equal(t, http.StatusUnauthorized, status)
+	require.Equal(t, problem.CodeMissingCredential, code)
+	status, code = walkGet(t, app, "/v2/catalog/claim-events", "")
+	require.Equal(t, http.StatusUnauthorized, status)
+	require.Equal(t, problem.CodeMissingCredential, code)
+	require.Greater(t, gated, 40, "the walk exercised too few gated paths to mean anything")
+
+	// Negative control on the other side: the unauthenticated faces and the
+	// keyless allowlist must still reach their handlers, or "everything 401s"
+	// would masquerade as a fix.
+	status, _ = walkGet(t, app, "/v2/problems", "")
+	require.Equal(t, http.StatusOK, status)
+	status, _ = walkGet(t, app, "/v2/vocabularies", "")
+	require.Equal(t, http.StatusOK, status)
+	_, code = walkGet(t, app, "/v2/catalog/schemas/work", "")
+	require.NotEqual(t, problem.CodeMissingCredential, code)
+}
+
+// /v2/catalog/claim-events carries actor uids and decline reasons across every
+// tenant. The extra scope was checked with `path == "/v2/catalog/claim-events"`,
+// so one trailing slash routed to the same handler and skipped the check.
+func TestClaimEventsOperatorScopeSurvivesPathVariants(t *testing.T) {
+	selfService := &devapi.Credential{
+		KeyID: 1, ClientID: "some-app", Tier: devapi.TierFree,
+		Scopes: []string{devapi.ScopeCatalogRead},
+	}
+	app := gateWalkApp(t, selfService)
+	key := mustV2Key(t)
+
+	status, code := walkGet(t, app, "/v2/catalog/claim-events", key)
+	require.Equal(t, http.StatusForbidden, status, "positive control: catalog:read alone must not read the operator feed")
+	require.Equal(t, problem.CodeScopeRequired, code)
+
+	for _, variant := range []string{
+		"/v2/catalog/claim-events/",
+		"/v2/catalog/claim-events//",
+		"/v2/Catalog/claim-events",
+	} {
+		vs, vc := walkGet(t, app, variant, key)
+		require.True(t, refusedBeforeTheHandler(vs, vc),
+			"GET %s answered %d %s and reached the operator feed with %v", variant, vs, vc, selfService.Scopes)
+	}
+
+	// The same key still reads the ordinary catalog faces, so the guard is not
+	// simply refusing everything.
+	_, code = walkGet(t, app, "/v2/catalog/works", key)
+	require.NotEqual(t, problem.CodeScopeRequired, code)
+}
+
+// A nil credential store used to mean "let everyone through".
+func TestCatalogAuthFailsClosedWithoutACredentialStore(t *testing.T) {
+	app := fiber.New(kunapp.FiberConfig("kun-catalog"))
+	SetupWith(app, Options{})
+	key := mustV2Key(t)
+
+	for _, path := range []string{"/v2/catalog/works", "/v2/store/stats"} {
+		status, code := walkGet(t, app, path, key)
+		require.Equal(t, http.StatusServiceUnavailable, status, path)
+		require.Equal(t, problem.CodeServiceUnavailable, code, path)
+	}
+	// Still 401 without a token at all, and the keyless allowlist is unaffected.
+	status, code := walkGet(t, app, "/v2/catalog/works", "")
+	require.Equal(t, http.StatusUnauthorized, status)
+	require.Equal(t, problem.CodeMissingCredential, code)
+	_, code = walkGet(t, app, "/v2/catalog/schemas/work", "")
+	require.NotEqual(t, problem.CodeMissingCredential, code)
+}
+
+func TestRoutedPathMirrorsFiberDetectionPath(t *testing.T) {
+	for raw, want := range map[string]string{
+		"/v2/catalog/works":         "/v2/catalog/works",
+		"/v2/Catalog/works":         "/v2/catalog/works",
+		"/v2/CATALOG/WORKS":         "/v2/catalog/works",
+		"/v2/catalog/claim-events/": "/v2/catalog/claim-events",
+		"/v2/catalog/works//":       "/v2/catalog/works",
+		"/":                         "/",
+	} {
+		require.Equal(t, want, routedPath(raw), "routedPath(%q)", raw)
+	}
+}

--- a/apps/developer/app/generated/docs-model.ts
+++ b/apps/developer/app/generated/docs-model.ts
@@ -41894,7 +41894,7 @@ export const docsModel: DocsModel = {
                   "in": "query",
                   "required": false,
                   "type": "string",
-                  "doc": "Comma-separated closed states: none, live, draft. Moderation states live on /v2/moderation/claims."
+                  "doc": "Comma-separated closed states: none, live, draft. pending, declined and hidden are the per-site moderation queue: they need a key holding claim_events:read and a site= naming the caller's own site, and are otherwise not in the vocabulary."
                 },
                 {
                   "name": "content_limit",

--- a/apps/developer/public/docs/v2/listCatalogWorks.md
+++ b/apps/developer/public/docs/v2/listCatalogWorks.md
@@ -35,7 +35,7 @@ Keyset-paginated work collection. q= switches to search (sort defaults to releva
 | `q` | query | 否 | string | Work title search. Switches this collection to the search index; sort defaults to relevance. Must not be used as a discriminant. |
 | `content_rating` | query | 否 | string | Closed: all_ages, sensitive, r18. r18 requires nsfw=true. |
 | `claimed` | query | 否 | string | true or false. Absent = no gate. |
-| `claim_state` | query | 否 | string | Comma-separated closed states: none, live, draft. Moderation states live on /v2/moderation/claims. |
+| `claim_state` | query | 否 | string | Comma-separated closed states: none, live, draft. pending, declined and hidden are the per-site moderation queue: they need a key holding claim_events:read and a site= naming the caller's own site, and are otherwise not in the vocabulary. |
 | `content_limit` | query | 否 | string | Comma-separated closed editorial axis: sfw, nsfw. |
 | `site` | query | 否 | string | Claiming site key. Open vocabulary; unknown values match nothing. |
 | `owner_uid` | query | 否 | string | The claiming site's own user id of the claim owner. Requires site=. Live registry filter; cannot be combined with q= or search sorts. |

--- a/apps/developer/public/llms-full.txt
+++ b/apps/developer/public/llms-full.txt
@@ -1059,7 +1059,7 @@ Keyset-paginated work collection. q= switches to search (sort defaults to releva
 | `q` | query | 否 | string | Work title search. Switches this collection to the search index; sort defaults to relevance. Must not be used as a discriminant. |
 | `content_rating` | query | 否 | string | Closed: all_ages, sensitive, r18. r18 requires nsfw=true. |
 | `claimed` | query | 否 | string | true or false. Absent = no gate. |
-| `claim_state` | query | 否 | string | Comma-separated closed states: none, live, draft. Moderation states live on /v2/moderation/claims. |
+| `claim_state` | query | 否 | string | Comma-separated closed states: none, live, draft. pending, declined and hidden are the per-site moderation queue: they need a key holding claim_events:read and a site= naming the caller's own site, and are otherwise not in the vocabulary. |
 | `content_limit` | query | 否 | string | Comma-separated closed editorial axis: sfw, nsfw. |
 | `site` | query | 否 | string | Claiming site key. Open vocabulary; unknown values match nothing. |
 | `owner_uid` | query | 否 | string | The claiming site's own user id of the claim owner. Requires site=. Live registry filter; cannot be combined with q= or search sorts. |

--- a/docs/catalog/v2-implementation-notes.md
+++ b/docs/catalog/v2-implementation-notes.md
@@ -117,6 +117,58 @@ Date: 2026-08-24, GA declared 2026-08-25 (stage 9); news write face added 2026-0
 
 47. **User-token traffic is rate-limited per user, not per IP** (2026-08-28). Deviation 29 moved keyed traffic onto per-key tier limits and left "any request that never authenticates" on the per-IP default — but a user access token *does* authenticate and still resolved no limiter identity, so the whole `/v2/me` and `/v2/moderation` plane fell into the anonymous bucket. A first-party backend relays every logged-in user's call from one egress IP: the forum's entire user plane shared a single `100/min + 10k/day` bucket and answered 429 `QUOTA_EXCEEDED` from 2026-08-27T22:46Z, re-tripping after each UTC-midnight reset (`v2:quota:<forum egress IP>` measured 17,848 by 07:35Z the next day). Now `credentialLimitIdentity` falls through to the authenticated uid — key `u<uid>`, the default `100/min + 10,000/day` per user. Anonymous keyless paths (problems, vocabularies, stats, schemas, openapi.json) keep the per-IP default; an application key still wins over a uid when both are present.
 
+48. **`claim_state=pending|declined|hidden` is readable on `/v2/catalog/works`, behind moderation authority** (2026-08-28). Wave R1 narrowed the closed set to `{none, live, draft}` and pointed the queue at `/v2/moderation/claims`, but the forum's live admin submission queue reads it from here (`claim_state=pending&claimed=true&site=kungal&sort=updated`) with an **application key**, and the moderation face demands a user token carrying `catalog.claim.review`. The queue answered 400 `UNKNOWN_ENUM_VALUE` in production and rendered as "no pending submissions" — the review POST on the same page still worked, so nothing looked broken. R1's intent is kept and only its instrument replaced: the three moderation states are admitted **only** to a credential holding the operator-granted `claim_events:read` scope, and then `site=` is **mandatory** and fenced to the caller's own catalog site (resolved from the key's oauth client, `oauth_clients.catalog_site`) — 403 `PERMISSION_REQUIRED` on another tenant's queue, 403 `SITE_NOT_BOUND` when the key's application has no site. Without the scope the request gets the **identical** 400 `UNKNOWN_ENUM_VALUE` with `allowed values: none, live, draft` it got before, byte for byte: the wider set must not be discoverable by the shape of the refusal, and no unauthorized caller sees any change at all. The adjudicated user-token half of the rule (`catalog.claim.review`) is **not reachable on this face** and is not implemented — `catalogAuth` rejects anything that is not an `nmk_` application key on `/v2/catalog/*` before a user token could be looked at. Zero migrations; the service layer already supported the states (`WorksListFilter.ClaimStates`).
+
+## Wave — the /v2 gate read a path fiber never matched on (2026-08-28)
+
+`GET /v2/Catalog/works` answered **200 with no credential** on production, and so
+did `/v2/CATALOG/works` and `/v2/Catalog/claim-events` — the last one returning
+real operator rows (`actor_uid`, `reason`, `site`, `from_state`, `to_state`)
+across every tenant. `/V2/catalog/works` 404'd, because Traefik's
+`PathPrefix(/v2)` is case-sensitive; only the segments after `/v2` were
+exploitable.
+
+The mechanism is one fiber fact. `Route.match` compares against
+`c.detectionPath` — `c.path` lowercased while `CaseSensitive` is off and with
+trailing slashes stripped while `StrictRouting` is off — while `c.Path()`
+returns the raw `c.path`. `catalogAuth` and `userAuth` both dispatched on
+`c.Path()` with case-sensitive `strings.HasPrefix` over an **open**
+`default: return c.Next()` arm, which is correct in itself (`/v2/me`,
+`/v2/news`, `/v2/problems`, `/v2/vocabularies` legitimately take no application
+key). So a case-variant path matched the route, missed every prefix in the gate,
+and fell out the open arm. The same mismatch defeated the operator guard, which
+compared `path == "/v2/catalog/claim-events"`: one trailing slash routed to the
+same handler with the extra scope unchecked.
+
+Three layers, because any one of them alone is a config flip away from
+regressing:
+
+1. **Both gates key on a normalized path** (`routedPath`: lowercase, trailing
+   slashes trimmed), so the gate sees what fiber matched. This holds even if the
+   router config is reverted.
+2. **`CaseSensitive: true`** on the shared fiber config, so variants 404 rather
+   than falling through. **`StrictRouting` stays off**: `cmd/oauth` registers
+   `sites.Get("/")` and `oauthClients.Get("/")` — i.e. `/api/v1/sites/` and
+   `/api/v1/oauth/clients/` — while `apps/web` calls both without the trailing
+   slash, so turning it on 404s the admin console's site and OAuth-client pages.
+   Verified empirically against fiber v3.2.0 rather than assumed. Layer 1 covers
+   the slash case instead.
+3. **A walk over every published path** (`route_gate_walk_test.go`) issues the
+   case-variant, `…/` and `…//` forms of every path in
+   `docs/catalog/v2-openapi.yaml` with no credential and asserts the answer is
+   still the gate's own (`MISSING_CREDENTIAL` / `NOT_FOUND`), never a
+   handler's. Asserting merely "not a 2xx" was tried first and passed green
+   against the unfixed gate — every face is unbound in a unit test, so a request
+   that sails past the gate still answers 503.
+
+`catalogAuth` also stopped treating a nil credential store as a grant: with no
+lookup wired, every gated face answered anonymously. It is 503
+`SERVICE_UNAVAILABLE` now, the same shape the lookup-error branch already used.
+Two existing tests leaned on that escape hatch (`Bearer test` against a nil
+store) and now carry a real credential store.
+
+Zero migrations. No spec change beyond deviation 48's `claim_state` description.
+
 ## Stage 6 write
 
 | Route | Bind |

--- a/docs/catalog/v2-openapi.yaml
+++ b/docs/catalog/v2-openapi.yaml
@@ -10612,12 +10612,12 @@ paths:
             description: true or false. Absent = no gate.
             maxLength: 8
             type: string
-        - description: "Comma-separated closed states: none, live, draft. Moderation states live on /v2/moderation/claims."
+        - description: "Comma-separated closed states: none, live, draft. pending, declined and hidden are the per-site moderation queue: they need a key holding claim_events:read and a site= naming the caller's own site, and are otherwise not in the vocabulary."
           explode: false
           in: query
           name: claim_state
           schema:
-            description: "Comma-separated closed states: none, live, draft. Moderation states live on /v2/moderation/claims."
+            description: "Comma-separated closed states: none, live, draft. pending, declined and hidden are the per-site moderation queue: they need a key holding claim_events:read and a site= naming the caller's own site, and are otherwise not in the vocabulary."
             maxLength: 128
             type: string
         - description: "Comma-separated closed editorial axis: sfw, nsfw."


### PR DESCRIPTION
Closes two production incidents. First of five waves from a full review of the v2 catalog API.

## 1. The `/v2` auth gate read a path fiber never matched on

`GET /v2/Catalog/works` answered **200 with no credential** in production, and so did `/v2/CATALOG/works` and `/v2/Catalog/claim-events` — the last one returning real operator rows (`actor_uid`, `reason`, `site`, `from_state`, `to_state`) across every tenant. `/V2/catalog/works` 404'd, because Traefik's `PathPrefix(/v2)` is case-sensitive; only the segments *after* `/v2` were reachable.

One fiber fact explains it. `Route.match` compares against `c.detectionPath` — `c.path` lowercased while `CaseSensitive` is off, trailing slashes stripped while `StrictRouting` is off — but `c.Path()` returns the raw `c.path`. `catalogAuth` and `userAuth` both dispatched on `c.Path()` with case-sensitive `strings.HasPrefix` over an open `default: return c.Next()` arm. A case-variant path matched the route, missed every prefix in the gate, and fell out the open arm. The same mismatch defeated the operator-scope guard, which compared `path == "/v2/catalog/claim-events"`: one trailing slash routed to the same handler with the scope unchecked.

`userAuth` had the identical defect — `/v2/Me/claims` and `/v2/Moderation/claims` skipped it entirely.

Three layers, because any one alone is a config flip from regressing:

1. **Both gates key on a normalized path** (`routedPath`: lowercase, trailing slashes trimmed), mirroring fiber's `configDependentPaths`. Holds even if the router config is reverted.
2. **`CaseSensitive: true`** on the shared fiber config. `StrictRouting` stays **off**: `cmd/oauth` registers `sites.Get("/")` and `oauthClients.Get("/")` while `apps/web` calls both without the trailing slash, so turning it on 404s the admin console's site and OAuth-client pages. Verified against fiber v3.2.0 rather than assumed; layer 1 covers the slash case instead.
3. **A walk over every published path** issues the case-variant, `…/` and `…//` forms of every path in `docs/catalog/v2-openapi.yaml` with no credential and asserts the answer is still the gate's own (`MISSING_CREDENTIAL` / `NOT_FOUND`), never a handler's.

`catalogAuth` also stopped treating a nil credential store as a grant — it is 503 `SERVICE_UNAVAILABLE` now, matching the lookup-error branch.

## 2. The forum's admin submission queue answered 400

Wave R1 narrowed `/v2/catalog/works?claim_state=` to `{none, live, draft}` and pointed the queue at `/v2/moderation/claims`. But the forum's live admin queue reads it from the works face with an **application key**, and the moderation face demands a user token carrying `catalog.claim.review`. The queue answered 400 `UNKNOWN_ENUM_VALUE` and rendered as "no pending submissions" — the review POST on the same page still worked, so nothing looked broken.

R1's intent is kept and only its instrument replaced. The three moderation states are admitted **only** to a credential holding the operator-granted `claim_events:read` scope, and then `site=` is mandatory and fenced to the caller's own catalog site (from `oauth_clients.catalog_site`).

Without the scope the request gets the **identical** 400 with `allowed values: none, live, draft` it got before, byte for byte — the wider set must not be discoverable from the shape of the refusal, and no existing public key observes any change.

## Verification

- Full suite: **162 packages, 0 FAIL**. DB suites really ran (`catalog/service` ~129s; a skip reports ~0.005s).
- The walk was **vacuous in its first draft and caught**: asserting "never a 2xx" passed green against the unfixed gate, because every face is unbound in a unit test so a bypassed request still answers 503. It now asserts the gate's own problem code — pre-fix it goes red on **47 paths**.
- Reverting `routedPath` alone while leaving `CaseSensitive: true` still goes red; restoring `routedPath` with `CaseSensitive: false` is green — the two layers are independently sufficient.
- Controls on both sides: `/v2/catalog/works` and `/v2/catalog/claim-events` must be 401; `gated > 40`; `/v2/problems` and `/v2/vocabularies` must still be 200, so "everything 401s" cannot masquerade as a fix.
- The claim_state chain verified end to end against production: forum key `kungal-forum-internal-s2s-v2` holds `claim_events:read`, its client resolves to `catalog_site=kungal`, and the queue already sends `site=kungal` — so the fence passes and the queue actually reopens.
- All four spec gates run and clear (`test.yml` generators, `spec-breaking.yml` oasdiff "No breaking changes", `docs-model.yml`, `openapi-types.yml`). Spec change is description-only.

**No migration required** — the service layer already supported all six claim states.

## Known gap, deliberately not in this PR

The adjudicated user-token half of the `claim_state` rule (`catalog.claim.review`) is **not reachable on this face**: `catalogAuth` rejects any non-`nmk_` bearer on `/v2/catalog/*` before a user token could be inspected. Implementing it would mean weakening the app-key gate to buy a path no consumer uses. Recorded as deviation 48.
