### PR TITLE
fix(reindex-catalog): purge soft-deleted works from the search index

### DIFF
--- a/apps/api/cmd/reindex-catalog/main.go
+++ b/apps/api/cmd/reindex-catalog/main.go
@@ -441,6 +441,13 @@ func reindexWorks(ctx context.Context, db *gorm.DB, idx *catalogSearch.Indexer, 
 	if err != nil {
 		return err
 	}
+	// Works was the only soft-deleting lane without this purge: the 2026-08-29
+	// merge wave left its 3,242 soft-deleted works in the index — hits
+	// self-healed through DB hydration, totals and ranking slots did not — and
+	// the stale documents had to be hand-deleted over the Meilisearch API.
+	if err := purgeSoftDeleted(ctx, db, idx, catalogSearch.IndexWorks, "catalog_work", "w"); err != nil {
+		return err
+	}
 	processed, lastID := 0, int64(0)
 	for {
 		var rows []struct {

--- a/apps/api/cmd/reindex-catalog/purge_test.go
+++ b/apps/api/cmd/reindex-catalog/purge_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	infrasearch "api/internal/infrastructure/search"
+	"api/internal/platform/catalog/model"
+	catalogSearch "api/internal/platform/catalog/search"
+	"api/internal/testsupport/dbtest"
+	"api/pkg/config"
+)
+
+func TestReindexWorksPurgesSoftDeleted(t *testing.T) {
+	truncateFacetTables(t)
+	live := mkWork(t, "purge-live", 0, galgameMedium)
+	dead := mkWork(t, "purge-dead", 0, galgameMedium)
+	if err := facetTestDB.Delete(&model.CatalogWork{}, dead).Error; err != nil {
+		t.Fatalf("soft-delete work %d: %v", dead, err)
+	}
+
+	host, apiKey := dbtest.SearchHost()
+	if host == "" {
+		dbtest.SkipSearch(t, "MEILISEARCH_TEST_HOST unset")
+	}
+	prefix := dbtest.SearchIndexPrefix("reindex")
+	client, err := infrasearch.NewClient(config.MeilisearchConfig{
+		Host: host, APIKey: apiKey, IndexPrefix: prefix,
+	})
+	if err != nil {
+		dbtest.SkipSearch(t, "meilisearch client: %v", err)
+	}
+	if err := client.Health(); err != nil {
+		dbtest.SkipSearch(t, "meilisearch unreachable: %v", err)
+	}
+	if err := catalogSearch.EnsureIndexes(client); err != nil {
+		t.Fatalf("ensure indexes: %v", err)
+	}
+	t.Cleanup(func() { dbtest.SweepSearchIndexes(client.Svc(), prefix) })
+
+	idx := catalogSearch.NewIndexer(client)
+	docs := []catalogSearch.EntityDoc{
+		catalogSearch.BuildWorkDoc(catalogSearch.WorkDocInput{ID: live, DisplayName: "purge-live", OLang: "ja"}),
+		catalogSearch.BuildWorkDoc(catalogSearch.WorkDocInput{ID: dead, DisplayName: "purge-dead", OLang: "ja"}),
+	}
+	if err := idx.UpsertBatch(context.Background(), catalogSearch.IndexWorks, docs); err != nil {
+		t.Fatalf("seed index: %v", err)
+	}
+	waitWorkDocs(t, client, 2)
+
+	if err := reindexWorks(context.Background(), facetTestDB, idx, 100); err != nil {
+		t.Fatalf("reindexWorks: %v", err)
+	}
+
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		var doc map[string]any
+		deadErr := client.Index(catalogSearch.IndexWorks).GetDocument(catalogSearch.WorkDocID(dead), nil, &doc)
+		liveErr := client.Index(catalogSearch.IndexWorks).GetDocument(catalogSearch.WorkDocID(live), nil, &doc)
+		if deadErr != nil && liveErr == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("purge did not converge: dead doc err=%v (want non-nil), live doc err=%v (want nil)",
+				deadErr, liveErr)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func waitWorkDocs(t *testing.T, client *infrasearch.Client, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		stats, err := client.Index(catalogSearch.IndexWorks).GetStats()
+		if err == nil && stats.NumberOfDocuments == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("works index did not reach %d docs (last err %v)", want, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Works was the only soft-deleting lane whose reindex did not call `purgeSoftDeleted` — labels and characters both do. The 2026-08-29 dedup merge wave soft-deleted 3,242 works past the write-through hook, and all of them stayed in the `catalog_works` Meilisearch index: search results self-healed through DB hydration, but totals stayed inflated and the dead documents kept occupying ranking slots. They were hand-purged over the Meili API in prod (82,698 → 79,469 docs, exactly the live population).

This adds the same purge call the labels/characters lanes already have, so the daily reindex heals this drift class for works automatically, plus a DB+Meili test that seeds a live and a soft-deleted work into the index and asserts `reindexWorks` removes only the dead one.

Test plan: `go test ./cmd/reindex-catalog/ -count=1 -p 1` with `REQUIRE_DB_TESTS=1 REQUIRE_SEARCH_TESTS=1` against an ephemeral DB + dev Meili — green, purge line logged (`docs=1`).

https://claude.ai/code/session_01NZJ7JMgjjkhciKhxA91H61