### PR TITLE
ops(cron): register work-dedup-watch in the README and deadman registry

### DIFF
--- a/scripts/prod-cron/README.md
+++ b/scripts/prod-cron/README.md
@@ -34,6 +34,7 @@ the image is the fix, not a preference.
 | playtime-aggregate | daily 05:20 | 48h |
 | refresh-tag-counts | hourly :40 | 6h |
 | tag-vocab-backlog | 1st 12:30 | 768h |
+| work-dedup-watch | Mon 04:20 | 192h |
 
 Crontab (root) also runs `/root/lib/watchdog.sh` daily at 09:00 — the deadman
 that alerts when a job has not *succeeded* within its limit, the failure mode

--- a/scripts/prod-cron/lib/watchdog.conf
+++ b/scripts/prod-cron/lib/watchdog.conf
@@ -13,3 +13,4 @@ reindex-catalog	/root/reindex-catalog/state/last-success	48
 intromt-nightly	/root/intromt-nightly/state/last-success	48
 image-grade-nightly	/root/image-grade-nightly/state/last-success	48
 tag-vocab-backlog	/root/tag-vocab-backlog/state/last-success	768
+work-dedup-watch	/root/work-dedup-watch/state/last-success	192

--- a/scripts/prod-cron/work-dedup-watch/run.sh
+++ b/scripts/prod-cron/work-dedup-watch/run.sh
@@ -11,11 +11,7 @@
 #      would make the deadman report a working job as dead every week.
 #   *  the detector broke            -> [FAIL] alert, no stamp
 #
-# Not yet registered in scripts/prod-cron/README.md or lib/watchdog.conf (both
-# outside this wave's owned paths). Add, in the same shape as the other weekly
-# jobs:
-#   crontab (root):  20 4 * * 1 /root/work-dedup-watch/run.sh
-#   watchdog.conf:   work-dedup-watch  /root/work-dedup-watch/state/last-success  192
+# crontab (root): 20 4 * * 1 /root/work-dedup-watch/run.sh
 #
 # Runs from the infra-tools image resolved below; nothing is staged on this
 # host. Canonical copy: scripts/prod-cron/work-dedup-watch/run.sh in


### PR DESCRIPTION
Registers the weekly duplicate-work watch (shipped in #93 with registration deliberately left out of that wave's owned paths):

- `scripts/prod-cron/README.md` — schedule row: Mon 04:20 UTC, deadman 192h
- `scripts/prod-cron/lib/watchdog.conf` — deadman line, same one-cycle-plus-a-day shape as the other weekly jobs
- `scripts/prod-cron/work-dedup-watch/run.sh` — header trimmed to the crontab line the box carries (the "not yet registered" note is now false)

Box-side install (manual scp of run.sh + watchdog.conf, root crontab line) is done in the same wave as the production dedup data run.

No code, no migrations, no spec.

https://claude.ai/code/session_01NZJ7JMgjjkhciKhxA91H61