### PR TITLE
feat(ai): force Tier2 escalation per (site,kind) with site-aware prompt

### DIFF
--- a/apps/api/cmd/ai/main.go
+++ b/apps/api/cmd/ai/main.go
@@ -65,7 +65,11 @@ func main() {
 	moderationSvc := service.NewModerationService(aiDB.DB(), omni, up, service.ModerationOptions{
 		EscalateThreshold:  cfg.AIOmni.EscalateThreshold,
 		NegativeSampleRate: cfg.AIOmni.NegativeSampleRate,
+		ForceEscalate:      cfg.AIOmni.ForceEscalate,
 	})
+	if cfg.AIOmni.ForceEscalate != "" {
+		slog.Info("ai cascade forced escalation", "pairs", cfg.AIOmni.ForceEscalate)
+	}
 	statsSvc := service.NewStatsService(aiDB.DB())
 	budgetSvc := service.NewBudgetService(aiDB.DB())
 

--- a/apps/api/internal/platform/ai/dto/ai_dto.go
+++ b/apps/api/internal/platform/ai/dto/ai_dto.go
@@ -1,8 +1,9 @@
 package dto
 
 type ModerateTextRequest struct {
-	Text     string `json:"text" doc:"the UGC text to scan"`
-	AuthorID *int64 `json:"author_id,omitempty" doc:"optional author global id (attribution/repeat-offender signal); NOT the tenant — the tenant is derived from the client binding"`
+	Text        string `json:"text" doc:"the UGC text to scan"`
+	AuthorID    *int64 `json:"author_id,omitempty" doc:"optional author global id (attribution/repeat-offender signal); NOT the tenant — the tenant is derived from the client binding"`
+	SubjectKind string `json:"subject_kind,omitempty" doc:"optional product-side content kind (e.g. forum_topic); with the tenant site it selects forced Tier2 escalation for configured (site,kind) pairs"`
 }
 
 type ModerateTextResponse struct {

--- a/apps/api/internal/platform/ai/handler/s2s.go
+++ b/apps/api/internal/platform/ai/handler/s2s.go
@@ -54,7 +54,7 @@ func (s *Server) moderateText(ctx context.Context, in *moderateTextInput) (*mode
 		return nil, he
 	}
 	res, err := s.moderation.Moderate(ctx, service.ModerateParams{
-		Site: site, Text: in.Body.Text, AuthorID: in.Body.AuthorID,
+		Site: site, Text: in.Body.Text, AuthorID: in.Body.AuthorID, SubjectKind: in.Body.SubjectKind,
 	})
 	if err != nil {
 		slog.Error("ai moderate-text", "err", err)

--- a/apps/api/internal/platform/ai/service/force_escalate_test.go
+++ b/apps/api/internal/platform/ai/service/force_escalate_test.go
@@ -1,0 +1,184 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"api/internal/platform/ai/model"
+	"api/internal/platform/ai/upstream"
+)
+
+func TestForcedEscalationDialsLLMBelowThreshold(t *testing.T) {
+	cleanTables(t)
+	omni := &fakeOmni{configured: true, model: omniModel, result: upstream.OmniResult{
+		Flagged:        false,
+		Categories:     map[string]bool{},
+		CategoryScores: map[string]float64{"violence": 0.01},
+		Channel:        omniModel,
+	}}
+	llm := &fakeUpstream{configured: true, model: "deepseek-chat", result: upstream.ChatResult{
+		Content: `{"flagged": true, "categories": ["spam"], "score": 0.97}`,
+		Channel: "deepseek-chat",
+	}}
+	s := NewModerationService(testDB, omni, llm, ModerationOptions{
+		EscalateThreshold: 0.4,
+		ForceEscalate:     "kungal:forum_topic",
+	})
+
+	res, err := s.Moderate(context.Background(), ModerateParams{
+		Site: "kungal", Text: "classified ad", SubjectKind: "forum_topic",
+	})
+	if err != nil {
+		t.Fatalf("Moderate: %v", err)
+	}
+	if !res.Flagged || res.Degraded {
+		t.Fatalf("want flagged not-degraded, got flagged=%v degraded=%v", res.Flagged, res.Degraded)
+	}
+	if res.Channel != "deepseek-chat" {
+		t.Fatalf("channel = %q, want deepseek-chat (LLM is final)", res.Channel)
+	}
+	if omni.calls != 1 {
+		t.Fatalf("omni calls = %d, want 1", omni.calls)
+	}
+	if llm.calls != 1 {
+		t.Fatalf("LLM calls = %d, want 1", llm.calls)
+	}
+	rows := usageRows(t, "kungal", model.RouteModerateText)
+	if len(rows) != 2 {
+		t.Fatalf("want 2 metered rows (omni + LLM), got %d", len(rows))
+	}
+	if rows[0].Channel != omniModel || rows[0].Status != model.StatusOK {
+		t.Fatalf("omni row wrong: %+v", rows[0])
+	}
+	if rows[1].Channel != "deepseek-chat" || rows[1].Status != model.StatusOK {
+		t.Fatalf("LLM row wrong: %+v", rows[1])
+	}
+	if !strings.Contains(llm.lastSystem, "Site context (kungal)") {
+		t.Fatalf("LLM system prompt missing kungal site context, got %q", llm.lastSystem)
+	}
+}
+
+func TestForcedEscalationIgnoresUnlistedPair(t *testing.T) {
+	cleanTables(t)
+	omni := &fakeOmni{configured: true, model: omniModel, result: upstream.OmniResult{
+		Flagged:        false,
+		Categories:     map[string]bool{},
+		CategoryScores: map[string]float64{"violence": 0.01},
+		Channel:        omniModel,
+	}}
+	llm := &fakeUpstream{configured: true, model: "deepseek-chat",
+		result: upstream.ChatResult{Content: `{"flagged": true, "categories": ["spam"], "score": 0.97}`, Channel: "deepseek-chat"}}
+	s := NewModerationService(testDB, omni, llm, ModerationOptions{
+		EscalateThreshold:  0.4,
+		NegativeSampleRate: 0,
+		ForceEscalate:      "kungal:forum_topic",
+	})
+
+	res, err := s.Moderate(context.Background(), ModerateParams{
+		Site: "letmoe", Text: "hi", SubjectKind: "forum_topic",
+	})
+	if err != nil {
+		t.Fatalf("Moderate (letmoe): %v", err)
+	}
+	if res.Flagged || res.Degraded {
+		t.Fatalf("unlisted pair must stay omni-terminal clean, got flagged=%v degraded=%v", res.Flagged, res.Degraded)
+	}
+	if res.Channel != omniModel {
+		t.Fatalf("channel = %q, want omni", res.Channel)
+	}
+	if llm.calls != 0 {
+		t.Fatalf("unlisted pair must NOT dial LLM, calls=%d", llm.calls)
+	}
+
+	res, err = s.Moderate(context.Background(), ModerateParams{
+		Site: "kungal", Text: "hi", SubjectKind: "",
+	})
+	if err != nil {
+		t.Fatalf("Moderate (empty kind): %v", err)
+	}
+	if res.Flagged || res.Degraded {
+		t.Fatalf("empty kind must stay omni-terminal clean, got flagged=%v degraded=%v", res.Flagged, res.Degraded)
+	}
+	if res.Channel != omniModel {
+		t.Fatalf("empty kind channel = %q, want omni", res.Channel)
+	}
+	if llm.calls != 0 {
+		t.Fatalf("empty kind must NOT dial LLM, calls=%d", llm.calls)
+	}
+}
+
+func TestForcedEscalationFallsBackWhenLLMUnconfigured(t *testing.T) {
+	cleanTables(t)
+	omni := &fakeOmni{configured: true, model: omniModel, result: upstream.OmniResult{
+		Flagged:        false,
+		Categories:     map[string]bool{},
+		CategoryScores: map[string]float64{"violence": 0.01},
+		Channel:        omniModel,
+	}}
+	llm := &fakeUpstream{configured: false}
+	s := NewModerationService(testDB, omni, llm, ModerationOptions{
+		EscalateThreshold: 0.4,
+		ForceEscalate:     "kungal:forum_topic",
+	})
+
+	res, err := s.Moderate(context.Background(), ModerateParams{
+		Site: "kungal", Text: "classified ad", SubjectKind: "forum_topic",
+	})
+	if err != nil {
+		t.Fatalf("Moderate: %v", err)
+	}
+	if res.Flagged {
+		t.Fatalf("omni-terminal clean must not flag, flagged=%v", res.Flagged)
+	}
+	if res.Degraded {
+		t.Fatalf("omni-terminal fallback is a REAL verdict — must NOT be degraded")
+	}
+	if res.Channel != omniModel {
+		t.Fatalf("channel = %q, want omni", res.Channel)
+	}
+	if llm.calls != 0 {
+		t.Fatalf("LLM unconfigured must not dial, calls=%d", llm.calls)
+	}
+}
+
+func TestParseForceEscalate(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"mixed case and spaces", " Kungal:Forum_Topic , kungal:forum_reply ", []string{"kungal:forum_topic", "kungal:forum_reply"}},
+		{"no colon", "kungal", nil},
+		{"empty site", ":x", nil},
+		{"empty kind", "x:", nil},
+		{"empty token", "kungal:forum_topic,,", []string{"kungal:forum_topic"}},
+		{"empty string", "", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseForceEscalate(c.raw)
+			if len(got) != len(c.want) {
+				t.Fatalf("len=%d want %d; set=%v", len(got), len(c.want), got)
+			}
+			for _, k := range c.want {
+				if _, ok := got[k]; !ok {
+					t.Fatalf("missing %q in %v", k, got)
+				}
+			}
+		})
+	}
+}
+
+func TestModerateSystemPromptSiteContext(t *testing.T) {
+	kungal := moderateSystemPrompt("kungal")
+	if !strings.HasPrefix(kungal, ModerateSystemPrompt) {
+		t.Fatal("kungal prompt must start with ModerateSystemPrompt")
+	}
+	if !strings.Contains(kungal, "Site context (kungal)") {
+		t.Fatalf("kungal prompt missing site context")
+	}
+	if got := moderateSystemPrompt("letmoe"); got != ModerateSystemPrompt {
+		t.Fatalf("letmoe prompt must equal ModerateSystemPrompt exactly")
+	}
+}

--- a/apps/api/internal/platform/ai/service/moderation.go
+++ b/apps/api/internal/platform/ai/service/moderation.go
@@ -36,12 +36,14 @@ type ModerationService struct {
 	negativeSampleRate float64
 	rand               func() float64
 	retryDelay         time.Duration
+	forceEscalate      map[string]struct{}
 }
 
 type ModerationOptions struct {
 	EscalateThreshold  float32
 	NegativeSampleRate float64
 	Rand               func() float64
+	ForceEscalate      string
 }
 
 func NewModerationService(db *gorm.DB, omni omniClient, llm upstreamClient, opts ModerationOptions) *ModerationService {
@@ -57,13 +59,36 @@ func NewModerationService(db *gorm.DB, omni omniClient, llm upstreamClient, opts
 		negativeSampleRate: opts.NegativeSampleRate,
 		rand:               r,
 		retryDelay:         moderateRetryDelay,
+		forceEscalate:      parseForceEscalate(opts.ForceEscalate),
 	}
 }
 
+func parseForceEscalate(raw string) map[string]struct{} {
+	set := map[string]struct{}{}
+	for _, pair := range strings.Split(raw, ",") {
+		pair = strings.ToLower(strings.TrimSpace(pair))
+		site, kind, ok := strings.Cut(pair, ":")
+		if !ok || site == "" || kind == "" {
+			continue
+		}
+		set[site+":"+kind] = struct{}{}
+	}
+	return set
+}
+
+func (s *ModerationService) forceEscalated(site, kind string) bool {
+	if kind == "" {
+		return false
+	}
+	_, ok := s.forceEscalate[strings.ToLower(site)+":"+strings.ToLower(kind)]
+	return ok
+}
+
 type ModerateParams struct {
-	Site     string
-	Text     string
-	AuthorID *int64
+	Site        string
+	Text        string
+	AuthorID    *int64
+	SubjectKind string
 }
 
 type ModerateResult struct {
@@ -80,6 +105,16 @@ Judge the user message for policy violations (abuse/harassment, spam, illegal co
 Respond with ONLY a JSON object, no prose, of the form:
 {"flagged": <bool>, "categories": [<string>, ...], "score": <number between 0 and 1>}
 "flagged" is true only when the message clearly violates policy; "score" is your confidence that it violates policy.`
+
+var siteModerationContext = map[string]string{
+	"kungal": `
+
+Site context (kungal): the text is from a Chinese-language visual-novel (galgame) community forum. Discussion of adult (R18) games, requests for game resources/patches, and lewd banter about fictional game content are on-policy here — do not flag them as sexual content. The dominant real abuse is commercial solicitation spam: escort/prostitution classified ads (外送茶, 楼凤, 上门, 空降, 兼职 companions, prices with LINE / Telegram / WeChat contact handles), gambling or casino promotion, and other off-platform recruitment. Flag those as spam with high confidence even when the wording is not explicitly sexual.`,
+}
+
+func moderateSystemPrompt(site string) string {
+	return ModerateSystemPrompt + siteModerationContext[site]
+}
 
 // moderateMaxTokens caps the reply. The verdict object itself is ~40 tokens, so
 // this looks generous — but it is a CEILING, not a budget: a model that answers
@@ -140,6 +175,10 @@ func (s *ModerationService) Moderate(ctx context.Context, p ModerateParams) (Mod
 
 	rel := relevantScore(ores.CategoryScores)
 
+	if s.llm.Configured() && s.forceEscalated(p.Site, p.SubjectKind) {
+		return s.moderateViaLLM(ctx, p, routeName, spec)
+	}
+
 	if rel >= s.escalateThreshold {
 		if s.llm.Configured() {
 			return s.moderateViaLLM(ctx, p, routeName, spec)
@@ -172,7 +211,7 @@ func (s *ModerationService) moderateViaLLM(ctx context.Context, p ModerateParams
 		return failOpen(routeName, "", spec), nil
 	}
 
-	res, err := s.llm.ChatJSON(ctx, ModerateSystemPrompt, p.Text, moderateMaxTokens)
+	res, err := s.llm.ChatJSON(ctx, moderateSystemPrompt(p.Site), p.Text, moderateMaxTokens)
 	if err != nil && upstream.IsRateLimited(err) {
 		// The Cloudflare inference bucket is per-minute and shared with every
 		// other caller on the account, so a 429 here is contention, not a
@@ -189,7 +228,7 @@ func (s *ModerationService) moderateViaLLM(ctx context.Context, p ModerateParams
 		case <-ctx.Done():
 			timer.Stop()
 		case <-timer.C:
-			res, err = s.llm.ChatJSON(ctx, ModerateSystemPrompt, p.Text, moderateMaxTokens)
+			res, err = s.llm.ChatJSON(ctx, moderateSystemPrompt(p.Site), p.Text, moderateMaxTokens)
 		}
 	}
 	if err != nil {

--- a/apps/api/internal/platform/ai/service/service_test.go
+++ b/apps/api/internal/platform/ai/service/service_test.go
@@ -56,12 +56,14 @@ type fakeUpstream struct {
 	err        error
 	errSeq     []error
 	calls      int
+	lastSystem string
 }
 
 func (f *fakeUpstream) Configured() bool { return f.configured }
 func (f *fakeUpstream) Model() string    { return f.model }
-func (f *fakeUpstream) ChatJSON(_ context.Context, _, _ string, _ int) (upstream.ChatResult, error) {
+func (f *fakeUpstream) ChatJSON(_ context.Context, system, _ string, _ int) (upstream.ChatResult, error) {
 	f.calls++
+	f.lastSystem = system
 	if len(f.errSeq) > 0 {
 		e := f.errSeq[0]
 		f.errSeq = f.errSeq[1:]

--- a/apps/api/internal/platform/trust/service/scan_gateway.go
+++ b/apps/api/internal/platform/trust/service/scan_gateway.go
@@ -14,7 +14,7 @@ import (
 
 type ScanGateway interface {
 	Configured() bool
-	Moderate(ctx context.Context, text string, authorID *int64) (GatewayVerdict, error)
+	Moderate(ctx context.Context, text, subjectKind string, authorID *int64) (GatewayVerdict, error)
 }
 
 type GatewayVerdict struct {
@@ -48,8 +48,9 @@ func (c *AIGatewayClient) Configured() bool {
 }
 
 type moderateReq struct {
-	Text     string `json:"text"`
-	AuthorID *int64 `json:"author_id,omitempty"`
+	Text        string `json:"text"`
+	SubjectKind string `json:"subject_kind,omitempty"`
+	AuthorID    *int64 `json:"author_id,omitempty"`
 }
 
 type moderateEnvelope struct {
@@ -65,8 +66,8 @@ type moderateEnvelope struct {
 	} `json:"data"`
 }
 
-func (c *AIGatewayClient) Moderate(ctx context.Context, text string, authorID *int64) (GatewayVerdict, error) {
-	raw, err := json.Marshal(moderateReq{Text: text, AuthorID: authorID})
+func (c *AIGatewayClient) Moderate(ctx context.Context, text, subjectKind string, authorID *int64) (GatewayVerdict, error) {
+	raw, err := json.Marshal(moderateReq{Text: text, SubjectKind: subjectKind, AuthorID: authorID})
 	if err != nil {
 		return GatewayVerdict{}, err
 	}

--- a/apps/api/internal/platform/trust/service/scan_gateway_test.go
+++ b/apps/api/internal/platform/trust/service/scan_gateway_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGatewayModerateSendsSubjectKind(t *testing.T) {
+	var lastBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		lastBody = b
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":0,"message":"","data":{"route":"moderate-text","flagged":true,"categories":["spam"],"score":0.9,"channel":"x","degraded":false}}`))
+	}))
+	defer srv.Close()
+
+	c := NewAIGatewayClient(srv.URL, "id", "secret")
+
+	v, err := c.Moderate(context.Background(), "hello", "forum_topic", nil)
+	if err != nil {
+		t.Fatalf("Moderate(forum_topic): %v", err)
+	}
+	if !strings.Contains(string(lastBody), `"subject_kind":"forum_topic"`) {
+		t.Fatalf("body missing subject_kind forum_topic: %s", lastBody)
+	}
+	if !v.Flagged || v.Degraded {
+		t.Fatalf("want flagged not-degraded, got flagged=%v degraded=%v", v.Flagged, v.Degraded)
+	}
+	if v.Channel != "x" {
+		t.Fatalf("channel = %q, want x", v.Channel)
+	}
+	if len(v.Categories) != 1 || v.Categories[0] != "spam" {
+		t.Fatalf("categories = %v, want [spam]", v.Categories)
+	}
+	if v.Score == nil || *v.Score < 0.89 || *v.Score > 0.91 {
+		t.Fatalf("score = %v, want ~0.9", v.Score)
+	}
+
+	v, err = c.Moderate(context.Background(), "hello", "", nil)
+	if err != nil {
+		t.Fatalf("Moderate(empty kind): %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(lastBody, &body); err != nil {
+		t.Fatalf("decode body: %v (%s)", err, lastBody)
+	}
+	if _, ok := body["subject_kind"]; ok {
+		t.Fatalf("empty subjectKind must omit the key, body=%s", lastBody)
+	}
+	if !v.Flagged || v.Degraded || v.Channel != "x" {
+		t.Fatalf("empty-kind verdict wrong: flagged=%v degraded=%v channel=%q", v.Flagged, v.Degraded, v.Channel)
+	}
+}

--- a/apps/api/internal/platform/trust/service/scan_retry_test.go
+++ b/apps/api/internal/platform/trust/service/scan_retry_test.go
@@ -20,7 +20,7 @@ type scriptStep struct {
 
 func (g *scriptedGateway) Configured() bool { return true }
 
-func (g *scriptedGateway) Moderate(_ context.Context, _ string, _ *int64) (GatewayVerdict, error) {
+func (g *scriptedGateway) Moderate(_ context.Context, _, _ string, _ *int64) (GatewayVerdict, error) {
 	s := g.steps[len(g.steps)-1]
 	if g.calls < len(g.steps) {
 		s = g.steps[g.calls]

--- a/apps/api/internal/platform/trust/service/scan_worker.go
+++ b/apps/api/internal/platform/trust/service/scan_worker.go
@@ -135,7 +135,7 @@ func (w *ScanWorker) scoreOne(ctx context.Context, tx *gorm.DB, r *model.TrustSc
 	if !w.gateway.Configured() {
 		return w.markDegraded(tx, r, tier0, pol, model.ScanDegradedGatewayUnconfigured)
 	}
-	verdict, err := w.gateway.Moderate(ctx, r.ContentText, r.AuthorID)
+	verdict, err := w.gateway.Moderate(ctx, r.ContentText, r.SubjectKind, r.AuthorID)
 	if err != nil {
 		slog.Warn("trust scan gateway call failed; draining to degraded",
 			"scan_id", r.ID, "attempt", r.ScanAttempts+1, "err", err)

--- a/apps/api/internal/platform/trust/service/scan_worker_test.go
+++ b/apps/api/internal/platform/trust/service/scan_worker_test.go
@@ -15,11 +15,13 @@ type fakeGateway struct {
 	verdict    GatewayVerdict
 	err        error
 	calls      atomic.Int32
+	lastKind   string
 }
 
 func (g *fakeGateway) Configured() bool { return g.configured }
-func (g *fakeGateway) Moderate(_ context.Context, _ string, _ *int64) (GatewayVerdict, error) {
+func (g *fakeGateway) Moderate(_ context.Context, _, kind string, _ *int64) (GatewayVerdict, error) {
 	g.calls.Add(1)
+	g.lastKind = kind
 	return g.verdict, g.err
 }
 
@@ -73,6 +75,9 @@ func TestScanWorkerScoredAndShadow(t *testing.T) {
 	}
 	if g.calls.Load() != 1 {
 		t.Fatalf("gateway calls = %d, want 1", g.calls.Load())
+	}
+	if g.lastKind != tKind {
+		t.Fatalf("gateway subjectKind = %q, want %q", g.lastKind, tKind)
 	}
 
 	row := getScan(t, id)
@@ -200,7 +205,7 @@ type blockingGateway struct {
 }
 
 func (g *blockingGateway) Configured() bool { return true }
-func (g *blockingGateway) Moderate(_ context.Context, _ string, _ *int64) (GatewayVerdict, error) {
+func (g *blockingGateway) Moderate(_ context.Context, _, _ string, _ *int64) (GatewayVerdict, error) {
 	g.calls.Add(1)
 	g.entered <- struct{}{}
 	<-g.release

--- a/apps/api/pkg/config/config.go
+++ b/apps/api/pkg/config/config.go
@@ -122,6 +122,7 @@ type AIOmniConfig struct {
 	Model              string
 	EscalateThreshold  float32
 	NegativeSampleRate float64
+	ForceEscalate      string
 }
 
 type TrustServiceConfig struct {
@@ -589,6 +590,7 @@ func Load() (*Config, error) {
 		Model:              getEnv("KUN_AI_OMNI_MODEL", "omni-moderation-latest"),
 		EscalateThreshold:  float32(omniEscalate),
 		NegativeSampleRate: omniSampleRate,
+		ForceEscalate:      getEnv("KUN_AI_FORCE_ESCALATE", ""),
 	}
 
 	cfg.AIClient = AIClientConfig{

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -471,6 +471,7 @@ services:
       # Tier1→Tier2 cascade tuning (explicit defaults; spec 09 ruling 3).
       KUN_AI_ESCALATE_THRESHOLD: "0.4"
       KUN_AI_NEGATIVE_SAMPLE_RATE: "0.05"
+      KUN_AI_FORCE_ESCALATE: ""
     depends_on:
       migrate: { condition: service_completed_successfully }     # reads oauth_clients
       migrate-ai: { condition: service_completed_successfully }  # kun_ai schema

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -712,6 +712,11 @@ services:
       # negative rate for shadow calibration (only when the LLM tier is configured).
       KUN_AI_ESCALATE_THRESHOLD: ${KUN_AI_ESCALATE_THRESHOLD:-0.4}
       KUN_AI_NEGATIVE_SAMPLE_RATE: ${KUN_AI_NEGATIVE_SAMPLE_RATE:-0.05}
+      # Per-face forced escalation: comma-separated site:kind pairs (e.g.
+      # "kungal:forum_topic,kungal:forum_reply") whose texts always get Tier2
+      # final adjudication — omni has no spam category, so classified-ad spam
+      # scores ~0 and the threshold can never catch it.
+      KUN_AI_FORCE_ESCALATE: ${KUN_AI_FORCE_ESCALATE:-}
     # Internal only — product/platform backends reach it at http://ai:9284 over
     # dokploy-network.
     expose: ["9284"]

--- a/docs/ai/openapi.yaml
+++ b/docs/ai/openapi.yaml
@@ -54,6 +54,9 @@ components:
           description: optional author global id (attribution/repeat-offender signal); NOT the tenant — the tenant is derived from the client binding
           format: int64
           type: integer
+        subject_kind:
+          description: optional product-side content kind (e.g. forum_topic); with the tenant site it selects forced Tier2 escalation for configured (site,kind) pairs
+          type: string
         text:
           description: the UGC text to scan
           type: string


### PR DESCRIPTION
## What

Closes the moderation-cascade blind spot that let escort-ad spam through on kungal: omni has no spam category, so classified-solicitation texts score ~0 relevant and the escalation threshold can never fire (0/196 forum topics flagged in 14 days).

- **Wire**: optional `subject_kind` on `moderate-text`; trust scan worker now forwards `r.SubjectKind`. Backward compatible — `omitempty` both directions, absent field = unchanged behavior.
- **Gateway**: new env `KUN_AI_FORCE_ESCALATE` (comma-separated `site:kind` pairs). Matching pairs skip the omni threshold gate and go straight to Tier2 (GLM) final adjudication; safe fallback to the omni-terminal path when no LLM is configured.
- **Prompt**: `moderateSystemPrompt(site)` appends per-site context for kungal — R18 galgame discussion is on-policy (fixes 4093-type sexual misfires), classified solicitation is spam (fixes the misses). Applied at both ChatJSON call sites (initial + 429 retry).
- Compose: `${KUN_AI_FORCE_ESCALATE:-}` interpolated in prod, empty in dev; `docs/ai/openapi.yaml` regenerated.

## Deploy

Zero migrations. Set in Dokploy before redeploy:
`KUN_AI_FORCE_ESCALATE=kungal:forum_topic,kungal:forum_reply,kungal:forum_comment`
(~55 extra GLM calls/day; do NOT set site-wide — galgame_resource alone is 3,903/14d on the shared CF bucket.)
Redeploy ai + trust together; ordering is safe either way (old gateway ignores the unknown field).

## Verification

Full ai+trust DB suites green on an ephemeral DB (`-count=1 -p 1`), 5 new tests confirmed executed via `-v -run` (not skipped); build/vet/gofmt clean on touched paths; prod replay of the 4 escort-ad texts through the real matcher: 3 deny, 4103 (full-width per-char spacing) is the structural term-list miss this PR's forced escalation exists to catch.

https://claude.ai/code/session_01GhHEqvDcwkbdct4UGGk726