### PR TITLE
fix(catalog): the works list serves the include vocabulary it declares

### DIFF
--- a/apps/api/internal/platform/apiv2/collect/work.go
+++ b/apps/api/internal/platform/apiv2/collect/work.go
@@ -11,6 +11,32 @@ var WorkFullSet = []string{
 	"releases", "ratings", "relations", "engines", "series", "links",
 }
 
+// WorkListInclude is the works LIST vocabulary, and it is deliberately not
+// WorkInclude. The list and the detail shared one Spec, so the list declared
+// all eighteen detail tokens, validated them, and then answered four blocks:
+// include=tags,credits was a 200 with no tags and no credits, ten more tokens
+// did nothing at all, and view=full unioned twelve tokens to emit four. A
+// consumer probed for a 400 first, got none, and shipped a per-work detail read
+// on its hottest page to recover what the list had accepted an ask for.
+//
+// titles and covers are narrower here than on the detail face, and that is the
+// contract rather than a gap: titles elects latin/localized, covers elects the
+// two cover slots that carry the sexual grading of the base cover. Both are
+// load-bearing for consumers in exactly that shape — emitting the detail face's
+// full titles[] and covers[] arrays on a 100-work batch would be a payload
+// regression, not a fix. The unbounded per-work galleries stay on
+// works/{id}/covers and the other sub-resources.
+var WorkListInclude = []string{
+	"titles", "refs", "intros", "covers", "companies", "ratings", "tags", "credits",
+}
+
+// credits is out of the list FullSet for the reason it is out of WorkFullSet:
+// it is an explicit ask, not part of "everything". Every other list-capable
+// token rides view=full.
+var WorkListFullSet = []string{
+	"titles", "refs", "intros", "covers", "companies", "ratings", "tags",
+}
+
 var WorkBasicFields = []string{
 	"object", "id", "medium", "display_name", "latin", "localized", "olang",
 	"content_rating", "release_date", "release_date_precision", "release_status",
@@ -39,6 +65,18 @@ func WorkSpec() Spec {
 		Sort:    WorkSort,
 		Include: WorkInclude,
 		FullSet: WorkFullSet,
+		Fields:  fields,
+		Facets:  WorkFacets,
+	}
+}
+
+func WorkListSpec() Spec {
+	fields := append([]string{}, WorkBasicFields...)
+	fields = append(fields, WorkListInclude...)
+	return Spec{
+		Sort:    WorkSort,
+		Include: WorkListInclude,
+		FullSet: WorkListFullSet,
 		Fields:  fields,
 		Facets:  WorkFacets,
 	}
@@ -276,13 +314,23 @@ func SearchSpec() Spec {
 
 func CalendarSpec() Spec {
 	fields := append([]string{}, WorkBasicFields...)
-	fields = append(fields, WorkInclude...)
+	fields = append(fields, WorkListInclude...)
 	return Spec{
 		Sort:    []string{"id"},
-		Include: WorkInclude,
-		FullSet: WorkFullSet,
+		Include: WorkListInclude,
+		FullSet: WorkListFullSet,
 		Fields:  fields,
 	}
+}
+
+// ObjectListSpec answers the vocabulary of the object's COLLECTION face, which
+// is the one a caller building a list request needs. Only work has a narrower
+// list face; for every other object the list and the detail share a Spec.
+func ObjectListSpec(object string) (Spec, bool) {
+	if object == "work" {
+		return WorkListSpec(), true
+	}
+	return ObjectSpec(object)
 }
 
 func ObjectSpec(object string) (Spec, bool) {

--- a/apps/api/internal/platform/apiv2/handler/catalog_calendar.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_calendar.go
@@ -42,7 +42,7 @@ func (c *Catalog) ListCalendar(ctx context.Context, q collect.Query, p calendarP
 		return repr.CalendarList{}, werr
 	}
 	f := catsvc.CalendarFilter{
-		NSFW: q.NSFW, Include: calendarWorksInclude(q.Include),
+		NSFW: q.NSFW, Include: listWorksInclude(q.Include),
 		DisplayLimits: limits, OLang: calendarOLang(p.OLang),
 	}
 	meta := &repr.CalendarMeta{Today: time.Now().In(calendarJST).Format("2006-01-02")}
@@ -184,17 +184,4 @@ func calendarWindow(month, year, precision, status string, now time.Time) (calen
 	return calendarWin{bucket: catsvc.CalendarBucket{
 		Kind: catsvc.CalendarMonthBucket, Year: t.Year(), Month: int(t.Month()),
 	}}, nil
-}
-
-func calendarWorksInclude(tokens []string) catsvc.WorksListInclude {
-	var raw []string
-	for _, t := range tokens {
-		switch t {
-		case "companies":
-			raw = append(raw, "labels")
-		case "intros", "ratings", "covers", "refs":
-			raw = append(raw, t)
-		}
-	}
-	return catsvc.ParseWorksListInclude(strings.Join(raw, ","))
 }

--- a/apps/api/internal/platform/apiv2/handler/catalog_feed_routes.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_feed_routes.go
@@ -68,7 +68,7 @@ func registerCatalogFeeds(api huma.API, cat *Catalog) {
 		Method:             http.MethodGet,
 		Path:               "/v2/catalog/calendar",
 		Summary:            "Release calendar",
-		Description:        "One collection. month=/year= pick a window; precision= and status= select among the dated month, year-only, and undated views that were three v1 routes. content_limit= gates on the editorial display axis and olang= on the original language (absent = ja plus zh). meta carries today plus, on the dated month window, min_month/max_month/has_prev/has_next for month navigation. Requires an application key. ids= is not accepted.",
+		Description:        "One collection. month=/year= pick a window; precision= and status= select among the dated month, year-only, and undated views that were three v1 routes. content_limit= gates on the editorial display axis and olang= on the original language (absent = ja plus zh). meta carries today plus, on the dated month window, min_month/max_month/has_prev/has_next for month navigation. Requires an application key. ids= is not accepted. include=titles,refs,intros,covers,companies,ratings,tags,credits fills on this lane; view=full is all of them except credits, which is an explicit ask. On a collection lane titles elects latin/localized and covers elects the two cover slots that grade the base cover — the full titles[] and covers[] arrays, and relations/releases/popularity/playtimes/series/platforms/screenshots/characters/engines/links, are per-record blocks and live on /v2/catalog/works/{id} and its sub-resources; asking for one here is 400 UNKNOWN_INCLUDE.",
 		Tags:               catalog,
 		Errors:             errs,
 		SkipValidateParams: true,

--- a/apps/api/internal/platform/apiv2/handler/catalog_schema.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_schema.go
@@ -23,6 +23,7 @@ func (c *Catalog) GetSchema(_ context.Context, object string) (repr.ObjectSchema
 		return repr.ObjectSchema{}, problem.New(problem.CodeServiceUnavailable, "", "", "catalog schemas are not bound.")
 	}
 	read, _ := collect.ObjectSpec(object)
+	list, _ := collect.ObjectListSpec(object)
 	fields := make([]repr.SchemaField, 0, len(spec.Fields))
 	for i := range spec.Fields {
 		f := spec.Fields[i]
@@ -48,6 +49,8 @@ func (c *Catalog) GetSchema(_ context.Context, object string) (repr.ObjectSchema
 		EntityType:       entityType,
 		Include:          copyStrings(read.Include),
 		FullSet:          copyStrings(read.FullSet),
+		ListInclude:      copyStrings(list.Include),
+		ListFullSet:      copyStrings(list.FullSet),
 		CreationDisabled: object == "release",
 		Fields:           fields,
 	}, nil

--- a/apps/api/internal/platform/apiv2/handler/catalog_schema_routes.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_schema_routes.go
@@ -23,7 +23,7 @@ func registerCatalogSchemas(api huma.API, cat *Catalog) {
 		Method:             http.MethodGet,
 		Path:               "/v2/catalog/schemas/{object}",
 		Summary:            "Editable-field schema for one family",
-		Description:        "Unauthenticated metadata: include tokens, FULL_SET, and editing-engine fields. Actor capabilities are not evaluated. Unknown object is 404 NOT_FOUND. schemas/release sets creation_disabled.",
+		Description:        "Unauthenticated metadata: include tokens, FULL_SET, and editing-engine fields. include/full_set describe the family's DETAIL face and list_include/list_full_set its collection face, which is narrower on work. Actor capabilities are not evaluated. Unknown object is 404 NOT_FOUND. schemas/release sets creation_disabled.",
 		Tags:               []string{"catalog"},
 		Errors:             collectionErrors(http.StatusNotFound, http.StatusServiceUnavailable),
 		SkipValidateParams: true,

--- a/apps/api/internal/platform/apiv2/handler/catalog_works_filter.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_works_filter.go
@@ -371,6 +371,10 @@ func listWorksInclude(tokens []string) catsvc.WorksListInclude {
 			inc.Covers = true
 		case "refs":
 			inc.Refs = true
+		case "tags":
+			inc.Tags = true
+		case "credits":
+			inc.Credits = true
 		}
 	}
 	return inc

--- a/apps/api/internal/platform/apiv2/handler/collection.go
+++ b/apps/api/internal/platform/apiv2/handler/collection.go
@@ -118,7 +118,7 @@ func registerCollections(api huma.API, works WorksFunc, cat *Catalog) {
 		Method:             http.MethodGet,
 		Path:               "/v2/catalog/works",
 		Summary:            "List catalog works",
-		Description:        "Keyset-paginated work collection. q= switches to search (sort defaults to relevance). company_id=/tag_id=/series_id= filter the live registry when q= is absent. Requires an application key. view/include/fields/ids/refs/facets follow the v2 collection contract.",
+		Description:        "Keyset-paginated work collection. q= switches to search (sort defaults to relevance). company_id=/tag_id=/series_id= filter the live registry when q= is absent. Requires an application key. view/include/fields/ids/refs/facets follow the v2 collection contract. include=titles,refs,intros,covers,companies,ratings,tags,credits fills on every lane; view=full is all of them except credits, which is an explicit ask. On a collection lane titles elects latin/localized and covers elects the two cover slots that grade the base cover — the full titles[] and covers[] arrays, and relations/releases/popularity/playtimes/series/platforms/screenshots/characters/engines/links, are per-record blocks and live on /v2/catalog/works/{id} and its sub-resources; asking for one here is 400 UNKNOWN_INCLUDE.",
 		Tags:               []string{"catalog"},
 		Errors:             collectionErrors(http.StatusUnauthorized, http.StatusForbidden, http.StatusServiceUnavailable),
 		SkipValidateParams: true,
@@ -164,7 +164,7 @@ func listWorks(src WorksFunc, cat *Catalog) func(context.Context, *listWorksInpu
 			Cursor: in.Cursor, Limit: in.Limit, View: in.View, Include: in.Include,
 			Fields: in.Fields, IDs: in.IDs, Refs: in.Refs, IncludeTotal: in.IncludeTotal,
 			Facets: in.Facets, Sort: in.Sort, NSFW: in.NSFW,
-		}), collect.WorkSpec())
+		}), collect.WorkListSpec())
 		if err != nil {
 			return nil, withIdent(ctx, err)
 		}

--- a/apps/api/internal/platform/apiv2/handler/live_setup_test.go
+++ b/apps/api/internal/platform/apiv2/handler/live_setup_test.go
@@ -296,6 +296,22 @@ func seedLiveFixtures(db *gorm.DB, claims *catsvc.ClaimLifecycleService) (liveFi
 	}
 	fx.Work = w.ID
 
+	// The fixture's only work-title rows. include=titles is the one list token
+	// whose effect is elected fields rather than a block, so with no title row
+	// nothing could tell the arm firing from the arm missing — which is how the
+	// calendar shipped without it while the works list had it.
+	liveWorkLatin := "Raibu Waaku"
+	for _, title := range []*model.CatalogWorkTitle{
+		{WorkID: w.ID, Lang: "ja", Title: "Live Work", Latin: &liveWorkLatin,
+			Kind: model.WorkTitleKindOfficial, Provenance: model.WorkTitleProvenanceSource},
+		{WorkID: w.ID, Lang: "zh-Hans", Title: "现场作品",
+			Kind: model.WorkTitleKindOfficial, Provenance: model.WorkTitleProvenanceSource},
+	} {
+		if err := db.Create(title).Error; err != nil {
+			return fx, err
+		}
+	}
+
 	pending := &model.CatalogWork{
 		MediumID: 1, OLang: "ja", DisplayName: "Pending Work",
 		ContentRating: model.ContentRatingAllAges, Status: model.WorkStatusLive,

--- a/apps/api/internal/platform/apiv2/handler/live_wave_w6_test.go
+++ b/apps/api/internal/platform/apiv2/handler/live_wave_w6_test.go
@@ -1,0 +1,231 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"api/internal/platform/apiv2/collect"
+	"api/internal/platform/apiv2/problem"
+
+	"github.com/stretchr/testify/require"
+)
+
+type w6Work struct {
+	ID        string             `json:"id"`
+	Latin     *string            `json:"latin"`
+	Localized map[string]w6Local `json:"localized"`
+	Tags      *[]w6Tag           `json:"tags"`
+	Credits   *[]w6CreditGroup   `json:"credits"`
+	Intros    *[]struct {
+		Lang string `json:"lang"`
+	} `json:"intros"`
+	Companies *[]struct {
+		ID string `json:"id"`
+	} `json:"companies"`
+	Ratings *[]struct {
+		Source string `json:"source"`
+	} `json:"ratings"`
+	Refs *[]struct {
+		Source string `json:"source"`
+	} `json:"refs"`
+}
+
+type w6Local struct {
+	Value string `json:"value"`
+}
+
+type w6Tag struct {
+	ID          *string `json:"id"`
+	DisplayName string  `json:"display_name"`
+	Source      string  `json:"source"`
+	Spoiler     string  `json:"spoiler"`
+}
+
+type w6CreditGroup struct {
+	RoleKey string `json:"role_key"`
+	Credits []struct {
+		ID       string `json:"id"`
+		Identity string `json:"identity"`
+	} `json:"credits"`
+}
+
+func w6ListItem(t *testing.T, env *liveEnv, path, id string) w6Work {
+	t.Helper()
+	var page struct {
+		Items []w6Work `json:"items"`
+	}
+	w4Get(t, env, path, &page)
+	for _, it := range page.Items {
+		if it.ID == id {
+			return it
+		}
+	}
+	t.Fatalf("%s: work %s is missing from the page", path, id)
+	return w6Work{}
+}
+
+func w6Problem(t *testing.T, env *liveEnv, path string) *problem.Problem {
+	t.Helper()
+	status, _, body := liveDo(t, env, http.MethodGet, path, liveAppKey, "")
+	require.Equal(t, 400, status, "%s -> %s", path, body)
+	var p problem.Problem
+	require.NoError(t, json.Unmarshal(body, &p), string(body))
+	return &p
+}
+
+// The works list declared all eighteen detail include tokens and hydrated four
+// blocks, so include=tags,credits was a 200 with neither block present and no
+// error. A consumer probed for a 400, got none, and shipped a per-work detail
+// read on its busiest page to recover what the list had accepted an ask for.
+func TestLiveWorksListHydratesTagsAndCredits(t *testing.T) {
+	env := liveCatalog(t)
+	id := idstr(env.fx.Work)
+
+	var detail w6Work
+	w4Get(t, env, "/v2/catalog/works/"+id+"?include=tags,credits", &detail)
+	require.NotNil(t, detail.Tags)
+	require.NotEmpty(t, *detail.Tags)
+	require.NotNil(t, detail.Credits)
+	require.NotEmpty(t, *detail.Credits)
+
+	for _, path := range []string{
+		"/v2/catalog/works?include=tags,credits&limit=100",
+		"/v2/catalog/works?include=tags,credits&ids=" + id,
+	} {
+		it := w6ListItem(t, env, path, id)
+		require.NotNil(t, it.Tags, "%s published no tags block", path)
+		require.Equal(t, *detail.Tags, *it.Tags, "%s: the list and detail tags blocks must agree", path)
+		require.NotNil(t, it.Credits, "%s published no credits block", path)
+		require.Equal(t, *detail.Credits, *it.Credits, "%s: the list and detail credits blocks must agree", path)
+	}
+
+	// Not asking still means not answering: the blocks are include-gated, and a
+	// consumer that reads their absence as "this work has none" must be right.
+	bare := w6ListItem(t, env, "/v2/catalog/works?limit=100", id)
+	require.Nil(t, bare.Tags)
+	require.Nil(t, bare.Credits)
+}
+
+// The credits block carries the D9 row identity and the D24/roster suppression
+// rules. Widening one query rather than writing a batch copy is what keeps the
+// two faces byte-identical; this pins that they are.
+func TestLiveWorksListCreditsMatchTheSubResource(t *testing.T) {
+	env := liveCatalog(t)
+	id := idstr(env.fx.Work)
+
+	var sub struct {
+		Items []w6CreditGroup `json:"items"`
+	}
+	w4Get(t, env, "/v2/catalog/works/"+id+"/credits?limit=100", &sub)
+	require.NotEmpty(t, sub.Items)
+
+	it := w6ListItem(t, env, "/v2/catalog/works?include=credits&ids="+id, id)
+	require.NotNil(t, it.Credits)
+	require.Equal(t, sub.Items, *it.Credits)
+}
+
+// The ten tokens the list cannot serve used to be accepted and answered by
+// nothing. They are refused through the vocabulary the collection declares, so
+// the refusal is the same UNKNOWN_INCLUDE any other unknown token gets.
+func TestLiveWorksListRefusesDetailOnlyIncludes(t *testing.T) {
+	env := liveCatalog(t)
+	id := idstr(env.fx.Work)
+
+	detailOnly := []string{
+		"relations", "releases", "popularity", "playtimes", "series",
+		"platforms", "screenshots", "characters", "engines", "links",
+	}
+	for _, tok := range detailOnly {
+		require.NotContains(t, collect.WorkListInclude, tok)
+		require.Contains(t, collect.WorkInclude, tok, "the token must still exist on the detail face")
+
+		p := w6Problem(t, env, "/v2/catalog/works?include="+tok)
+		require.Equal(t, problem.CodeUnknownInclude, p.Code, tok)
+		p = w6Problem(t, env, "/v2/catalog/calendar?month=2024-01&include="+tok)
+		require.Equal(t, problem.CodeUnknownInclude, p.Code, tok)
+
+		status, _, body := liveDo(t, env, http.MethodGet,
+			"/v2/catalog/works/"+id+"?include="+tok, liveAppKey, "")
+		require.Equal(t, 200, status, "%s must stay a detail token: %s", tok, body)
+	}
+}
+
+// view=full unioned a twelve-token FULL_SET into a face that emitted four, so
+// the one request that means "everything you have" was the widest silent gap.
+func TestLiveWorksListViewFullIsTheListFullSet(t *testing.T) {
+	env := liveCatalog(t)
+	id := idstr(env.fx.Work)
+
+	require.NotContains(t, collect.WorkListFullSet, "credits")
+	for _, tok := range collect.WorkListFullSet {
+		require.Contains(t, collect.WorkListInclude, tok)
+	}
+
+	it := w6ListItem(t, env, "/v2/catalog/works?view=full&ids="+id, id)
+	require.NotNil(t, it.Intros)
+	require.NotNil(t, it.Companies)
+	require.NotNil(t, it.Ratings)
+	require.NotNil(t, it.Refs)
+	require.NotNil(t, it.Tags)
+	require.Contains(t, it.Localized, "zh-Hans")
+	require.Nil(t, it.Credits, "credits is an explicit ask on the list, exactly as on the detail face")
+}
+
+// The calendar shares workFromListItem and enrichWorkListItems with the works
+// list but had its own include mapper, which never learned titles. include=
+// titles on the calendar therefore dropped latin and localized[] — the two
+// fields every card renders a Chinese name from.
+func TestLiveCalendarHonoursTheListVocabulary(t *testing.T) {
+	env := liveCatalog(t)
+	id := idstr(env.fx.Work)
+
+	bare := w6ListItem(t, env, "/v2/catalog/calendar?month=2024-01", id)
+	require.Empty(t, bare.Localized)
+	require.Nil(t, bare.Tags)
+
+	// Compared against the works list rather than against fixture literals: the
+	// claim is that one work reads the same through either collection, and the
+	// two reads are taken together so an unrelated edit cannot decide it.
+	for _, tok := range collect.WorkListInclude {
+		cal := w6ListItem(t, env, "/v2/catalog/calendar?month=2024-01&include="+tok, id)
+		list := w6ListItem(t, env, "/v2/catalog/works?include="+tok+"&ids="+id, id)
+		require.Equal(t, list, cal, "include=%s reads differently on the calendar", tok)
+	}
+
+	named := w6ListItem(t, env, "/v2/catalog/calendar?month=2024-01&include=titles", id)
+	require.NotEmpty(t, named.Localized, "the fixture must carry a localized title or this test cannot fail")
+
+	tagged := w6ListItem(t, env, "/v2/catalog/calendar?month=2024-01&include=tags", id)
+	require.NotNil(t, tagged.Tags)
+	require.NotEmpty(t, *tagged.Tags)
+}
+
+// A machine consumer discovers the vocabulary here. Publishing only the detail
+// set would hand it tokens the collection face refuses.
+func TestLiveWorkSchemaPublishesBothVocabularies(t *testing.T) {
+	env := liveCatalog(t)
+
+	var got struct {
+		Include     []string `json:"include"`
+		FullSet     []string `json:"full_set"`
+		ListInclude []string `json:"list_include"`
+		ListFullSet []string `json:"list_full_set"`
+	}
+	w4Get(t, env, "/v2/catalog/schemas/work", &got)
+	require.Equal(t, collect.WorkInclude, got.Include)
+	require.Equal(t, collect.WorkFullSet, got.FullSet)
+	require.Equal(t, collect.WorkListInclude, got.ListInclude)
+	require.Equal(t, collect.WorkListFullSet, got.ListFullSet)
+	require.NotEqual(t, got.Include, got.ListInclude,
+		"work is the family whose two faces differ; equal lists here mean the split was lost")
+
+	for _, object := range []string{"company", "character", "tag", "series", "engine", "release"} {
+		var same struct {
+			Include     []string `json:"include"`
+			ListInclude []string `json:"list_include"`
+		}
+		w4Get(t, env, "/v2/catalog/schemas/"+object, &same)
+		require.Equal(t, same.Include, same.ListInclude, object)
+	}
+}

--- a/apps/api/internal/platform/apiv2/handler/map_work.go
+++ b/apps/api/internal/platform/apiv2/handler/map_work.go
@@ -43,6 +43,12 @@ func workFromListItem(it dto.PublicWorkListItem, include []string, logoURL func(
 	if want["refs"] {
 		w.Refs = ptrSlice(refsFrom(it.Refs))
 	}
+	if want["tags"] {
+		w.Tags = ptrSlice(workTagsFrom(it.Tags))
+	}
+	if want["credits"] {
+		w.Credits = ptrSlice(creditGroupsFrom(it.Credits))
+	}
 	if it.ViaLabel != nil {
 		w.ViaCompany = &repr.ViaCompany{
 			Object: "company", ID: repr.ID(it.ViaLabel.ID),

--- a/apps/api/internal/platform/apiv2/handler/setup.go
+++ b/apps/api/internal/platform/apiv2/handler/setup.go
@@ -57,7 +57,7 @@ func SetupWith(app *fiber.App, opt Options) huma.API {
 	app.Use(protocol.RateLimit(opt.Store, credentialLimitIdentity))
 	app.Use(protocol.Idempotency(opt.Store, credentialLimitIdentity))
 
-	cfg := huma.DefaultConfig("NextMoe Public API v2", "2.2.0")
+	cfg := huma.DefaultConfig("NextMoe Public API v2", "2.3.0")
 	cfg.OpenAPIPath = ""
 	cfg.DocsPath = ""
 	cfg.SchemasPath = ""

--- a/apps/api/internal/platform/apiv2/repr/schema.go
+++ b/apps/api/internal/platform/apiv2/repr/schema.go
@@ -5,8 +5,10 @@ type ObjectSchema struct {
 	Object           string        `json:"object" enum:"object_schema" doc:"Type discriminant. Always object_schema."`
 	TargetObject     string        `json:"target_object" enum:"work,company,character,release,tag,engine,series" doc:"Family this schema describes."`
 	EntityType       string        `json:"entity_type" enum:"catalog.work,catalog.label,catalog.character,catalog.release,catalog.tag,catalog.engine,catalog.series" doc:"Editing-engine type this family writes as."`
-	Include          []string      `json:"include" doc:"include= tokens for this family. Empty array, never null. FULL_SET is a subset."`
-	FullSet          []string      `json:"full_set" doc:"Tokens view=full expands. A subset of include. Empty array, never null."`
+	Include          []string      `json:"include" doc:"include= tokens the family's DETAIL face takes. Empty array, never null. full_set is a subset."`
+	FullSet          []string      `json:"full_set" doc:"Tokens view=full expands on the detail face. A subset of include. Empty array, never null."`
+	ListInclude      []string      `json:"list_include" doc:"include= tokens the family's COLLECTION face takes, which is not always the detail vocabulary: a list hydrates in batch, so blocks whose only shape is per-record stay on the detail face and on the sub-resources. Empty array, never null."`
+	ListFullSet      []string      `json:"list_full_set" doc:"Tokens view=full expands on the collection face. A subset of list_include. Empty array, never null."`
 	CreationDisabled bool          `json:"creation_disabled" doc:"true when new rows of this family cannot be created. Always true on release."`
 	Fields           []SchemaField `json:"fields" doc:"Editable fields. Empty array, never null. Actor capabilities are not evaluated."`
 }

--- a/apps/api/internal/platform/catalog/dto/public_dto.go
+++ b/apps/api/internal/platform/catalog/dto/public_dto.go
@@ -481,14 +481,16 @@ type PublicWorkListItem struct {
 	Updated       string           `json:"updated"`
 	ViaLabel      *PublicLabelVia  `json:"via_label,omitempty"`
 
-	Latin     string                         `json:"latin,omitempty" doc:"include=names only: romanisation of display_name, from the title row display_name was taken from"`
-	Localized map[string]PublicLocalizedName `json:"localized,omitempty" doc:"include=names only, and absent (never {}) when this work has no localized title — the block is include-gated exactly like names, so its absence means \"not requested or none\", not \"none\". SPARSE by design — render localized[yourLocale] ?? display_name ?? latin"`
+	Latin     string                         `json:"latin,omitempty" doc:"include=titles only: romanisation of display_name, from the title row display_name was taken from"`
+	Localized map[string]PublicLocalizedName `json:"localized,omitempty" doc:"include=titles only, and absent (never {}) when this work has no localized title — the block is include-gated exactly like titles, so its absence means \"not requested or none\", not \"none\". SPARSE by design — render localized[yourLocale] ?? display_name ?? latin"`
 
 	Intros  []PublicIntro         `json:"intros,omitempty" doc:"include=intros only: one intro per language, same shape and election as the work-detail intros block"`
 	Labels  []PublicWorkLabel     `json:"labels,omitempty"`
 	Ratings []PublicRating        `json:"ratings,omitempty"`
 	Covers  *PublicWorkCoverSlots `json:"covers,omitempty"`
 	Refs    []PublicCatalogRef    `json:"refs,omitempty"`
+	Tags    []PublicTag           `json:"tags,omitempty" doc:"include=tags only: same shape and election as the work-detail tags block, cut at the default spoiler ceiling"`
+	Credits []PublicCreditGroup   `json:"credits,omitempty" doc:"include=credits only: same groups, ordering and suppression as the work-detail credits block"`
 }
 
 type PublicCoverSlot struct {

--- a/apps/api/internal/platform/catalog/service/public_works_include.go
+++ b/apps/api/internal/platform/catalog/service/public_works_include.go
@@ -9,6 +9,10 @@ import (
 	"api/internal/platform/catalog/model"
 )
 
+// The works list has no spoiler= axis, so its tags block is cut at the same
+// default ceiling the works detail applies when the caller sends none.
+const listSpoilerCeiling int16 = 0
+
 type WorksListInclude struct {
 	Names   bool
 	Intros  bool
@@ -16,10 +20,12 @@ type WorksListInclude struct {
 	Ratings bool
 	Covers  bool
 	Refs    bool
+	Tags    bool
+	Credits bool
 }
 
 func (i WorksListInclude) any() bool {
-	return i.Names || i.Intros || i.Labels || i.Ratings || i.Covers || i.Refs
+	return i.Names || i.Intros || i.Labels || i.Ratings || i.Covers || i.Refs || i.Tags || i.Credits
 }
 
 // intersect is the "fields acts AFTER include" rule: a block is loaded only
@@ -33,6 +39,8 @@ func (i WorksListInclude) intersect(sel PublicFields) WorksListInclude {
 		Ratings: i.Ratings && sel.Wants("ratings"),
 		Covers:  i.Covers && sel.Wants("covers"),
 		Refs:    i.Refs && sel.Wants("refs"),
+		Tags:    i.Tags && sel.Wants("tags"),
+		Credits: i.Credits && sel.Wants("credits"),
 	}
 }
 
@@ -52,6 +60,10 @@ func ParseWorksListInclude(raw string) WorksListInclude {
 			inc.Covers = true
 		case "refs":
 			inc.Refs = true
+		case "tags":
+			inc.Tags = true
+		case "credits":
+			inc.Credits = true
 		}
 	}
 	return inc
@@ -134,6 +146,53 @@ func (s *PublicService) attachWorkListBlocks(
 		for i, r := range rows {
 			items[i].Refs = refs[r.ID]
 		}
+	}
+	// The list block is cut at the default spoiler ceiling, the same way the
+	// characters list cuts traits: the works list has no spoiler= axis, and the
+	// caller who needs a wider ceiling reads works/{id} or works/{id}/tags.
+	if inc.Tags {
+		tags, err := s.read.loadWorkTags(ctx, subjects, listSpoilerCeiling)
+		if err != nil {
+			return err
+		}
+		for i, r := range rows {
+			items[i].Tags = s.publicWorkTags(tags[r.ID], listSpoilerCeiling)
+		}
+	}
+	if inc.Credits {
+		if err := s.attachWorkListCredits(ctx, items, rows, ids); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *PublicService) attachWorkListCredits(
+	ctx context.Context, items []dto.PublicWorkListItem, rows []workListSourceRow, ids []int64,
+) error {
+	byWork, err := s.read.workCreditsFor(ctx, ids)
+	if err != nil {
+		return err
+	}
+	var nameIDs []int64
+	for _, id := range ids {
+		for _, r := range byWork[id] {
+			nameIDs = append(nameIDs, r.CreditNameID)
+		}
+	}
+	nameLoc, err := s.localizedFor(ctx, creditNameAliasSource, nameIDs)
+	if err != nil {
+		return err
+	}
+	for i, r := range rows {
+		groups := s.publicCreditGroups(byWork[r.ID])
+		for gi := range groups {
+			for ci := range groups[gi].Credits {
+				c := &groups[gi].Credits[ci]
+				c.Localized = locOrEmpty(nameLoc[c.ID])
+			}
+		}
+		items[i].Credits = groups
 	}
 	return nil
 }

--- a/apps/api/internal/platform/catalog/service/public_works_include.go
+++ b/apps/api/internal/platform/catalog/service/public_works_include.go
@@ -9,8 +9,6 @@ import (
 	"api/internal/platform/catalog/model"
 )
 
-// The works list has no spoiler= axis, so its tags block is cut at the same
-// default ceiling the works detail applies when the caller sends none.
 const listSpoilerCeiling int16 = 0
 
 type WorksListInclude struct {

--- a/apps/api/internal/platform/catalog/service/public_works_include_test.go
+++ b/apps/api/internal/platform/catalog/service/public_works_include_test.go
@@ -360,15 +360,18 @@ func TestWorkDetailCoversCarryImageMeta(t *testing.T) {
 	}
 }
 
-// moyu renders every work title out of the include=names block, so the six
-// token spellings are a contract in their own right: rename one and it renders
-// empty titles site-wide, with no error raised on either side.
+// moyu renders every work title out of the include=names block, so the token
+// spellings are a contract in their own right: rename one and it renders empty
+// titles site-wide, with no error raised on either side.
 func TestParseWorksListIncludeTokenSpellings(t *testing.T) {
-	want := WorksListInclude{Names: true, Intros: true, Labels: true, Ratings: true, Covers: true, Refs: true}
-	if inc := ParseWorksListInclude("names,intros,labels,ratings,covers,refs"); inc != want {
+	want := WorksListInclude{
+		Names: true, Intros: true, Labels: true, Ratings: true, Covers: true,
+		Refs: true, Tags: true, Credits: true,
+	}
+	if inc := ParseWorksListInclude("names,intros,labels,ratings,covers,refs,tags,credits"); inc != want {
 		t.Fatalf("include selector = %+v, want every token set: %+v", inc, want)
 	}
-	for _, tok := range []string{"names", "intros", "labels", "ratings", "covers", "refs"} {
+	for _, tok := range []string{"names", "intros", "labels", "ratings", "covers", "refs", "tags", "credits"} {
 		if !ParseWorksListInclude(tok).any() {
 			t.Fatalf("token %q selected nothing", tok)
 		}

--- a/apps/api/internal/platform/catalog/service/read_service.go
+++ b/apps/api/internal/platform/catalog/service/read_service.go
@@ -1223,6 +1223,7 @@ func (s *ReadService) CharacterByID(ctx context.Context, characterID int64, maxS
 }
 
 type CreditRow struct {
+	WorkID       int64
 	RoleID       int64
 	RoleKey      string
 	RoleNameCN   string
@@ -1240,17 +1241,35 @@ type CreditRow struct {
 	Identity     string
 }
 
-// The last two ORDER BY terms are the tiebreak, and they are not decoration:
+func (s *ReadService) WorkCredits(ctx context.Context, workID int64) ([]CreditRow, error) {
+	byWork, err := s.workCreditsFor(ctx, []int64{workID})
+	if err != nil {
+		return nil, err
+	}
+	return byWork[workID], nil
+}
+
+// workCreditsFor is the only place the credits read is spelled. The suppression
+// predicate, the curated-lane ordering and the identity projection all live in
+// it, so the works list hydrates credits by widening this query rather than
+// growing a second copy that would drift away from the D9/D24 rules the detail
+// face enforces.
+//
+// The last three ORDER BY terms are the tiebreak, and they are not decoration:
 // uq_catalog_credit is (work_id, credit_name_id, role_id,
 // COALESCE(character_id, 0)), so one voice actor on three characters of one work
 // is three rows that tie on every earlier term. works/{id}/credits pages by
 // OFFSET, and an unstable sort there duplicates or drops rows at a page
 // boundary. COLLATE "C" pins src.key against the database's collation, which is
 // not part of this contract.
-func (s *ReadService) WorkCredits(ctx context.Context, workID int64) ([]CreditRow, error) {
+func (s *ReadService) workCreditsFor(ctx context.Context, workIDs []int64) (map[int64][]CreditRow, error) {
+	out := make(map[int64][]CreditRow, len(workIDs))
+	if len(workIDs) == 0 {
+		return out, nil
+	}
 	var rows []CreditRow
-	err := s.db.WithContext(ctx).Raw(`SELECT
-		c.role_id, ro.key AS role_key, ro.name_cn AS role_name_cn, ro.name_ja AS role_name_ja,
+	if err := s.db.WithContext(ctx).Raw(`SELECT
+		c.work_id, c.role_id, ro.key AS role_key, ro.name_cn AS role_name_cn, ro.name_ja AS role_name_ja,
 		cn.id AS credit_name_id, cn.name, cn.lang, cn.latin,
 		c.character_id, ch.display_name AS character_nm,
 		c.label_id, la.display_name AS label_nm, c.note, src.key AS source_key,
@@ -1261,9 +1280,14 @@ func (s *ReadService) WorkCredits(ctx context.Context, workID int64) ([]CreditRo
 		LEFT JOIN catalog_character ch ON ch.id = c.character_id
 		LEFT JOIN catalog_label la ON la.id = c.label_id
 		LEFT JOIN catalog_source src ON src.id = c.source_id
-		WHERE c.work_id = ? AND `+editspec.NotSuppressedCreditSQL("c")+`
-		ORDER BY c.role_id ASC, `+editspec.HumanLaneFirstNoProvenanceSQL("c.source_id")+
+		WHERE c.work_id IN ? AND `+editspec.NotSuppressedCreditSQL("c")+`
+		ORDER BY c.work_id ASC, c.role_id ASC, `+editspec.HumanLaneFirstNoProvenanceSQL("c.source_id")+
 		`, src.key COLLATE "C" ASC NULLS LAST, cn.id ASC, COALESCE(c.character_id, 0) ASC, c.id ASC`,
-		workID).Scan(&rows).Error
-	return rows, err
+		workIDs).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		out[r.WorkID] = append(out[r.WorkID], r)
+	}
+	return out, nil
 }

--- a/apps/api/internal/platform/catalog/service/read_service.go
+++ b/apps/api/internal/platform/catalog/service/read_service.go
@@ -1255,7 +1255,7 @@ func (s *ReadService) WorkCredits(ctx context.Context, workID int64) ([]CreditRo
 // growing a second copy that would drift away from the D9/D24 rules the detail
 // face enforces.
 //
-// The last three ORDER BY terms are the tiebreak, and they are not decoration:
+// The last two ORDER BY terms are the tiebreak, and they are not decoration:
 // uq_catalog_credit is (work_id, credit_name_id, role_id,
 // COALESCE(character_id, 0)), so one voice actor on three characters of one work
 // is three rows that tie on every earlier term. works/{id}/credits pages by

--- a/apps/api/internal/platform/catalog/service/works_list_blocks_test.go
+++ b/apps/api/internal/platform/catalog/service/works_list_blocks_test.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"testing"
+
+	"api/internal/platform/catalog/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The works list hydrated four blocks while declaring the detail face's whole
+// vocabulary, so include=tags,credits was a 200 with neither block. Both are
+// batch reads; what has to stay true is that batching them changes nothing but
+// the number of round trips.
+func TestWorksListCreditsAreTheDetailRowsBatched(t *testing.T) {
+	f := seedCreditReads(t)
+	read := NewReadService(testDB)
+	ctx := t.Context()
+	suppressCredit(t, f.work.ID, f.badVA)
+
+	byWork, err := read.workCreditsFor(ctx, []int64{f.work.ID, f.other.ID})
+	require.NoError(t, err)
+
+	for _, id := range []int64{f.work.ID, f.other.ID} {
+		one, err := read.WorkCredits(ctx, id)
+		require.NoError(t, err)
+		require.NotEmpty(t, one, "work %d must carry credits or this test cannot fail", id)
+		require.Equal(t, one, byWork[id], "work %d reads differently in a batch", id)
+	}
+
+	// A suppression is per work: the batch must not leak one work's excluded row
+	// into the other's slice, which a map keyed on anything but work_id would.
+	for _, r := range byWork[f.other.ID] {
+		require.Equal(t, f.other.ID, r.WorkID)
+	}
+	require.Len(t, byWork[f.work.ID], 3)
+	require.Len(t, byWork[f.other.ID], 1)
+
+	empty, err := read.workCreditsFor(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+}
+
+func TestWorksListBlocksMatchTheWorkDetail(t *testing.T) {
+	f := seedCreditReads(t)
+	ctx := t.Context()
+	pub := newPublicSvc()
+	require.NoError(t, testDB.Create(&model.CatalogWorkTag{
+		WorkID: f.work.ID, Name: "純愛", Count: 3, SourceID: 3,
+	}).Error)
+
+	detail, found, err := pub.WorkDetail(ctx, f.work.ID,
+		PublicInclude{Credits: true}, true, listSpoilerCeiling, PublicFields{})
+	require.NoError(t, err)
+	require.True(t, found)
+	require.NotEmpty(t, detail.Tags)
+	require.NotEmpty(t, detail.Credits)
+
+	page, err := pub.WorksList(ctx, WorksListFilter{
+		IDs: []int64{f.work.ID}, NSFW: true, Sort: "id",
+		OLang:   PublicOLang{All: true},
+		Include: WorksListInclude{Tags: true, Credits: true},
+	}, "", 10)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	require.Equal(t, detail.Tags, page.Items[0].Tags)
+	require.Equal(t, detail.Credits, page.Items[0].Credits)
+
+	bare, err := pub.WorksList(ctx, WorksListFilter{
+		IDs: []int64{f.work.ID}, NSFW: true, Sort: "id", OLang: PublicOLang{All: true},
+	}, "", 10)
+	require.NoError(t, err)
+	require.Len(t, bare.Items, 1)
+	require.Nil(t, bare.Items[0].Tags)
+	require.Nil(t, bare.Items[0].Credits)
+}

--- a/apps/developer/app/generated/docs-model.ts
+++ b/apps/developer/app/generated/docs-model.ts
@@ -2590,7 +2590,7 @@ export const docsModel: DocsModel = {
               "method": "get",
               "path": "/v2/catalog/calendar",
               "summary": "Release calendar",
-              "description": "One collection. month=/year= pick a window; precision= and status= select among the dated month, year-only, and undated views that were three v1 routes. content_limit= gates on the editorial display axis and olang= on the original language (absent = ja plus zh). meta carries today plus, on the dated month window, min_month/max_month/has_prev/has_next for month navigation. Requires an application key. ids= is not accepted.",
+              "description": "One collection. month=/year= pick a window; precision= and status= select among the dated month, year-only, and undated views that were three v1 routes. content_limit= gates on the editorial display axis and olang= on the original language (absent = ja plus zh). meta carries today plus, on the dated month window, min_month/max_month/has_prev/has_next for month navigation. Requires an application key. ids= is not accepted. include=titles,refs,intros,covers,companies,ratings,tags,credits fills on this lane; view=full is all of them except credits, which is an explicit ask. On a collection lane titles elects latin/localized and covers elects the two cover slots that grade the base cover — the full titles[] and covers[] arrays, and relations/releases/popularity/playtimes/series/platforms/screenshots/characters/engines/links, are per-record blocks and live on /v2/catalog/works/{id} and its sub-resources; asking for one here is 400 UNKNOWN_INCLUDE.",
               "scope": "catalog:read",
               "params": [
                 {
@@ -33845,7 +33845,7 @@ export const docsModel: DocsModel = {
               "method": "get",
               "path": "/v2/catalog/schemas/{object}",
               "summary": "Editable-field schema for one family",
-              "description": "Unauthenticated metadata: include tokens, FULL_SET, and editing-engine fields. Actor capabilities are not evaluated. Unknown object is 404 NOT_FOUND. schemas/release sets creation_disabled.",
+              "description": "Unauthenticated metadata: include tokens, FULL_SET, and editing-engine fields. include/full_set describe the family's DETAIL face and list_include/list_full_set its collection face, which is narrower on work. Actor capabilities are not evaluated. Unknown object is 404 NOT_FOUND. schemas/release sets creation_disabled.",
               "scope": "",
               "auth": {
                 "kind": "none",
@@ -33967,7 +33967,7 @@ export const docsModel: DocsModel = {
                       {
                         "name": "full_set",
                         "required": true,
-                        "doc": "Tokens view=full expands. A subset of include. Empty array, never null.",
+                        "doc": "Tokens view=full expands on the detail face. A subset of include. Empty array, never null.",
                         "type": "array",
                         "itemsOf": {
                           "type": "string"
@@ -33976,7 +33976,25 @@ export const docsModel: DocsModel = {
                       {
                         "name": "include",
                         "required": true,
-                        "doc": "include= tokens for this family. Empty array, never null. FULL_SET is a subset.",
+                        "doc": "include= tokens the family's DETAIL face takes. Empty array, never null. full_set is a subset.",
+                        "type": "array",
+                        "itemsOf": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "name": "list_full_set",
+                        "required": true,
+                        "doc": "Tokens view=full expands on the collection face. A subset of list_include. Empty array, never null.",
+                        "type": "array",
+                        "itemsOf": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "name": "list_include",
+                        "required": true,
+                        "doc": "include= tokens the family's COLLECTION face takes, which is not always the detail vocabulary: a list hydrates in batch, so blocks whose only shape is per-record stay on the detail face and on the sub-resources. Empty array, never null.",
                         "type": "array",
                         "itemsOf": {
                           "type": "string"
@@ -41817,7 +41835,7 @@ export const docsModel: DocsModel = {
               "method": "get",
               "path": "/v2/catalog/works",
               "summary": "List catalog works",
-              "description": "Keyset-paginated work collection. q= switches to search (sort defaults to relevance). company_id=/tag_id=/series_id= filter the live registry when q= is absent. Requires an application key. view/include/fields/ids/refs/facets follow the v2 collection contract.",
+              "description": "Keyset-paginated work collection. q= switches to search (sort defaults to relevance). company_id=/tag_id=/series_id= filter the live registry when q= is absent. Requires an application key. view/include/fields/ids/refs/facets follow the v2 collection contract. include=titles,refs,intros,covers,companies,ratings,tags,credits fills on every lane; view=full is all of them except credits, which is an explicit ask. On a collection lane titles elects latin/localized and covers elects the two cover slots that grade the base cover — the full titles[] and covers[] arrays, and relations/releases/popularity/playtimes/series/platforms/screenshots/characters/engines/links, are per-record blocks and live on /v2/catalog/works/{id} and its sub-resources; asking for one here is 400 UNKNOWN_INCLUDE.",
               "scope": "catalog:read",
               "params": [
                 {

--- a/apps/developer/public/docs/v2/getCatalogSchema.md
+++ b/apps/developer/public/docs/v2/getCatalogSchema.md
@@ -13,7 +13,7 @@
 
 Editable-field schema for one family
 
-Unauthenticated metadata: include tokens, FULL_SET, and editing-engine fields. Actor capabilities are not evaluated. Unknown object is 404 NOT_FOUND. schemas/release sets creation_disabled.
+Unauthenticated metadata: include tokens, FULL_SET, and editing-engine fields. include/full_set describe the family's DETAIL face and list_include/list_full_set its collection face, which is narrower on work. Actor capabilities are not evaluated. Unknown object is 404 NOT_FOUND. schemas/release sets creation_disabled.
 
 - 所属 API：Public API v2（/v2）
 - 鉴权：无需凭据

--- a/apps/developer/public/docs/v2/listCatalogCalendar.md
+++ b/apps/developer/public/docs/v2/listCatalogCalendar.md
@@ -13,7 +13,7 @@
 
 Release calendar
 
-One collection. month=/year= pick a window; precision= and status= select among the dated month, year-only, and undated views that were three v1 routes. content_limit= gates on the editorial display axis and olang= on the original language (absent = ja plus zh). meta carries today plus, on the dated month window, min_month/max_month/has_prev/has_next for month navigation. Requires an application key. ids= is not accepted.
+One collection. month=/year= pick a window; precision= and status= select among the dated month, year-only, and undated views that were three v1 routes. content_limit= gates on the editorial display axis and olang= on the original language (absent = ja plus zh). meta carries today plus, on the dated month window, min_month/max_month/has_prev/has_next for month navigation. Requires an application key. ids= is not accepted. include=titles,refs,intros,covers,companies,ratings,tags,credits fills on this lane; view=full is all of them except credits, which is an explicit ask. On a collection lane titles elects latin/localized and covers elects the two cover slots that grade the base cover — the full titles[] and covers[] arrays, and relations/releases/popularity/playtimes/series/platforms/screenshots/characters/engines/links, are per-record blocks and live on /v2/catalog/works/{id} and its sub-resources; asking for one here is 400 UNKNOWN_INCLUDE.
 
 - 所属 API：Public API v2（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…

--- a/apps/developer/public/docs/v2/listCatalogWorks.md
+++ b/apps/developer/public/docs/v2/listCatalogWorks.md
@@ -13,7 +13,7 @@
 
 List catalog works
 
-Keyset-paginated work collection. q= switches to search (sort defaults to relevance). company_id=/tag_id=/series_id= filter the live registry when q= is absent. Requires an application key. view/include/fields/ids/refs/facets follow the v2 collection contract.
+Keyset-paginated work collection. q= switches to search (sort defaults to relevance). company_id=/tag_id=/series_id= filter the live registry when q= is absent. Requires an application key. view/include/fields/ids/refs/facets follow the v2 collection contract. include=titles,refs,intros,covers,companies,ratings,tags,credits fills on every lane; view=full is all of them except credits, which is an explicit ask. On a collection lane titles elects latin/localized and covers elects the two cover slots that grade the base cover — the full titles[] and covers[] arrays, and relations/releases/popularity/playtimes/series/platforms/screenshots/characters/engines/links, are per-record blocks and live on /v2/catalog/works/{id} and its sub-resources; asking for one here is 400 UNKNOWN_INCLUDE.
 
 - 所属 API：Public API v2（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…

--- a/apps/developer/public/llms-full.txt
+++ b/apps/developer/public/llms-full.txt
@@ -173,7 +173,7 @@ curl "https://api.nextmoe.dev/v2/vocabularies/value"
 
 Release calendar
 
-One collection. month=/year= pick a window; precision= and status= select among the dated month, year-only, and undated views that were three v1 routes. content_limit= gates on the editorial display axis and olang= on the original language (absent = ja plus zh). meta carries today plus, on the dated month window, min_month/max_month/has_prev/has_next for month navigation. Requires an application key. ids= is not accepted.
+One collection. month=/year= pick a window; precision= and status= select among the dated month, year-only, and undated views that were three v1 routes. content_limit= gates on the editorial display axis and olang= on the original language (absent = ja plus zh). meta carries today plus, on the dated month window, min_month/max_month/has_prev/has_next for month navigation. Requires an application key. ids= is not accepted. include=titles,refs,intros,covers,companies,ratings,tags,credits fills on this lane; view=full is all of them except credits, which is an explicit ask. On a collection lane titles elects latin/localized and covers elects the two cover slots that grade the base cover — the full titles[] and covers[] arrays, and relations/releases/popularity/playtimes/series/platforms/screenshots/characters/engines/links, are per-record blocks and live on /v2/catalog/works/{id} and its sub-resources; asking for one here is 400 UNKNOWN_INCLUDE.
 
 - 所属 API：Public API v2（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…
@@ -814,7 +814,7 @@ curl "https://api.nextmoe.dev/v2/catalog/revisions/value" \
 
 Editable-field schema for one family
 
-Unauthenticated metadata: include tokens, FULL_SET, and editing-engine fields. Actor capabilities are not evaluated. Unknown object is 404 NOT_FOUND. schemas/release sets creation_disabled.
+Unauthenticated metadata: include tokens, FULL_SET, and editing-engine fields. include/full_set describe the family's DETAIL face and list_include/list_full_set its collection face, which is narrower on work. Actor capabilities are not evaluated. Unknown object is 404 NOT_FOUND. schemas/release sets creation_disabled.
 
 - 所属 API：Public API v2（/v2）
 - 鉴权：无需凭据
@@ -1037,7 +1037,7 @@ curl "https://api.nextmoe.dev/v2/catalog/traits/value" \
 
 List catalog works
 
-Keyset-paginated work collection. q= switches to search (sort defaults to relevance). company_id=/tag_id=/series_id= filter the live registry when q= is absent. Requires an application key. view/include/fields/ids/refs/facets follow the v2 collection contract.
+Keyset-paginated work collection. q= switches to search (sort defaults to relevance). company_id=/tag_id=/series_id= filter the live registry when q= is absent. Requires an application key. view/include/fields/ids/refs/facets follow the v2 collection contract. include=titles,refs,intros,covers,companies,ratings,tags,credits fills on every lane; view=full is all of them except credits, which is an explicit ask. On a collection lane titles elects latin/localized and covers elects the two cover slots that grade the base cover — the full titles[] and covers[] arrays, and relations/releases/popularity/playtimes/series/platforms/screenshots/characters/engines/links, are per-record blocks and live on /v2/catalog/works/{id} and its sub-resources; asking for one here is 400 UNKNOWN_INCLUDE.
 
 - 所属 API：Public API v2（/v2）
 - 鉴权：Authorization: Bearer nmk_live_…

--- a/docs/catalog/v2-implementation-notes.md
+++ b/docs/catalog/v2-implementation-notes.md
@@ -41,7 +41,7 @@ Date: 2026-08-24, GA declared 2026-08-25 (stage 9); news write face added 2026-0
 
 9. **Moderation queues and `/v2/me/proposals` are keyset-paginated** on event/proposal id (`cur_` + over-fetch).
 
-10. **Works list `include=` hydrates the list-capable subset** (`titles`, `intros`, `companies`, `ratings`, `covers` slots, `refs`). Other FULL_SET tokens stay on detail / sub-resources. Facets on the SQL browse path return empty buckets; named facet counts come from Meili. **Amended 2026-08-27:** this entry used to read "SQL `include_total` is omitted (search path returns Meili `total`)". The SQL lane now honors `include_total` with an exact `count(*)` over the same predicate set the page query uses, so `/v2/catalog/works` publishes `total` on both lanes. The old behavior was never defensible as a deviation: `include_total` was parsed and validated on the SQL lane (a bogus value 400s) and the published envelope doc on `List.total` says "Present only when `include_total=true`. Same visibility gate as items." — which contradicted a lane that silently never published it, while every other registry list did. It also hard-blocked the forum's flip, whose pagination is `Math.ceil(total/limit)` and read `null` as zero pages. The COUNT is **flag-gated**, unlike the taxonomy lanes' unconditional count, because the works predicate set is `EXISTS`-subquery heavy (label rollup, tag maps, series, engine, platform, release windows); it follows the `ReleaseFeedMeta` / `CalendarMeta` precedent instead. It is computed from the filter predicates **before** the cursor predicate is appended, so paging does not shrink it. The all-miss `ids=`/`refs=` batch now publishes `total: 0` like every other entity lane rather than dropping the key.
+10. **Works list `include=` hydrates the list-capable subset** (`titles`, `intros`, `companies`, `ratings`, `covers` slots, `refs`). Other FULL_SET tokens stay on detail / sub-resources. Facets on the SQL browse path return empty buckets; named facet counts come from Meili. **Amended 2026-08-27:** this entry used to read "SQL `include_total` is omitted (search path returns Meili `total`)". The SQL lane now honors `include_total` with an exact `count(*)` over the same predicate set the page query uses, so `/v2/catalog/works` publishes `total` on both lanes. The old behavior was never defensible as a deviation: `include_total` was parsed and validated on the SQL lane (a bogus value 400s) and the published envelope doc on `List.total` says "Present only when `include_total=true`. Same visibility gate as items." — which contradicted a lane that silently never published it, while every other registry list did. It also hard-blocked the forum's flip, whose pagination is `Math.ceil(total/limit)` and read `null` as zero pages. The COUNT is **flag-gated**, unlike the taxonomy lanes' unconditional count, because the works predicate set is `EXISTS`-subquery heavy (label rollup, tag maps, series, engine, platform, release windows); it follows the `ReleaseFeedMeta` / `CalendarMeta` precedent instead. It is computed from the filter predicates **before** the cursor predicate is appended, so paging does not shrink it. The all-miss `ids=`/`refs=` batch now publishes `total: 0` like every other entity lane rather than dropping the key. **Amended again 2026-08-28 (deviation 100):** the parenthesised subset in this entry's first sentence was never what the code did — `workFromListItem` emitted four blocks, not six, and the list declared all eighteen detail tokens rather than the six named here. The list vocabulary is now `collect.WorkListInclude` and is eight tokens; what `titles` and `covers` mean on a collection lane is stated in 100 rather than implied here.
 
 11. **`release_status=` is not bound** on `GET /v2/catalog/works`. It is in 05 §6.1; v1 list did not have it either. Calendar remains the status filter.
 
@@ -295,6 +295,22 @@ The first two are the same defect shape in a different env var. They are deliber
     Neither existing sibling fits, which is why this took a third spec rather than a one-word swap. `PublicProposalSpec` is the public transparency face and publishes no `patch`. `ProposalSpec` is the **detail** spec — `proposalInclude` uses it for `GET /v2/{me,moderation}/proposals/{id}` — and advertises `include=patch,amendments`, which these list lanes build with `proposalFrom` and never populate; adopting it would have traded one accept-and-ignore for two. It is also not `NoBatch`, so it would have opened a batch lane neither lane implements. `collect.ProposalListSpec` is therefore the proposal field vocabulary, an empty include set, the single `filed_desc` sort the shared `proposalQuery` builder actually applies, and `NoBatch` — so the refusal set the batch guard names is byte-identical before and after, which is asserted rather than assumed. No consumer sends `fields=` to these faces (positive control: the consumers that do send `fields=` send it to `/v2/catalog/works`, and every `fields`/`Fields` hit on the proposal faces is a response-body key, not a query parameter).
 
     **Left alone deliberately: `internal/platform/trust/**` is not gofmt-clean on `main`** — nine files, all pre-existing (verified against `HEAD`), all unrelated alignment. No gate runs gofmt, so this is invisible to CI; sweeping nine files in another track's area risks a conflict for no gain, and a whole-tree `gofmt -w` inside a test wave is exactly the unreviewable diff this file exists to prevent.
+
+100. **The works list declared the detail face's whole include vocabulary and hydrated four blocks** (2026-08-28). `collect.WorkSpec()` was parsed by both `GET /v2/catalog/works` and `GET /v2/catalog/works/{id}`, so the list validated all eighteen tokens and `workFromListItem` answered four (`intros`, `companies`, `ratings`, `refs`). `include=tags,credits` was a **200 with neither block and no error**; ten tokens — `relations`, `releases`, `popularity`, `playtimes`, `series`, `platforms`, `screenshots`, `characters`, `engines`, `links` — did nothing at all; and `view=full`, which unions a twelve-token FULL_SET, emitted the same four. The published document said only "Unknown token is 400 UNKNOWN_INCLUDE", whose natural reading is that a known token is honoured, and deviation 10 lived in this file. A downstream consumer probed for a 400, got none, read this file, and shipped a per-work detail read behind concurrency 8 and a six-hour cache on its busiest page to recover what the list had accepted an ask for — an N+1 on the hottest page in the product, caused by the contract rather than by their code.
+
+    The fix is split by what each token actually costs. `tags` and `credits` are **hydrated**: `loadWorkTags` was already batch-shaped (a subject slice in, a map out, two queries regardless of page size) and needed only an arm, and `WorkCredits` is widened into `workCreditsFor(ctx, []int64)` with the single-work path calling it with one id — a second batch copy would have grown a second implementation of the D9 identity projection and the D24/roster suppression predicate, which is the "third code copy" trap this repo has paid for before. Measured on `kun_catalog` before writing either: tags per work average 14.8 at the default spoiler ceiling, p99 88, max 261; credits average 6.0, p99 64, max 340 — so a 24-row browse page costs roughly 350 tag rows and 150 credit rows, and no truncation is needed or added. The other ten tokens are **refused**: `collect.WorkListSpec()` gives the collection its own `Include`/`FullSet`, so they answer the same `400 UNKNOWN_INCLUDE` any unknown token gets, through the existing check, and `view=full` on a list now means the full set that lane can serve.
+
+    `titles` and `covers` stay narrower on a collection lane, and that is the contract rather than a remaining gap: `titles` elects `latin`/`localized` and `covers` elects the two cover slots — which is what puts the `sexual` grading on the base `cover`, load-bearing for letmoe's SFW gate. Both are on live consumer hot paths in exactly that shape (`WorkLoader.Brief` sends `include=titles,covers` on a 100-id batch; patch sends `titles,covers,refs,companies`; the forum sends `titles,covers,companies`), so emitting the detail face's full `titles[]` and `covers[]` arrays there would be a payload regression on every one of them, not a fix. The unbounded per-work galleries keep their sub-resources.
+
+    `credits` is in `WorkListInclude` but **not** in `WorkListFullSet`, for the same reason it is not in `WorkFullSet` on the detail face: it is an explicit ask, not part of "everything".
+
+    **What changes for a caller.** Additive: `include=tags` and `include=credits` now answer blocks, and `view=full` additionally carries `tags`. Refusing: the ten detail-only tokens 400 instead of returning 200 and nothing. No data a working request received before stops arriving — a token that produced nothing now says so. The three sibling repos were checked before the narrowing rather than after: the forum's list constants are `names,covers,labels` and `names,covers,refs` (renamed to `titles,covers,companies` / `titles,covers,refs` in `v2CatalogQuery`), patch sends `titles,covers,refs,companies`, letmoe sends `titles,covers` and `refs,covers`, and the forum's eighteen-token string is `v2CatalogDetailInclude["works"]`, which `v2DetailEntity` applies only to a two-segment path. None of them sends a refused token to a collection.
+
+    The guards are `TestLiveWorksListHydratesTagsAndCredits` (list, `ids=` batch and detail must publish byte-identical blocks, and the blocks must be absent when not asked for), `TestLiveWorksListCreditsMatchTheSubResource`, `TestLiveWorksListRefusesDetailOnlyIncludes` (each of the ten is refused on both collections and still accepted on the detail face) and `TestLiveWorksListViewFullIsTheListFullSet`. At the service layer `TestWorksListCreditsAreTheDetailRowsBatched` pins that batching changes nothing but the round-trip count, including that one work's suppressed row cannot land in another's slice.
+
+101. **The calendar had its own include mapper, and it never learned `titles`** (2026-08-28). `/v2/catalog/calendar` shares `workFromListItem` and `enrichWorkListItems` with the works list but translated tokens through `calendarWorksInclude`, which handled `companies`, `intros`, `ratings`, `covers` and `refs` and silently dropped `titles` — so `include=titles` on the calendar answered 200 with no `latin` and no `localized{}`, the two fields every card renders a Chinese name from, while the same token on the works list filled them. Two mappers for one shape is the defect; the calendar now calls `listWorksInclude` and `CalendarSpec` carries the same `WorkListInclude`/`WorkListFullSet` as the works list. The guard is `TestLiveCalendarHonoursTheListVocabulary`, which compares the calendar against the works list token by token over `WorkListInclude` rather than against fixture literals — one work must read the same through either collection, and both reads are taken together so an unrelated edit cannot decide it.
+
+102. **`GET /v2/catalog/schemas/{object}` published only the detail vocabulary** (2026-08-28). The schema face is where a machine consumer discovers `include=`, and it answered `collect.ObjectSpec(object)` for both halves — which for `work` is now the detail face's eighteen tokens. Left alone, deviation 100 would have made this face hand a generator the tokens the collection refuses. `list_include` and `list_full_set` are added beside `include`/`full_set`; for every family but `work` the two pairs are equal, because those lists and details share a Spec, and `TestLiveWorkSchemaPublishesBothVocabularies` asserts both the equality and the one inequality.
 
 ## Stage 6 write
 
@@ -687,5 +703,44 @@ now derived from the document and guarded, each with a named exclusion list
 carrying reasons: the live-read sweep (deviation 93), the collection-binding set
 (94) and the batch-lane contract (90). The pattern is the one the repo doctrine
 asks for — the list is the contract, and what is deliberately out of it says why.
+
+**Zero migrations.**
+
+## Wave — the works list answers what it accepts (2026-08-28)
+
+Deviations 100, 101 and 102. One defect in three places: the collection faces
+of the work family declared the **detail** face's include vocabulary. The works
+list validated eighteen tokens and served four, the calendar translated through
+a second mapper that had never learned `titles`, and the schema face published
+the detail list as if it were the only one.
+
+This is the same class the five preceding waves were written against — a
+parameter declared, parsed, validated and then answered by nothing — and it is
+the first one a consumer paid a production cost for rather than reporting from a
+reading. Moyu's browse page carries a per-work detail read behind concurrency 8
+and a six-hour in-process cache, on the site's busiest page, because
+`include=tags,credits` answered 200 with neither block. That read becomes one
+request on the deploy that carries this.
+
+**Two halves, deliberately unequal.** `tags` and `credits` are hydrated, because
+both are batch reads and the page cost was measured before either was written
+(tags average 14.8 rows per work at the default ceiling, credits 6.0). The ten
+tokens a list cannot serve in batch are refused through the collection's own
+`Spec`, so they answer the existing `400 UNKNOWN_INCLUDE` instead of 200 and
+silence. `titles` and `covers` keep their narrower collection meanings, which
+three live consumers depend on in exactly that shape and which are now written
+into the operation description instead of into this file only.
+
+**Spec is 2.3.0.** Additive: two response properties on `object_schema`
+(`list_include`, `list_full_set`), longer descriptions on `listCatalogWorks`,
+`listCatalogCalendar` and `getCatalogSchema`. Zero new operations (88 stays 88),
+zero request-schema changes. `oasdiff` 1.21.0 reports "no breaking changes"
+against `origin/main`.
+
+**One behaviour change a caller can see beyond the additions:** the ten
+detail-only tokens now 400 on `/v2/catalog/works` and `/v2/catalog/calendar`.
+The three sibling repos were enumerated before the narrowing, not after, and
+none of them sends one; the eighteen-token string in the forum is its
+`v2CatalogDetailInclude["works"]`, applied only to two-segment detail paths.
 
 **Zero migrations.**

--- a/docs/catalog/v2-openapi.yaml
+++ b/docs/catalog/v2-openapi.yaml
@@ -4090,12 +4090,22 @@ components:
             $ref: "#/components/schemas/SchemaField"
           type: array
         full_set:
-          description: Tokens view=full expands. A subset of include. Empty array, never null.
+          description: Tokens view=full expands on the detail face. A subset of include. Empty array, never null.
           items:
             type: string
           type: array
         include:
-          description: include= tokens for this family. Empty array, never null. FULL_SET is a subset.
+          description: include= tokens the family's DETAIL face takes. Empty array, never null. full_set is a subset.
+          items:
+            type: string
+          type: array
+        list_full_set:
+          description: Tokens view=full expands on the collection face. A subset of list_include. Empty array, never null.
+          items:
+            type: string
+          type: array
+        list_include:
+          description: "include= tokens the family's COLLECTION face takes, which is not always the detail vocabulary: a list hydrates in batch, so blocks whose only shape is per-record stay on the detail face and on the sub-resources. Empty array, never null."
           items:
             type: string
           type: array
@@ -4123,6 +4133,8 @@ components:
         - entity_type
         - include
         - full_set
+        - list_include
+        - list_full_set
         - creation_disabled
         - fields
       type: object
@@ -6422,13 +6434,13 @@ components:
 info:
   description: "NextMoe public API v2. Public since 2026-08-25: any application mints its own nmk_ key in the developer portal, no approval required. The shape evolves additively; a breaking change to this document fails CI."
   title: NextMoe Public API v2
-  version: 2.2.0
+  version: 2.3.0
   x-stability: stable
 openapi: 3.1.0
 paths:
   /v2/catalog/calendar:
     get:
-      description: One collection. month=/year= pick a window; precision= and status= select among the dated month, year-only, and undated views that were three v1 routes. content_limit= gates on the editorial display axis and olang= on the original language (absent = ja plus zh). meta carries today plus, on the dated month window, min_month/max_month/has_prev/has_next for month navigation. Requires an application key. ids= is not accepted.
+      description: One collection. month=/year= pick a window; precision= and status= select among the dated month, year-only, and undated views that were three v1 routes. content_limit= gates on the editorial display axis and olang= on the original language (absent = ja plus zh). meta carries today plus, on the dated month window, min_month/max_month/has_prev/has_next for month navigation. Requires an application key. ids= is not accepted. include=titles,refs,intros,covers,companies,ratings,tags,credits fills on this lane; view=full is all of them except credits, which is an explicit ask. On a collection lane titles elects latin/localized and covers elects the two cover slots that grade the base cover — the full titles[] and covers[] arrays, and relations/releases/popularity/playtimes/series/platforms/screenshots/characters/engines/links, are per-record blocks and live on /v2/catalog/works/{id} and its sub-resources; asking for one here is 400 UNKNOWN_INCLUDE.
       operationId: listCatalogCalendar
       parameters:
         - description: Opaque keyset cursor from a prior next_cursor. Must start with cur_.
@@ -9605,7 +9617,7 @@ paths:
         - catalog
   /v2/catalog/schemas/{object}:
     get:
-      description: "Unauthenticated metadata: include tokens, FULL_SET, and editing-engine fields. Actor capabilities are not evaluated. Unknown object is 404 NOT_FOUND. schemas/release sets creation_disabled."
+      description: "Unauthenticated metadata: include tokens, FULL_SET, and editing-engine fields. include/full_set describe the family's DETAIL face and list_include/list_full_set its collection face, which is narrower on work. Actor capabilities are not evaluated. Unknown object is 404 NOT_FOUND. schemas/release sets creation_disabled."
       operationId: getCatalogSchema
       parameters:
         - description: Family this schema describes. Unknown family is 404 NOT_FOUND.
@@ -10670,7 +10682,7 @@ paths:
         - catalog
   /v2/catalog/works:
     get:
-      description: Keyset-paginated work collection. q= switches to search (sort defaults to relevance). company_id=/tag_id=/series_id= filter the live registry when q= is absent. Requires an application key. view/include/fields/ids/refs/facets follow the v2 collection contract.
+      description: Keyset-paginated work collection. q= switches to search (sort defaults to relevance). company_id=/tag_id=/series_id= filter the live registry when q= is absent. Requires an application key. view/include/fields/ids/refs/facets follow the v2 collection contract. include=titles,refs,intros,covers,companies,ratings,tags,credits fills on every lane; view=full is all of them except credits, which is an explicit ask. On a collection lane titles elects latin/localized and covers elects the two cover slots that grade the base cover — the full titles[] and covers[] arrays, and relations/releases/popularity/playtimes/series/platforms/screenshots/characters/engines/links, are per-record blocks and live on /v2/catalog/works/{id} and its sub-resources; asking for one here is 400 UNKNOWN_INCLUDE.
       operationId: listCatalogWorks
       parameters:
         - description: Opaque keyset cursor from a prior next_cursor. Must start with cur_.


### PR DESCRIPTION
## What

`GET /v2/catalog/works` parsed `collect.WorkSpec()` — the **detail** face's spec — so it validated all eighteen include tokens and `workFromListItem` answered four (`intros`, `companies`, `ratings`, `refs`).

- `include=tags,credits` → **200 with neither block and no error**
- ten more tokens (`relations`, `releases`, `popularity`, `playtimes`, `series`, `platforms`, `screenshots`, `characters`, `engines`, `links`) → did nothing at all
- `view=full`, which unions a twelve-token FULL_SET → emitted the same four

Reported downstream: a consumer probed for a 400, found none, read the internal notes, and shipped a per-work detail read behind concurrency 8 and a six-hour cache on the site's busiest page to recover what the list had accepted an ask for. That is an N+1 caused by the contract, not by their code.

## How

**Hydrate what a batch lane can serve.** `loadWorkTags` was already batch-shaped (subject slice in, map out, two queries regardless of page size) and needed one arm. `WorkCredits` is widened into `workCreditsFor(ctx, []int64)` with the single-work path calling it with one id — a second batch copy would grow a second implementation of the D9 identity projection and the D24/roster suppression predicate. Sized on `kun_catalog` before writing either: 14.8 tags per work at the default spoiler ceiling (p99 88, max 261), 6.0 credits (p99 64, max 340). No cap needed and none added.

**Refuse what it cannot.** `collect.WorkListSpec()` gives the collection its own `Include`/`FullSet`, so the ten detail-only tokens answer the existing `400 UNKNOWN_INCLUDE` and `view=full` means the full set the lane can serve. `credits` is in `WorkListInclude` but not `WorkListFullSet`, exactly as it is excluded from `WorkFullSet` on the detail face.

**`titles` and `covers` stay narrower on a collection lane** — that is the contract, not a remaining gap. `titles` elects `latin`/`localized`; `covers` elects the two cover slots, which is what puts the `sexual` grading on the base `cover` for letmoe's SFW gate. All three sibling consumers are on those hot paths in exactly that shape, so emitting the detail face's full `titles[]`/`covers[]` arrays would be a payload regression. Both meanings now live in the operation description instead of only in the notes.

Two adjacent instances of the same defect:

- **`/v2/catalog/calendar`** shared the mapper but had its own include translator that never learned `titles`, so `include=titles` there answered no `latin` and no `localized{}`. It now uses the works list's mapper and spec.
- **`GET /v2/catalog/schemas/{object}`** published only the detail vocabulary, which after this split would hand a generator the tokens the collection refuses. It grows `list_include` / `list_full_set`; the pairs are equal for every family but `work`.

## Compatibility

Additive: `include=tags`, `include=credits`, and `view=full` additionally carrying `tags`.

Refusing: the ten detail-only tokens now 400 instead of answering 200 and nothing. **No data a working request received before stops arriving** — a token that produced nothing now says so. The siblings were enumerated before the narrowing, not after: forum sends `titles,covers,companies` and `titles,covers,refs`; patch sends `titles,covers,refs,companies`; letmoe sends `titles,covers` and `refs,covers`. The forum's eighteen-token string is `v2CatalogDetailInclude["works"]`, which `v2DetailEntity` applies only to two-segment detail paths.

**Spec 2.2.0 → 2.3.0.** 88 operations stays 88, no request schema moves. `oasdiff` 1.21.0 (the pinned CI version, run locally) reports **no breaking changes** against `origin/main`.

## Tests

New, each with the negative control run:

- `TestLiveWorksListHydratesTagsAndCredits` — list, `ids=` batch and detail publish byte-identical blocks; absent when not asked for
- `TestLiveWorksListCreditsMatchTheSubResource`
- `TestLiveWorksListRefusesDetailOnlyIncludes` — each of the ten refused on both collections, still accepted on the detail face
- `TestLiveWorksListViewFullIsTheListFullSet`
- `TestLiveCalendarHonoursTheListVocabulary` — calendar vs works list token by token over `WorkListInclude`, both reads taken together so an unrelated edit cannot decide it
- `TestLiveWorkSchemaPublishesBothVocabularies`
- `TestWorksListCreditsAreTheDetailRowsBatched` / `TestWorksListBlocksMatchTheWorkDetail` at the service layer

Verified failing without the mapper arms before being verified passing with them. Full `apps/api` sweep green under `REQUIRE_DB_TESTS=1` with a dedicated ephemeral database; `go vet ./...` clean.

## Deploy

**Zero migrations.** The **mcp container must be restarted** after the deploy — both operation descriptions changed and the MCP face snapshots the spec at startup.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD