### PR TITLE
fix(prod-compose): store-stats-sync needs the shortlink vars in the oauth block

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -261,6 +261,16 @@ services:
       # with every other developer. Empty => both jobs soft-skip.
       KUN_YMGAL_CLIENT_ID: ${KUN_YMGAL_CLIENT_ID:-}
       KUN_YMGAL_CLIENT_SECRET: ${KUN_YMGAL_CLIENT_SECRET:-}
+      # store-stats-sync runs in THIS container's scheduler, not catalog's. The
+      # 08-26/08-29 catalog fixes put the shortlink vars only in the catalog
+      # block, so this job soft-skipped hourly and store_link_daily_stats sat
+      # empty while the shortener counted 3.3k real clicks (2026-08-30). The
+      # first configured run backfills from the earliest mint day, so nothing
+      # is lost — but every service that reads a store var needs it listed in
+      # ITS OWN block. Base URL literal for the same reason as catalog's: only
+      # the `shortlink-api` alias serves the S2S face.
+      KUN_STORE_SHORTLINK_BASE_URL: http://shortlink-api:7845
+      KUN_STORE_SHORTLINK_API_KEY: ${KUN_STORE_SHORTLINK_API_KEY:-}
       # Where the news-moderate job reaches Tier0 and the AI adviser. Both are
       # spelled out because the AI client's built-in default is 127.0.0.1:9284,
       # which resolves to this container itself rather than the ai service.


### PR DESCRIPTION
The jobs scheduler runs in the **oauth** container, but `KUN_STORE_SHORTLINK_BASE_URL`/`KUN_STORE_SHORTLINK_API_KEY` were only interpolated in the **catalog** block (the 08-26 and 08-29 panel-vars fixes). Result: `store-stats-sync` has soft-skipped hourly since the store deploy —

```
WARN store-stats-sync: link shortener not configured — skipping (set KUN_STORE_SHORTLINK_BASE_URL/API_KEY)
```

— and `store_link_daily_stats` is empty while the shortener has already counted **3,336 real clicks** (08-29: 100 / 08-30 partial: 3,236). Partner-facing stats and settlement measurement read that table, so this is a prerequisite for onboarding third-party sites.

No data is lost: `storestats.Run` full-pulls from the earliest mint day when the local table is empty, and the shortener's day buckets are authoritative (overwrite upsert).

Zero migrations. Takes effect on next redeploy of the infra project.

https://claude.ai/code/session_01NZJ7JMgjjkhciKhxA91H61