### PR TITLE
feat(image): add sticker preset for emoji-pack uploads

### DIFF
--- a/apps/api/configs/image_presets.yaml
+++ b/apps/api/configs/image_presets.yaml
@@ -195,6 +195,30 @@ presets:
       - image/png
       - image/webp
 
+  # Galgame sticker / emoji-pack frames. Square-ish expression crops; `inside`
+  # keeps ahoge and full character (same reason as character_figure — cover
+  # would clip). `320` is the pack-grid card; `128` is the home-row preview.
+  # Uploaded under site_key "sticker"; that client's image_allowed_presets MUST
+  # list `sticker` or every upload is 403'd.
+  sticker:
+    variants:
+      - name: "320"
+        width: 320
+        height: 320
+        fit: inside
+        format: webp
+        quality: 80
+      - name: "128"
+        width: 128
+        height: 128
+        fit: inside
+        format: webp
+        quality: 80
+    allowed_mime:
+      - image/jpeg
+      - image/png
+      - image/webp
+
   # Topic / inline post images. Main image only; no extra variants.
   topic:
     variants: []

--- a/apps/api/internal/platform/image/preset/preset.go
+++ b/apps/api/internal/platform/image/preset/preset.go
@@ -51,6 +51,8 @@ func (c *Config) Get(name string) (Preset, bool) {
 	return p, ok
 }
 
+// Load reads configs/image_presets.yaml. New presets are YAML-only plus an
+// oauth_clients.image_allowed_presets grant; this package does not name them.
 func Load(path string) (*Config, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {


### PR DESCRIPTION
Adds a `sticker` preset (`fit: inside`, variants `_320` and `_128`) so kun-galgame-stickers can store pack frames on the image service without cover-cropping ahoge.

The sticker OAuth client (`c5cd7b074804ba134934eb6c175a8f4d`) needs `image_enabled` + `image_allowed_presets=["sticker"]` on `oauth_clients` (already applied on this machine's infra DB). Rebuild/restart `infra-image` to load the YAML.