### PR TITLE
fix(ai): key forced escalation and the site prompt off the subject site

### DIFF
--- a/apps/api/internal/platform/ai/dto/ai_dto.go
+++ b/apps/api/internal/platform/ai/dto/ai_dto.go
@@ -3,7 +3,8 @@ package dto
 type ModerateTextRequest struct {
 	Text        string `json:"text" doc:"the UGC text to scan"`
 	AuthorID    *int64 `json:"author_id,omitempty" doc:"optional author global id (attribution/repeat-offender signal); NOT the tenant — the tenant is derived from the client binding"`
-	SubjectKind string `json:"subject_kind,omitempty" doc:"optional product-side content kind (e.g. forum_topic); with the tenant site it selects forced Tier2 escalation for configured (site,kind) pairs"`
+	SubjectSite string `json:"subject_site,omitempty" doc:"optional site the content belongs to (e.g. kungal) when the caller proxies for other sites; falls back to the client-binding site"`
+	SubjectKind string `json:"subject_kind,omitempty" doc:"optional product-side content kind (e.g. forum_topic); with the subject site it selects forced Tier2 escalation for configured (site,kind) pairs"`
 }
 
 type ModerateTextResponse struct {

--- a/apps/api/internal/platform/ai/handler/s2s.go
+++ b/apps/api/internal/platform/ai/handler/s2s.go
@@ -54,7 +54,7 @@ func (s *Server) moderateText(ctx context.Context, in *moderateTextInput) (*mode
 		return nil, he
 	}
 	res, err := s.moderation.Moderate(ctx, service.ModerateParams{
-		Site: site, Text: in.Body.Text, AuthorID: in.Body.AuthorID, SubjectKind: in.Body.SubjectKind,
+		Site: site, SubjectSite: in.Body.SubjectSite, Text: in.Body.Text, AuthorID: in.Body.AuthorID, SubjectKind: in.Body.SubjectKind,
 	})
 	if err != nil {
 		slog.Error("ai moderate-text", "err", err)

--- a/apps/api/internal/platform/ai/service/force_escalate_test.go
+++ b/apps/api/internal/platform/ai/service/force_escalate_test.go
@@ -59,6 +59,53 @@ func TestForcedEscalationDialsLLMBelowThreshold(t *testing.T) {
 	}
 }
 
+// The prod shape: the trust worker proxies every product site through one
+// client, so the binding site is always "trust" — the first ship keyed the
+// pair match and the site prompt off it and neither ever fired in prod.
+func TestForcedEscalationKeysOffSubjectSite(t *testing.T) {
+	cleanTables(t)
+	omni := &fakeOmni{configured: true, model: omniModel, result: upstream.OmniResult{
+		Flagged:        false,
+		Categories:     map[string]bool{},
+		CategoryScores: map[string]float64{"violence": 0.01},
+		Channel:        omniModel,
+	}}
+	llm := &fakeUpstream{configured: true, model: "deepseek-chat", result: upstream.ChatResult{
+		Content: `{"flagged": true, "categories": ["spam"], "score": 0.97}`,
+		Channel: "deepseek-chat",
+	}}
+	s := NewModerationService(testDB, omni, llm, ModerationOptions{
+		EscalateThreshold: 0.4,
+		ForceEscalate:     "kungal:forum_topic",
+	})
+
+	res, err := s.Moderate(context.Background(), ModerateParams{
+		Site: "trust", SubjectSite: "kungal", Text: "classified ad", SubjectKind: "forum_topic",
+	})
+	if err != nil {
+		t.Fatalf("Moderate: %v", err)
+	}
+	if !res.Flagged || res.Channel != "deepseek-chat" {
+		t.Fatalf("subject_site=kungal must force-escalate to LLM, got flagged=%v channel=%q", res.Flagged, res.Channel)
+	}
+	if !strings.Contains(llm.lastSystem, "Site context (kungal)") {
+		t.Fatalf("prompt context must follow the subject site, got %q", llm.lastSystem)
+	}
+	if rows := usageRows(t, "trust", model.RouteModerateText); len(rows) != 2 {
+		t.Fatalf("metering must stay on the binding site, got %d rows under trust", len(rows))
+	}
+
+	res, err = s.Moderate(context.Background(), ModerateParams{
+		Site: "trust", SubjectSite: "letmoe", Text: "hi", SubjectKind: "forum_topic",
+	})
+	if err != nil {
+		t.Fatalf("Moderate (letmoe subject): %v", err)
+	}
+	if res.Flagged || res.Channel != omniModel {
+		t.Fatalf("unlisted subject site must stay omni-terminal, got flagged=%v channel=%q", res.Flagged, res.Channel)
+	}
+}
+
 func TestForcedEscalationIgnoresUnlistedPair(t *testing.T) {
 	cleanTables(t)
 	omni := &fakeOmni{configured: true, model: omniModel, result: upstream.OmniResult{

--- a/apps/api/internal/platform/ai/service/moderation.go
+++ b/apps/api/internal/platform/ai/service/moderation.go
@@ -86,9 +86,22 @@ func (s *ModerationService) forceEscalated(site, kind string) bool {
 
 type ModerateParams struct {
 	Site        string
+	SubjectSite string
 	Text        string
 	AuthorID    *int64
 	SubjectKind string
+}
+
+// contentSite is what force-escalation pairs and the site prompt key off.
+// Site alone is wrong for that: it is the credential-binding tenant, and the
+// trust worker proxies every product site through one client, so Site is
+// always "trust" there — the first ship keyed off it and never fired in prod.
+// Site stays the metering/budget identity; SubjectSite says whose content it is.
+func (p ModerateParams) contentSite() string {
+	if p.SubjectSite != "" {
+		return p.SubjectSite
+	}
+	return p.Site
 }
 
 type ModerateResult struct {
@@ -175,7 +188,7 @@ func (s *ModerationService) Moderate(ctx context.Context, p ModerateParams) (Mod
 
 	rel := relevantScore(ores.CategoryScores)
 
-	if s.llm.Configured() && s.forceEscalated(p.Site, p.SubjectKind) {
+	if s.llm.Configured() && s.forceEscalated(p.contentSite(), p.SubjectKind) {
 		return s.moderateViaLLM(ctx, p, routeName, spec)
 	}
 
@@ -211,7 +224,7 @@ func (s *ModerationService) moderateViaLLM(ctx context.Context, p ModerateParams
 		return failOpen(routeName, "", spec), nil
 	}
 
-	res, err := s.llm.ChatJSON(ctx, moderateSystemPrompt(p.Site), p.Text, moderateMaxTokens)
+	res, err := s.llm.ChatJSON(ctx, moderateSystemPrompt(p.contentSite()), p.Text, moderateMaxTokens)
 	if err != nil && upstream.IsRateLimited(err) {
 		// The Cloudflare inference bucket is per-minute and shared with every
 		// other caller on the account, so a 429 here is contention, not a
@@ -228,7 +241,7 @@ func (s *ModerationService) moderateViaLLM(ctx context.Context, p ModerateParams
 		case <-ctx.Done():
 			timer.Stop()
 		case <-timer.C:
-			res, err = s.llm.ChatJSON(ctx, moderateSystemPrompt(p.Site), p.Text, moderateMaxTokens)
+			res, err = s.llm.ChatJSON(ctx, moderateSystemPrompt(p.contentSite()), p.Text, moderateMaxTokens)
 		}
 	}
 	if err != nil {

--- a/apps/api/internal/platform/trust/service/scan_gateway.go
+++ b/apps/api/internal/platform/trust/service/scan_gateway.go
@@ -14,7 +14,7 @@ import (
 
 type ScanGateway interface {
 	Configured() bool
-	Moderate(ctx context.Context, text, subjectKind string, authorID *int64) (GatewayVerdict, error)
+	Moderate(ctx context.Context, site, text, subjectKind string, authorID *int64) (GatewayVerdict, error)
 }
 
 type GatewayVerdict struct {
@@ -49,6 +49,7 @@ func (c *AIGatewayClient) Configured() bool {
 
 type moderateReq struct {
 	Text        string `json:"text"`
+	SubjectSite string `json:"subject_site,omitempty"`
 	SubjectKind string `json:"subject_kind,omitempty"`
 	AuthorID    *int64 `json:"author_id,omitempty"`
 }
@@ -66,8 +67,8 @@ type moderateEnvelope struct {
 	} `json:"data"`
 }
 
-func (c *AIGatewayClient) Moderate(ctx context.Context, text, subjectKind string, authorID *int64) (GatewayVerdict, error) {
-	raw, err := json.Marshal(moderateReq{Text: text, SubjectKind: subjectKind, AuthorID: authorID})
+func (c *AIGatewayClient) Moderate(ctx context.Context, site, text, subjectKind string, authorID *int64) (GatewayVerdict, error) {
+	raw, err := json.Marshal(moderateReq{Text: text, SubjectSite: site, SubjectKind: subjectKind, AuthorID: authorID})
 	if err != nil {
 		return GatewayVerdict{}, err
 	}

--- a/apps/api/internal/platform/trust/service/scan_gateway_test.go
+++ b/apps/api/internal/platform/trust/service/scan_gateway_test.go
@@ -22,12 +22,15 @@ func TestGatewayModerateSendsSubjectKind(t *testing.T) {
 
 	c := NewAIGatewayClient(srv.URL, "id", "secret")
 
-	v, err := c.Moderate(context.Background(), "hello", "forum_topic", nil)
+	v, err := c.Moderate(context.Background(), "kungal", "hello", "forum_topic", nil)
 	if err != nil {
 		t.Fatalf("Moderate(forum_topic): %v", err)
 	}
 	if !strings.Contains(string(lastBody), `"subject_kind":"forum_topic"`) {
 		t.Fatalf("body missing subject_kind forum_topic: %s", lastBody)
+	}
+	if !strings.Contains(string(lastBody), `"subject_site":"kungal"`) {
+		t.Fatalf("body missing subject_site kungal: %s", lastBody)
 	}
 	if !v.Flagged || v.Degraded {
 		t.Fatalf("want flagged not-degraded, got flagged=%v degraded=%v", v.Flagged, v.Degraded)
@@ -42,7 +45,7 @@ func TestGatewayModerateSendsSubjectKind(t *testing.T) {
 		t.Fatalf("score = %v, want ~0.9", v.Score)
 	}
 
-	v, err = c.Moderate(context.Background(), "hello", "", nil)
+	v, err = c.Moderate(context.Background(), "", "hello", "", nil)
 	if err != nil {
 		t.Fatalf("Moderate(empty kind): %v", err)
 	}
@@ -52,6 +55,9 @@ func TestGatewayModerateSendsSubjectKind(t *testing.T) {
 	}
 	if _, ok := body["subject_kind"]; ok {
 		t.Fatalf("empty subjectKind must omit the key, body=%s", lastBody)
+	}
+	if _, ok := body["subject_site"]; ok {
+		t.Fatalf("empty site must omit subject_site, body=%s", lastBody)
 	}
 	if !v.Flagged || v.Degraded || v.Channel != "x" {
 		t.Fatalf("empty-kind verdict wrong: flagged=%v degraded=%v channel=%q", v.Flagged, v.Degraded, v.Channel)

--- a/apps/api/internal/platform/trust/service/scan_retry_test.go
+++ b/apps/api/internal/platform/trust/service/scan_retry_test.go
@@ -20,7 +20,7 @@ type scriptStep struct {
 
 func (g *scriptedGateway) Configured() bool { return true }
 
-func (g *scriptedGateway) Moderate(_ context.Context, _, _ string, _ *int64) (GatewayVerdict, error) {
+func (g *scriptedGateway) Moderate(_ context.Context, _, _, _ string, _ *int64) (GatewayVerdict, error) {
 	s := g.steps[len(g.steps)-1]
 	if g.calls < len(g.steps) {
 		s = g.steps[g.calls]

--- a/apps/api/internal/platform/trust/service/scan_worker.go
+++ b/apps/api/internal/platform/trust/service/scan_worker.go
@@ -135,7 +135,7 @@ func (w *ScanWorker) scoreOne(ctx context.Context, tx *gorm.DB, r *model.TrustSc
 	if !w.gateway.Configured() {
 		return w.markDegraded(tx, r, tier0, pol, model.ScanDegradedGatewayUnconfigured)
 	}
-	verdict, err := w.gateway.Moderate(ctx, r.ContentText, r.SubjectKind, r.AuthorID)
+	verdict, err := w.gateway.Moderate(ctx, r.Site, r.ContentText, r.SubjectKind, r.AuthorID)
 	if err != nil {
 		slog.Warn("trust scan gateway call failed; draining to degraded",
 			"scan_id", r.ID, "attempt", r.ScanAttempts+1, "err", err)

--- a/apps/api/internal/platform/trust/service/scan_worker_test.go
+++ b/apps/api/internal/platform/trust/service/scan_worker_test.go
@@ -16,11 +16,13 @@ type fakeGateway struct {
 	err        error
 	calls      atomic.Int32
 	lastKind   string
+	lastSite   string
 }
 
 func (g *fakeGateway) Configured() bool { return g.configured }
-func (g *fakeGateway) Moderate(_ context.Context, _, kind string, _ *int64) (GatewayVerdict, error) {
+func (g *fakeGateway) Moderate(_ context.Context, site, _, kind string, _ *int64) (GatewayVerdict, error) {
 	g.calls.Add(1)
+	g.lastSite = site
 	g.lastKind = kind
 	return g.verdict, g.err
 }
@@ -75,6 +77,9 @@ func TestScanWorkerScoredAndShadow(t *testing.T) {
 	}
 	if g.calls.Load() != 1 {
 		t.Fatalf("gateway calls = %d, want 1", g.calls.Load())
+	}
+	if g.lastSite != tSite {
+		t.Fatalf("gateway site = %q, want %q", g.lastSite, tSite)
 	}
 	if g.lastKind != tKind {
 		t.Fatalf("gateway subjectKind = %q, want %q", g.lastKind, tKind)
@@ -205,7 +210,7 @@ type blockingGateway struct {
 }
 
 func (g *blockingGateway) Configured() bool { return true }
-func (g *blockingGateway) Moderate(_ context.Context, _, _ string, _ *int64) (GatewayVerdict, error) {
+func (g *blockingGateway) Moderate(_ context.Context, _, _, _ string, _ *int64) (GatewayVerdict, error) {
 	g.calls.Add(1)
 	g.entered <- struct{}{}
 	<-g.release

--- a/docs/ai/openapi.yaml
+++ b/docs/ai/openapi.yaml
@@ -55,7 +55,10 @@ components:
           format: int64
           type: integer
         subject_kind:
-          description: optional product-side content kind (e.g. forum_topic); with the tenant site it selects forced Tier2 escalation for configured (site,kind) pairs
+          description: optional product-side content kind (e.g. forum_topic); with the subject site it selects forced Tier2 escalation for configured (site,kind) pairs
+          type: string
+        subject_site:
+          description: optional site the content belongs to (e.g. kungal) when the caller proxies for other sites; falls back to the client-binding site
           type: string
         text:
           description: the UGC text to scan


### PR DESCRIPTION
## What

Post-deploy verification of #110 found the whole layer inert in prod: the trust worker proxies every product site through one OAuth client bound to `catalog_site=trust`, so the gateway-side `Site` is always `trust` (all 578 post-deploy calls metered as `site=trust`). The `(site,kind)` pair match AND the kungal prompt context both keyed off it and could never fire.

Fix: the scan row's site rides the wire as optional `subject_site`; force-escalation matching and the site prompt follow it (falling back to the binding site), while metering/budget stay on the binding tenant. Backward compatible (`omitempty` both directions).

## Deploy

Zero migrations, **no env change** — the deployed `KUN_AI_FORCE_ESCALATE=kungal:forum_topic,kungal:forum_reply,kungal:forum_comment` becomes reachable as-is. Redeploy ai + trust (ordering safe either way).

## Verification

Full ai+trust suites green on ephemeral DB (`-count=1 -p 1`, `REQUIRE_DB_TESTS=1`); new prod-shape test pins binding=trust + subject_site=kungal → LLM final with kungal context and metering still under trust; wire test asserts `subject_site` presence/omission; worker test asserts the row's site reaches the gateway.

https://claude.ai/code/session_01GhHEqvDcwkbdct4UGGk726