### PR TITLE
fix(store): let the affiliate templates actually reach the container

### DIFF
--- a/apps/api/cmd/catalog/main.go
+++ b/apps/api/cmd/catalog/main.go
@@ -263,6 +263,11 @@ func setupPublicCatalog(
 	} else {
 		slog.Warn("store face: link shortener not configured — /v2/store answers 503 (set KUN_STORE_SHORTLINK_BASE_URL and KUN_STORE_SHORTLINK_API_KEY)")
 	}
+	if storeMinter != nil && !(storeService.ValidAffTemplate(cfg.Store.AffTemplateManiax) && storeService.ValidAffTemplate(cfg.Store.AffTemplatePro)) {
+		slog.Warn("store face: affiliate template missing or without the {product_id} slot — purchase-link minting answers 503 (set KUN_STORE_DLSITE_AFF_URL_TMPL_MANIAX and _PRO)",
+			"maniax_ready", storeService.ValidAffTemplate(cfg.Store.AffTemplateManiax),
+			"pro_ready", storeService.ValidAffTemplate(cfg.Store.AffTemplatePro))
+	}
 	storeSvc := storeService.New(oauthDB, storeMinter, storeService.Options{
 		AffTemplateManiax:  cfg.Store.AffTemplateManiax,
 		AffTemplatePro:     cfg.Store.AffTemplatePro,

--- a/apps/api/internal/platform/store/service/links.go
+++ b/apps/api/internal/platform/store/service/links.go
@@ -72,15 +72,24 @@ type PurchaseLinks struct {
 
 func ValidProductID(productID string) bool { return productIDRe.MatchString(productID) }
 
+// ReplaceAll silently does nothing when the template spells the slot some other
+// way, and the forum's own template env calls it {workno}. An unsubstituted
+// template mints one alias per product all pointing at the same dead URL, and
+// pins them there: the alias is fixed per (client, product) and the shortener
+// has no re-point face.
+const productIDSlot = "{product_id}"
+
+func ValidAffTemplate(tmpl string) bool { return strings.Contains(tmpl, productIDSlot) }
+
 func (s *Service) affURL(productID string) (string, error) {
 	tmpl := s.opts.AffTemplatePro
 	if strings.HasPrefix(productID, "RJ") {
 		tmpl = s.opts.AffTemplateManiax
 	}
-	if tmpl == "" {
+	if !ValidAffTemplate(tmpl) {
 		return "", ErrNotConfigured
 	}
-	return strings.ReplaceAll(tmpl, "{product_id}", productID), nil
+	return strings.ReplaceAll(tmpl, productIDSlot, productID), nil
 }
 
 func (s *Service) PurchaseLinks(ctx context.Context, clientID, productID string) (*PurchaseLinks, error) {

--- a/apps/api/internal/platform/store/service/links_test.go
+++ b/apps/api/internal/platform/store/service/links_test.go
@@ -403,3 +403,40 @@ func TestMissingAffTemplateRefusesRatherThanMintingAnEmptyDestination(t *testing
 		t.Errorf("mint calls = %d, want 0", got)
 	}
 }
+
+func TestAffTemplateWithoutTheProductIDSlotRefusesRatherThanMintingOneDeadURL(t *testing.T) {
+	if err := storetest.Truncate(testDB); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	fake := storetest.NewFakeShortener()
+	t.Cleanup(fake.Close)
+	svc := New(testDB, fake.Client("slk_test"), Options{
+		AffTemplateManiax: "https://dlaf.jp/soft/dlaf/=/t/s/link/work/aid/kungal/id/{workno}.html",
+		AffTemplatePro:    tmplPro,
+	})
+
+	if _, err := svc.PurchaseLinks(context.Background(), "site-a", "RJ123456"); !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("err = %v, want ErrNotConfigured", err)
+	}
+	if got := len(fake.Mints()); got != 0 {
+		t.Errorf("mint calls = %d, want 0", got)
+	}
+	if _, err := svc.PurchaseLinks(context.Background(), "site-a", "VJ01000123"); err != nil {
+		t.Fatalf("the well-formed pro template must still mint: %v", err)
+	}
+}
+
+func TestValidAffTemplate(t *testing.T) {
+	for _, c := range []struct {
+		tmpl string
+		want bool
+	}{
+		{"", false},
+		{"https://dlaf.jp/soft/dlaf/=/t/s/link/work/aid/kungal/id/{workno}.html", false},
+		{"https://dlaf.jp/soft/dlaf/=/t/s/link/work/aid/kungal/locale/zh_CN/id/{product_id}.html/?locale=zh_CN", true},
+	} {
+		if got := ValidAffTemplate(c.tmpl); got != c.want {
+			t.Errorf("ValidAffTemplate(%q) = %v, want %v", c.tmpl, got, c.want)
+		}
+	}
+}

--- a/apps/api/pkg/config/config.go
+++ b/apps/api/pkg/config/config.go
@@ -598,10 +598,15 @@ func Load() (*Config, error) {
 	}
 
 	cfg.Store = StoreConfig{
-		ShortlinkBaseURL:   getEnv("KUN_STORE_SHORTLINK_BASE_URL", ""),
-		ShortlinkAPIKey:    getEnv("KUN_STORE_SHORTLINK_API_KEY", ""),
-		AffTemplateManiax:  getEnv("KUN_STORE_DLSITE_AFF_URL_TMPL_MANIAX", "https://www.dlsite.com/maniax/dlaf/=/link/work/aid/nextmoe/id/{product_id}.html"),
-		AffTemplatePro:     getEnv("KUN_STORE_DLSITE_AFF_URL_TMPL_PRO", "https://www.dlsite.com/pro/dlaf/=/link/work/aid/nextmoe/id/{product_id}.html"),
+		ShortlinkBaseURL: getEnv("KUN_STORE_SHORTLINK_BASE_URL", ""),
+		ShortlinkAPIKey:  getEnv("KUN_STORE_SHORTLINK_API_KEY", ""),
+		// Deliberately no default. These once fell back to a well-formed URL
+		// carrying the affiliate id aid/nextmoe, which does not exist: an
+		// unconfigured deployment minted real short links crediting nobody, and
+		// a minted alias is pinned to its destination forever. Empty makes the
+		// minting face answer 503 instead, which the caller retries.
+		AffTemplateManiax:  getEnv("KUN_STORE_DLSITE_AFF_URL_TMPL_MANIAX", ""),
+		AffTemplatePro:     getEnv("KUN_STORE_DLSITE_AFF_URL_TMPL_PRO", ""),
 		LinkQuotaPerClient: int(getEnvInt64("KUN_STORE_LINK_QUOTA_PER_CLIENT", 5000)),
 	}
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -429,6 +429,13 @@ services:
       # working value here.
       KUN_STORE_SHORTLINK_BASE_URL: http://shortlink-api:7845
       KUN_STORE_SHORTLINK_API_KEY: ${KUN_STORE_SHORTLINK_API_KEY:-}
+      # 2026-08-29, the same trap a second time: the affiliate templates and the
+      # quota were filled in the panel alone and the redeployed container came
+      # back without them. EVERY store var has to be listed here, not just the
+      # two the first fix happened to need.
+      KUN_STORE_DLSITE_AFF_URL_TMPL_MANIAX: ${KUN_STORE_DLSITE_AFF_URL_TMPL_MANIAX:-}
+      KUN_STORE_DLSITE_AFF_URL_TMPL_PRO: ${KUN_STORE_DLSITE_AFF_URL_TMPL_PRO:-}
+      KUN_STORE_LINK_QUOTA_PER_CLIENT: ${KUN_STORE_LINK_QUOTA_PER_CLIENT:-5000}
     # S2S read/admin face stays internal — product backends (wiki/forum/moyu)
     # reach it at http://catalog:9281 over dokploy-network. The ONLY public path
     # is the open-API /v1/catalog projection routed by the labels block below.


### PR DESCRIPTION
Found while verifying the forum's DLsite integration (`506bf4ad`). The forum side is contract-correct; all three defects here are on infra's side.

## 1. The panel vars never reached the container

`KUN_STORE_DLSITE_AFF_URL_TMPL_MANIAX` / `_PRO` / `KUN_STORE_LINK_QUOTA_PER_CLIENT` were set in the Dokploy panel, catalog was redeployed (`StartedAt` 2026-08-29T06:06:52Z), and `docker inspect` still showed only the two shortlink vars. A panel var only exists inside a service whose compose block interpolates it — this file's own header states the rule ("**NO `env_file`** — all runtime config is inline `environment:`"), and 98f3c06d fixed exactly this for the two vars it needed at the time. Same trap, second occurrence, three days later.

Verified after the change with the real values:

```
KUN_STORE_DLSITE_AFF_URL_TMPL_MANIAX = https://dlaf.jp/soft/dlaf/=/t/s/link/work/aid/kungal/locale/zh_CN/id/{product_id}.html/?locale=zh_CN
KUN_STORE_DLSITE_AFF_URL_TMPL_PRO    = (same)
KUN_STORE_LINK_QUOTA_PER_CLIENT      = 100000
```

## 2. The placeholder default was a plausible-looking wrong value

`AffTemplateManiax` / `AffTemplatePro` defaulted to a well-formed DLsite URL carrying `aid/nextmoe` — an affiliate id that does not exist. An unconfigured deployment therefore did not fail: it minted **real** short links crediting nobody. That is unrecoverable in practice — a purchase link is pinned per `(client_id, product_id)` forever, the shortener's s2s face has no re-point op (only an admin-session `PUT /links/{id}`, one link at a time), and the forum caches `short_url` in `dlsite_store_link` indefinitely.

Default is now empty → `ErrNotConfigured` → 503, which the caller already retries. `refs/plans/14-dlsite-store/02-store-domain.md` flagged this on 08-25 ("带着占位值上线等于把所有点击记到一个不存在的联盟号上"); this removes the possibility rather than restating the warning.

## 3. `affURL` never checked that the slot was present

`strings.ReplaceAll(tmpl, "{product_id}", …)` silently does nothing when the template spells the slot otherwise — and the forum's own template env calls it `{workno}`. Pasting that spelling here would mint one alias per product, all pointing at the same dead URL, all pinned. A template without `{product_id}` is now treated as unconfigured, and catalog logs a warning at startup so a bad template surfaces in the first log line instead of at the first reader's click.

## Tests

`internal/platform/store/...` green against an ephemeral DB with `REQUIRE_DB_TESTS=1` (`-count=1 -p 1`), plus the apiv2 store handler suite. Two new cases: a `{workno}` template refuses and mints nothing while the well-formed sibling template still mints, and a table test for `ValidAffTemplate`.

## Migration

**None.**

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD