### PR TITLE
perf(catalog): cache listing totals in-process for 60s

### DIFF
--- a/apps/api/internal/platform/apiv2/handler/live_setup_test.go
+++ b/apps/api/internal/platform/apiv2/handler/live_setup_test.go
@@ -911,6 +911,11 @@ func seedLiveNews(db *gorm.DB) (int64, error) {
 
 func liveDo(t *testing.T, env *liveEnv, method, path, token, body string) (int, string, []byte) {
 	t.Helper()
+	// liveOnce shares one PublicService across the package, so a totals-cache
+	// entry minted by an earlier test outlived a fixture mutation and broke
+	// TestLiveWorksIncludeTotalFollowsNSFW in CI. The live suite asserts data,
+	// not caching; the service tests own the TTL semantics.
+	env.cat.Public.FlushTotals()
 	var rdr io.Reader
 	if body != "" {
 		rdr = strings.NewReader(body)
@@ -945,6 +950,7 @@ func liveETag(t *testing.T, env *liveEnv, path, token string) string {
 
 func liveDoHeader(t *testing.T, env *liveEnv, method, path, token, body string, extra map[string]string) (int, string, []byte) {
 	t.Helper()
+	env.cat.Public.FlushTotals()
 	var rdr io.Reader
 	if body != "" {
 		rdr = strings.NewReader(body)

--- a/apps/api/internal/platform/catalog/service/public_service.go
+++ b/apps/api/internal/platform/catalog/service/public_service.go
@@ -33,6 +33,11 @@ type PublicService struct {
 	worksSearch *catsearch.Indexer
 }
 
+// FlushTotals empties the include_total count cache so the next read recounts.
+func (s *PublicService) FlushTotals() {
+	s.totals.flush()
+}
+
 func NewPublicService(db *gorm.DB, read *ReadService, resolve *ResolveService, cdnBase string) *PublicService {
 	s := &PublicService{db: db, read: read, resolve: resolve,
 		mediums: map[int16]string{}, sources: map[int16]string{}, cdnBase: cdnBase,

--- a/apps/api/internal/platform/catalog/service/public_service.go
+++ b/apps/api/internal/platform/catalog/service/public_service.go
@@ -29,12 +29,14 @@ type PublicService struct {
 	cdnBase     string
 	imageMeta   ImageMetaFunc
 	metaCache   *imageMetaCache
+	totals      *totalsCache
 	worksSearch *catsearch.Indexer
 }
 
 func NewPublicService(db *gorm.DB, read *ReadService, resolve *ResolveService, cdnBase string) *PublicService {
 	s := &PublicService{db: db, read: read, resolve: resolve,
-		mediums: map[int16]string{}, sources: map[int16]string{}, cdnBase: cdnBase}
+		mediums: map[int16]string{}, sources: map[int16]string{}, cdnBase: cdnBase,
+		totals: newTotalsCache()}
 	var rows []struct {
 		ID  int16
 		Key string

--- a/apps/api/internal/platform/catalog/service/public_supply_test.go
+++ b/apps/api/internal/platform/catalog/service/public_supply_test.go
@@ -472,7 +472,7 @@ func TestTaxonomyTotalsAndTagDetailWorkCount(t *testing.T) {
 	if err := testDB.Exec(`UPDATE catalog_label SET deleted_at = now() WHERE id = ?`, l1).Error; err != nil {
 		t.Fatalf("soft-delete label: %v", err)
 	}
-	labels, err = svc.LabelsList(ctx, LabelsListFilter{}, "", 50)
+	labels, err = newPublicSvc().LabelsList(ctx, LabelsListFilter{}, "", 50)
 	if err != nil {
 		t.Fatalf("LabelsList after merge: %v", err)
 	}

--- a/apps/api/internal/platform/catalog/service/public_taxonomy.go
+++ b/apps/api/internal/platform/catalog/service/public_taxonomy.go
@@ -414,10 +414,23 @@ func (s *PublicService) tagSexualFor(ctx context.Context, ids []int64) (map[int6
 }
 
 func (s *PublicService) taxonomyTotal(ctx context.Context, table string, where []string, args []any) (int64, error) {
+	var key string
+	cacheable := false
+	if raw, err := json.Marshal(args); err == nil {
+		key = table + "\x00" + strings.Join(where, "\x00") + "\x00" + string(raw)
+		cacheable = true
+		if v, ok := s.totals.get(key); ok {
+			return v, nil
+		}
+	}
+
 	var total int64
 	q := `SELECT count(*) FROM ` + table + ` ` + whereClause(where)
 	if err := s.db.WithContext(ctx).Raw(q, args...).Scan(&total).Error; err != nil {
 		return 0, err
+	}
+	if cacheable {
+		s.totals.put(key, total)
 	}
 	return total, nil
 }

--- a/apps/api/internal/platform/catalog/service/public_works_list_test.go
+++ b/apps/api/internal/platform/catalog/service/public_works_list_test.go
@@ -294,3 +294,34 @@ func TestChangesFeedSeesFacetOnlyWrites(t *testing.T) {
 			resumed.Items, host.ID, bystander.ID)
 	}
 }
+
+func TestWorksListTotalStaleWithinTTL(t *testing.T) {
+	cleanTables(t)
+	svc := newPublicSvc()
+	ctx := t.Context()
+
+	createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "CachedTotalA")
+	createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "CachedTotalB")
+
+	filter := WorksListFilter{Sort: "id", IncludeTotal: true}
+	first, err := svc.WorksList(ctx, filter, "", 50)
+	if err != nil {
+		t.Fatalf("WorksList: %v", err)
+	}
+	if first.Total != 2 {
+		t.Fatalf("total = %d, want 2", first.Total)
+	}
+
+	createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "CachedTotalC")
+
+	second, err := svc.WorksList(ctx, filter, "", 50)
+	if err != nil {
+		t.Fatalf("WorksList after insert: %v", err)
+	}
+	if second.Total != 2 {
+		t.Fatalf("cached total = %d, want 2 (insert must not be visible within TTL)", second.Total)
+	}
+	if len(second.Items) != 3 {
+		t.Fatalf("items = %d, want 3 (the page itself is not cached)", len(second.Items))
+	}
+}

--- a/apps/api/internal/platform/catalog/service/total_cache.go
+++ b/apps/api/internal/platform/catalog/service/total_cache.go
@@ -51,3 +51,9 @@ func (c *totalsCache) put(key string, v int64) {
 	}
 	c.entries[key] = totalsEntry{val: v, exp: c.now().Add(totalsTTL)}
 }
+
+func (c *totalsCache) flush() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = make(map[string]totalsEntry)
+}

--- a/apps/api/internal/platform/catalog/service/total_cache.go
+++ b/apps/api/internal/platform/catalog/service/total_cache.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	totalsTTL        = 60 * time.Second
+	totalsMaxEntries = 8192
+)
+
+// Forum S2S traffic at ~40 rps re-ran identical count(*) per page request and saturated prod postgres on 2026-09-01.
+type totalsCache struct {
+	mu      sync.Mutex
+	entries map[string]totalsEntry
+	now     func() time.Time
+}
+
+type totalsEntry struct {
+	val int64
+	exp time.Time
+}
+
+func newTotalsCache() *totalsCache {
+	return &totalsCache{
+		entries: make(map[string]totalsEntry),
+		now:     time.Now,
+	}
+}
+
+func (c *totalsCache) get(key string) (int64, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return 0, false
+	}
+	if !e.exp.After(c.now()) {
+		delete(c.entries, key)
+		return 0, false
+	}
+	return e.val, true
+}
+
+func (c *totalsCache) put(key string, v int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.entries[key]; !exists && len(c.entries) >= totalsMaxEntries {
+		c.entries = make(map[string]totalsEntry)
+	}
+	c.entries[key] = totalsEntry{val: v, exp: c.now().Add(totalsTTL)}
+}

--- a/apps/api/internal/platform/catalog/service/total_cache_test.go
+++ b/apps/api/internal/platform/catalog/service/total_cache_test.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestTotalsCacheMissOnEmpty(t *testing.T) {
+	c := newTotalsCache()
+	if v, ok := c.get("missing"); ok || v != 0 {
+		t.Fatalf("empty get = %d, %v, want miss", v, ok)
+	}
+}
+
+func TestTotalsCachePutThenGet(t *testing.T) {
+	c := newTotalsCache()
+	c.put("k", 7)
+	v, ok := c.get("k")
+	if !ok || v != 7 {
+		t.Fatalf("get = %d, %v, want 7, true", v, ok)
+	}
+}
+
+func TestTotalsCacheExpiry(t *testing.T) {
+	c := newTotalsCache()
+	t0 := time.Unix(1_700_000_000, 0)
+	now := t0
+	c.now = func() time.Time { return now }
+
+	c.put("exp", 3)
+	if v, ok := c.get("exp"); !ok || v != 3 {
+		t.Fatalf("before expiry get = %d, %v, want 3, true", v, ok)
+	}
+
+	now = t0.Add(totalsTTL + time.Nanosecond)
+	if v, ok := c.get("exp"); ok || v != 0 {
+		t.Fatalf("after expiry get = %d, %v, want miss", v, ok)
+	}
+	if _, exists := c.entries["exp"]; exists {
+		t.Fatal("expired entry was not deleted")
+	}
+}
+
+func TestTotalsCacheCapReset(t *testing.T) {
+	c := newTotalsCache()
+	for i := 0; i < totalsMaxEntries; i++ {
+		c.put(strconv.Itoa(i), int64(i))
+	}
+	if len(c.entries) != totalsMaxEntries {
+		t.Fatalf("fill len = %d, want %d", len(c.entries), totalsMaxEntries)
+	}
+
+	c.put("overflow", 99)
+	if len(c.entries) != 1 {
+		t.Fatalf("after overflow len = %d, want 1 (whole-map reset then insert)", len(c.entries))
+	}
+	if v, ok := c.get("overflow"); !ok || v != 99 {
+		t.Fatalf("overflow get = %d, %v, want 99, true", v, ok)
+	}
+	if _, ok := c.get("0"); ok {
+		t.Fatal("pre-reset key survived whole-map reset")
+	}
+}

--- a/docs/catalog/v2-implementation-notes.md
+++ b/docs/catalog/v2-implementation-notes.md
@@ -312,6 +312,8 @@ The first two are the same defect shape in a different env var. They are deliber
 
 102. **`GET /v2/catalog/schemas/{object}` published only the detail vocabulary** (2026-08-28). The schema face is where a machine consumer discovers `include=`, and it answered `collect.ObjectSpec(object)` for both halves — which for `work` is now the detail face's eighteen tokens. Left alone, deviation 100 would have made this face hand a generator the tokens the collection refuses. `list_include` and `list_full_set` are added beside `include`/`full_set`; for every family but `work` the two pairs are equal, because those lists and details share a Spec, and `TestLiveWorkSchemaPublishesBothVocabularies` asserts both the equality and the one inequality.
 
+103. **Listing `total` values are served through a 60-second in-process cache** (2026-09-01). Works list, labels/tags/engines/series, and the entity list faces all go through `taxonomyTotal`. That helper now caches by the full filter signature (table + WHERE clauses + bound args) for 60s, so `total` may lag writes by up to 60 seconds. Cursor predicates stay outside the key: the pre-existing "total counted before the cursor" property is preserved and strengthened — the total is now also stable across pages within the TTL.
+
 ## Stage 6 write
 
 | Route | Bind |


### PR DESCRIPTION
## Why

Prod postgres CPU saturation (2026-09-01): the forum S2S caller issues 2.6–5.1M catalog v2 requests/day; the works listing lane alone (~1.6M/day, ~40 rps peak) re-runs an identical `SELECT count(*)` with heavy EXISTS predicates on every page request. Totals for the same filter combination are identical across pages — recomputing them per request is pure waste.

## What

- `taxonomyTotal` (the single choke point behind works/labels/tags/engines/series/entity-list totals) now consults a per-process TTL cache (60s, 8192-entry cap with whole-map reset) keyed by `table + where + json(args)`. Marshal failure bypasses the cache.
- Cursor predicates stay outside the key, preserving the count-before-cursor property and making totals stable across pages within the TTL.
- Deviation 103 recorded in docs/catalog/v2-implementation-notes.md.
- New unit tests for the cache (hit/miss/expiry/cap) + a DB test pinning staleness-within-TTL; the existing supply test now proves post-delete count correctness on a fresh service instance.

Zero migrations. No spec change.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD