### PR TITLE
feat(work-dedup): widen the detector floor, corpus, and pair sources

### DIFF
--- a/apps/api/cmd/work-dedup/census.go
+++ b/apps/api/cmd/work-dedup/census.go
@@ -14,6 +14,7 @@ type pairRow struct {
 	B              int64      `gorm:"column:b"`
 	SharedNorm     string     `gorm:"column:shared_norm"`
 	SharedNorms    int        `gorm:"column:shared_norms"`
+	SharedOfficial int        `gorm:"column:shared_official"`
 	LaneA          string     `gorm:"column:lane_a"`
 	LaneB          string     `gorm:"column:lane_b"`
 	AnchorsA       int        `gorm:"column:anchors_a"`
@@ -25,13 +26,16 @@ type pairRow struct {
 	AnchorConflict bool       `gorm:"column:anchor_conflict"`
 	RelConflict    bool       `gorm:"column:release_conflict"`
 	RefOverlap     bool       `gorm:"column:ref_overlap"`
+	RefOverlapCI   bool       `gorm:"column:ref_overlap_ci"`
 	DateA          *time.Time `gorm:"column:date_a"`
 	DateB          *time.Time `gorm:"column:date_b"`
 	LabelOverlap   bool       `gorm:"column:label_overlap"`
 }
 
 // pairQuerySQL is the standing duplicate detector: every pair of live works
-// sharing a folded official-title/display_name norm, scored with the
+// sharing a folded title/display_name norm or a case-insensitively equal
+// work-level external ref (identity kinds pair outright; related-page refs
+// pair only when no exact anchors prove the works distinct), scored with the
 // corroborating facts the verdict needs. Work-level identity anchors drive
 // lanes and conflicts; dlsite identity lives on releases (entity_type 6), so
 // the dlsite lane and the release-level conflict/overlap read through
@@ -43,18 +47,59 @@ WITH lw AS (
   SELECT id, site, display_name FROM catalog_work WHERE deleted_at IS NULL
 ),
 norms AS (
-  SELECT DISTINCT work_id, n FROM (` + service.WorkDupeCorpusSQL() + `) c
+  SELECT work_id, n, bool_or(official) AS official FROM (` + service.WorkDupeCorpusSQL() + `) c GROUP BY work_id, n
 ),
 pairs AS (
-  SELECT a.work_id AS a, b.work_id AS b, min(a.n) AS shared_norm, count(*) AS shared_norms
+  SELECT a.work_id AS a, b.work_id AS b, min(a.n) AS shared_norm, count(*) AS shared_norms,
+    count(*) FILTER (WHERE a.official AND b.official) AS shared_official
   FROM norms a JOIN norms b ON a.n = b.n AND a.work_id < b.work_id
-  WHERE length(a.n) >= 4
+  WHERE ` + service.WorkDupeNormEligibleSQL("a.n") + `
   GROUP BY a.work_id, b.work_id
 ),
 wanchor AS (
   SELECT entity_id AS work_id, source_id, external_id
   FROM catalog_external_ref
   WHERE entity_type = 5 AND link_kind = 0 AND dead_at IS NULL
+),
+refpairs AS (
+  SELECT x.entity_id AS a, y.entity_id AS b
+  FROM catalog_external_ref x
+  JOIN catalog_external_ref y
+    ON y.source_id = x.source_id
+   AND lower(y.external_id) = lower(x.external_id)
+   AND x.entity_id < y.entity_id
+  JOIN lw ON lw.id = x.entity_id
+  JOIN lw lw_b ON lw_b.id = y.entity_id
+  WHERE x.entity_type = 5 AND y.entity_type = 5
+    AND x.dead_at IS NULL AND y.dead_at IS NULL
+    AND x.link_kind IN (0, 1) AND y.link_kind IN (0, 1)
+  GROUP BY x.entity_id, y.entity_id
+  UNION
+  -- any-kind pairing generated ~78k brand-hub pairs of which 76,632 had conflicting exact
+  -- anchors; the no-conflict residue sampled 15/15 as true duplicates.
+  SELECT x.entity_id AS a, y.entity_id AS b
+  FROM catalog_external_ref x
+  JOIN catalog_external_ref y
+    ON y.source_id = x.source_id
+   AND lower(y.external_id) = lower(x.external_id)
+   AND x.entity_id < y.entity_id
+  JOIN lw ON lw.id = x.entity_id
+  JOIN lw lw_b ON lw_b.id = y.entity_id
+  WHERE x.entity_type = 5 AND y.entity_type = 5
+    AND x.dead_at IS NULL AND y.dead_at IS NULL
+    AND x.link_kind = 2 AND y.link_kind = 2
+    AND NOT EXISTS (
+      SELECT 1 FROM wanchor p JOIN wanchor q ON q.source_id = p.source_id AND q.external_id <> p.external_id
+      WHERE p.work_id = x.entity_id AND q.work_id = y.entity_id)
+  GROUP BY x.entity_id, y.entity_id
+),
+universe AS (
+  SELECT coalesce(p.a, r.a) AS a, coalesce(p.b, r.b) AS b,
+    coalesce(p.shared_norm, '') AS shared_norm,
+    coalesce(p.shared_norms, 0) AS shared_norms,
+    coalesce(p.shared_official, 0) AS shared_official
+  FROM pairs p
+  FULL OUTER JOIN refpairs r ON r.a = p.a AND r.b = p.b
 ),
 ranchor AS (
   SELECT rel.work_id, r.source_id, r.external_id
@@ -86,7 +131,7 @@ bgmdate AS (
   WHERE r.source_id = 3 AND s.date ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
   GROUP BY r.work_id
 )
-SELECT p.a, p.b, p.shared_norm, p.shared_norms,
+SELECT p.a, p.b, p.shared_norm, p.shared_norms, p.shared_official,
   la.lane AS lane_a, lb.lane AS lane_b,
   la.anchors AS anchors_a, lb.anchors AS anchors_b,
   wa.site AS site_a, wb.site AS site_b,
@@ -100,14 +145,21 @@ SELECT p.a, p.b, p.shared_norm, p.shared_norms,
   (EXISTS (SELECT 1 FROM catalog_external_ref x
            JOIN catalog_external_ref y ON y.source_id = x.source_id AND y.external_id = x.external_id
            WHERE x.entity_type = 5 AND x.entity_id = p.a AND x.dead_at IS NULL
-             AND y.entity_type = 5 AND y.entity_id = p.b AND y.dead_at IS NULL)
+             AND y.entity_type = 5 AND y.entity_id = p.b AND y.dead_at IS NULL
+             AND x.link_kind IN (0, 1) AND y.link_kind IN (0, 1))
    OR EXISTS (SELECT 1 FROM ranchor x JOIN ranchor y ON y.source_id = x.source_id AND y.external_id = x.external_id
               WHERE x.work_id = p.a AND y.work_id = p.b)) AS ref_overlap,
+  (EXISTS (SELECT 1 FROM catalog_external_ref x
+           JOIN catalog_external_ref y ON y.source_id = x.source_id AND lower(y.external_id) = lower(x.external_id)
+           WHERE x.entity_type = 5 AND x.entity_id = p.a AND x.dead_at IS NULL
+             AND y.entity_type = 5 AND y.entity_id = p.b AND y.dead_at IS NULL)
+   OR EXISTS (SELECT 1 FROM ranchor x JOIN ranchor y ON y.source_id = x.source_id AND lower(y.external_id) = lower(x.external_id)
+              WHERE x.work_id = p.a AND y.work_id = p.b)) AS ref_overlap_ci,
   coalesce(da.d, ba.d) AS date_a,
   coalesce(dbb.d, bb.d) AS date_b,
   EXISTS (SELECT 1 FROM catalog_work_label x JOIN catalog_work_label y ON y.label_id = x.label_id
           WHERE x.work_id = p.a AND y.work_id = p.b) AS label_overlap
-FROM pairs p
+FROM universe p
 JOIN lane la ON la.id = p.a
 JOIN lane lb ON lb.id = p.b
 JOIN lw wa ON wa.id = p.a

--- a/apps/api/cmd/work-dedup/pipeline_test.go
+++ b/apps/api/cmd/work-dedup/pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"api/internal/platform/catalog/migrate"
 	"api/internal/platform/catalog/model"
@@ -89,16 +90,27 @@ func mkWork(t *testing.T, medium int16, name string, site *string) int64 {
 
 func mkTitle(t *testing.T, workID int64, title string) {
 	t.Helper()
+	mkTitleKind(t, workID, title, model.WorkTitleKindOfficial)
+}
+
+func mkTitleKind(t *testing.T, workID int64, title string, kind int16) {
+	t.Helper()
 	require.NoError(t, testDB.Create(&model.CatalogWorkTitle{
-		WorkID: workID, Lang: "ja", Title: title, Kind: model.WorkTitleKindOfficial,
+		WorkID: workID, Lang: "ja", Title: title, Kind: kind,
 	}).Error)
 }
 
 func mkAnchor(t *testing.T, workID int64, sourceID int16, externalID string) {
 	t.Helper()
+	mkRef(t, workID, sourceID, externalID, model.LinkKindExact, nil)
+}
+
+func mkRef(t *testing.T, workID int64, sourceID int16, externalID string, linkKind int16, deadAt *time.Time) {
+	t.Helper()
 	require.NoError(t, testDB.Create(&model.CatalogExternalRef{
 		EntityType: model.EntityTypeWork, EntityID: workID, SourceID: sourceID,
-		ExternalID: externalID, LinkKind: model.LinkKindExact, MatchedBy: "test:work-dedup",
+		ExternalID: externalID, LinkKind: linkKind, MatchedBy: "test:work-dedup",
+		DeadAt: deadAt,
 	}).Error)
 }
 
@@ -308,4 +320,212 @@ func newMerge(t *testing.T) *service.MergeService {
 	resolve := service.NewResolveService(repository.NewRedirectRepository(testDB))
 	return service.NewMergeService(testDB, resolve,
 		repository.NewProposalRepository(testDB), repository.NewRevisionRepository(testDB))
+}
+
+func findPair(t *testing.T, c *census, a, b int64) (pairRow, bucket) {
+	t.Helper()
+	lo, hi := min(a, b), max(a, b)
+	for i, r := range c.rows {
+		if r.A == lo && r.B == hi {
+			return r, c.verdicts[i]
+		}
+	}
+	t.Fatalf("no pair (%d,%d) in %d rows: %+v", lo, hi, len(c.rows), c.rows)
+	return pairRow{}, ""
+}
+
+func hasPair(c *census, a, b int64) bool {
+	lo, hi := min(a, b), max(a, b)
+	for _, r := range c.rows {
+		if r.A == lo && r.B == hi {
+			return true
+		}
+	}
+	return false
+}
+
+func candidateOf(t *testing.T, a, b int64) model.CatalogMatchCandidate {
+	t.Helper()
+	var cand model.CatalogMatchCandidate
+	require.NoError(t, testDB.Where("entity_type = ? AND a_id = ? AND b_id = ?",
+		model.EntityTypeWork, min(a, b), max(a, b)).First(&cand).Error)
+	return cand
+}
+
+func TestWorkDedupCensusWidening(t *testing.T) {
+	requireDB(t)
+	ctx := context.Background()
+	const officialSite int16 = 9
+
+	t.Run("a_case_insensitive_ref", func(t *testing.T) {
+		cleanPipeline(t)
+		medium := galgameMedium(t)
+		a := mkWork(t, medium, "ケースエイ参照作品テスト", nil)
+		b := mkWork(t, medium, "ケースビー参照作品テスト", nil)
+		mkRef(t, a, officialSite, "www.example.com/home/x", model.LinkKindExact, nil)
+		mkRef(t, b, officialSite, "www.example.com/Home/x", model.LinkKindProbable, nil)
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		row, verdict := findPair(t, c, a, b)
+		assert.True(t, row.RefOverlapCI)
+		assert.False(t, row.RefOverlap)
+		assert.Equal(t, 0, row.SharedNorms)
+		assert.Equal(t, bucketRefCI, verdict)
+
+		var out bytes.Buffer
+		require.NoError(t, runSeed(ctx, testDB, &out, 1, true))
+		got := candidateOf(t, a, b)
+		assert.Equal(t, model.CandidateStatusNeedsManual, got.Status)
+		assert.Equal(t, model.CandidateReasonSharedExternalID, got.Reason)
+	})
+
+	t.Run("b_exact_ref_outranks_year_clash", func(t *testing.T) {
+		cleanPipeline(t)
+		medium := galgameMedium(t)
+		a := mkWork(t, medium, "年差エイ参照作品テスト", nil)
+		b := mkWork(t, medium, "年差ビー参照作品テスト", nil)
+		mkRef(t, a, officialSite, "www.example.com/ident/b", model.LinkKindProbable, nil)
+		mkRef(t, b, officialSite, "www.example.com/ident/b", model.LinkKindExact, nil)
+		mkRelease(t, a, 2014, 5, 1)
+		mkRelease(t, b, 2016, 5, 1)
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		row, verdict := findPair(t, c, a, b)
+		assert.True(t, row.RefOverlap)
+		assert.Equal(t, bucketAuto, verdict)
+	})
+
+	t.Run("c_han_three_rune_floor", func(t *testing.T) {
+		cleanPipeline(t)
+		medium := galgameMedium(t)
+		a := mkWork(t, medium, "红楼梦", nil)
+		b := mkWork(t, medium, "红楼梦", nil)
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		assert.True(t, hasPair(c, a, b), "3-rune all-Han display_name must pair")
+	})
+
+	t.Run("d_ascii_three_rune_no_pair", func(t *testing.T) {
+		cleanPipeline(t)
+		medium := galgameMedium(t)
+		a := mkWork(t, medium, "abc", nil)
+		b := mkWork(t, medium, "abc", nil)
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		assert.False(t, hasPair(c, a, b), "3-rune ASCII display_name must not pair")
+	})
+
+	t.Run("e_alias_only_and_abbreviation_excluded", func(t *testing.T) {
+		cleanPipeline(t)
+		medium := galgameMedium(t)
+		a := mkWork(t, medium, "エイ公式タイトルホルダー作品", nil)
+		b := mkWork(t, medium, "ビー別名タイトルホルダー作品", nil)
+		mkTitleKind(t, a, "共有別名タイトル検証", model.WorkTitleKindOfficial)
+		mkTitleKind(t, b, "共有別名タイトル検証", model.WorkTitleKindAlias)
+		lab := &model.CatalogLabel{DisplayName: "共有ブランド検証", Lang: "ja", Kind: model.LabelKindGameBrand, FieldProvenance: []byte(`{}`)}
+		require.NoError(t, testDB.Create(lab).Error)
+		require.NoError(t, testDB.Create(&model.CatalogWorkLabel{
+			WorkID: a, LabelID: lab.ID, Kind: model.WorkLabelKindBrand,
+		}).Error)
+		require.NoError(t, testDB.Create(&model.CatalogWorkLabel{
+			WorkID: b, LabelID: lab.ID, Kind: model.WorkLabelKindBrand,
+		}).Error)
+
+		cAbbrev := mkWork(t, medium, "シー短縮名ホルダー作品", nil)
+		dAbbrev := mkWork(t, medium, "ディー短縮名ホルダー作品", nil)
+		mkTitleKind(t, cAbbrev, "短縮名検証用", model.WorkTitleKindAbbreviation)
+		mkTitleKind(t, dAbbrev, "短縮名検証用", model.WorkTitleKindAbbreviation)
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		row, verdict := findPair(t, c, a, b)
+		assert.Equal(t, 1, row.SharedNorms)
+		assert.Equal(t, 0, row.SharedOfficial)
+		assert.True(t, row.LabelOverlap)
+		assert.Equal(t, bucketAliasOnly, verdict)
+		assert.False(t, hasPair(c, cAbbrev, dAbbrev), "kind=2 abbreviation must not generate a pair")
+	})
+
+	t.Run("f_dead_ref_no_pair", func(t *testing.T) {
+		cleanPipeline(t)
+		medium := galgameMedium(t)
+		a := mkWork(t, medium, "デッドエイ参照作品テスト", nil)
+		b := mkWork(t, medium, "デッドビー参照作品テスト", nil)
+		dead := time.Now()
+		mkRef(t, a, officialSite, "www.example.com/dead/x", model.LinkKindProbable, &dead)
+		mkRef(t, b, officialSite, "www.example.com/dead/x", model.LinkKindExact, nil)
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		assert.False(t, hasPair(c, a, b), "a dead_at ref must not generate a pair")
+	})
+
+	t.Run("g_soft_deleted_work_no_pair", func(t *testing.T) {
+		cleanPipeline(t)
+		medium := galgameMedium(t)
+		a := mkWork(t, medium, "削除エイ参照作品テスト", nil)
+		b := mkWork(t, medium, "削除ビー参照作品テスト", nil)
+		mkRef(t, a, officialSite, "www.example.com/gone/x", model.LinkKindProbable, nil)
+		mkRef(t, b, officialSite, "www.example.com/gone/x", model.LinkKindExact, nil)
+		require.NoError(t, testDB.Delete(&model.CatalogWork{}, a).Error)
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		assert.False(t, hasPair(c, a, b), "a soft-deleted work must not generate a pair")
+	})
+
+	t.Run("h_related_url_pair_needs_manual", func(t *testing.T) {
+		cleanPipeline(t)
+		medium := galgameMedium(t)
+		a := mkWork(t, medium, "関連エイ参照作品テスト", nil)
+		b := mkWork(t, medium, "関連ビー参照作品テスト", nil)
+		mkRef(t, a, officialSite, "www.example.com/related/h", model.LinkKindRelated, nil)
+		mkRef(t, b, officialSite, "www.example.com/related/h", model.LinkKindRelated, nil)
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		row, verdict := findPair(t, c, a, b)
+		assert.True(t, row.RefOverlapCI)
+		assert.False(t, row.RefOverlap)
+		assert.Equal(t, bucketRefCI, verdict)
+	})
+
+	t.Run("i_related_url_conflicting_anchors_no_pair", func(t *testing.T) {
+		cleanPipeline(t)
+		medium := galgameMedium(t)
+		a := mkWork(t, medium, "衝突関連エイ参照作品", nil)
+		b := mkWork(t, medium, "衝突関連ビー参照作品", nil)
+		mkRef(t, a, officialSite, "www.example.com/related/i", model.LinkKindRelated, nil)
+		mkRef(t, b, officialSite, "www.example.com/related/i", model.LinkKindRelated, nil)
+		mkAnchor(t, a, 3, "111")
+		mkAnchor(t, b, 3, "222")
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		assert.False(t, hasPair(c, a, b), "kind=2 URL plus conflicting exact anchors must not pair")
+	})
+
+	t.Run("j_related_url_does_not_grant_auto", func(t *testing.T) {
+		cleanPipeline(t)
+		medium := galgameMedium(t)
+		a := mkWork(t, medium, "年差関連エイ作品テスト", nil)
+		b := mkWork(t, medium, "年差関連ビー作品テスト", nil)
+		mkTitle(t, a, "関連年差作品検証テスト")
+		mkTitle(t, b, "関連年差作品検証テスト")
+		mkRef(t, a, officialSite, "www.example.com/related/j", model.LinkKindRelated, nil)
+		mkRef(t, b, officialSite, "www.example.com/related/j", model.LinkKindRelated, nil)
+		mkRelease(t, a, 2014, 5, 1)
+		mkRelease(t, b, 2016, 5, 1)
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		row, verdict := findPair(t, c, a, b)
+		assert.False(t, row.RefOverlap)
+		assert.True(t, row.RefOverlapCI)
+		assert.Equal(t, bucketDateClash, verdict)
+	})
 }

--- a/apps/api/cmd/work-dedup/propose.go
+++ b/apps/api/cmd/work-dedup/propose.go
@@ -168,6 +168,9 @@ func pairEvidence(r pairRow) string {
 	if r.RefOverlap {
 		parts = append(parts, "ref")
 	}
+	if r.RefOverlapCI && !r.RefOverlap {
+		parts = append(parts, "ref_ci")
+	}
 	if datesNear(r.DateA, r.DateB) {
 		parts = append(parts, fmt.Sprintf("date(%s~%s)", dateStr(r.DateA), dateStr(r.DateB)))
 	}

--- a/apps/api/cmd/work-dedup/report.go
+++ b/apps/api/cmd/work-dedup/report.go
@@ -42,7 +42,7 @@ func printCensus(c *census, w io.Writer) {
 		}
 	}
 	fmt.Fprintf(w, "[census] pairs=%d in_scope=%d\n", len(c.rows), len(c.rows)-buckets[bucketOutOfScope])
-	for _, b := range []bucket{bucketAuto, bucketAnchorConflict, bucketRelConflict, bucketDateClash, bucketBare, bucketBothKungal, bucketBridged, bucketOutOfScope} {
+	for _, b := range []bucket{bucketAuto, bucketAnchorConflict, bucketRelConflict, bucketDateClash, bucketBare, bucketBothKungal, bucketBridged, bucketRefCI, bucketAliasOnly, bucketOutOfScope} {
 		fmt.Fprintf(w, "  %-16s %d\n", b, buckets[b])
 	}
 	fmt.Fprintf(w, "  merge groups: %d\n", len(c.groups))
@@ -73,6 +73,7 @@ func exportCSV(c *census, path string) error {
 		"a", "b", "bucket", "lane_a", "lane_b", "site_a", "site_b", "name_a", "name_b",
 		"shared_norm", "shared_norms", "anchor_conflict", "release_conflict", "ref_overlap",
 		"date_a", "date_b", "label_overlap", "anchors_a", "anchors_b",
+		"shared_official", "ref_overlap_ci",
 	}); err != nil {
 		return err
 	}
@@ -90,6 +91,7 @@ func exportCSV(c *census, path string) error {
 			strconv.FormatBool(r.AnchorConflict), strconv.FormatBool(r.RelConflict), strconv.FormatBool(r.RefOverlap),
 			dateStr(r.DateA), dateStr(r.DateB),
 			strconv.FormatBool(r.LabelOverlap), strconv.Itoa(r.AnchorsA), strconv.Itoa(r.AnchorsB),
+			strconv.Itoa(r.SharedOfficial), strconv.FormatBool(r.RefOverlapCI),
 		}
 		if err := cw.Write(rec); err != nil {
 			return err

--- a/apps/api/cmd/work-dedup/seed.go
+++ b/apps/api/cmd/work-dedup/seed.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 
 	"api/internal/platform/catalog/model"
 
@@ -12,11 +13,6 @@ import (
 )
 
 const seedChunk = 1000
-
-var seedBuckets = []bucket{
-	bucketAuto, bucketAnchorConflict, bucketRelConflict, bucketDateClash,
-	bucketBare, bucketBothKungal, bucketBridged,
-}
 
 func seedStatusFor(b bucket) int16 {
 	if b == bucketAuto {
@@ -36,14 +32,24 @@ func runSeed(ctx context.Context, db *gorm.DB, w io.Writer, actor int64, run boo
 		if b == bucketOutOfScope {
 			continue
 		}
+		reason := model.CandidateReasonNameNormEqual
+		if r.SharedNorms == 0 {
+			reason = model.CandidateReasonSharedExternalID
+		}
 		planned[b] = append(planned[b], model.CatalogMatchCandidate{
 			EntityType: model.EntityTypeWork, AID: r.A, BID: r.B,
-			Reason: model.CandidateReasonNameNormEqual, Status: seedStatusFor(b),
+			Reason: reason, Status: seedStatusFor(b),
 		})
 	}
 
+	keys := make([]bucket, 0, len(planned))
+	for b := range planned {
+		keys = append(keys, b)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+
 	total, inserted := 0, 0
-	for _, b := range seedBuckets {
+	for _, b := range keys {
 		rows := planned[b]
 		total += len(rows)
 		if !run {

--- a/apps/api/cmd/work-dedup/verdict.go
+++ b/apps/api/cmd/work-dedup/verdict.go
@@ -16,6 +16,8 @@ const (
 	bucketDateClash      bucket = "date-clash"
 	bucketBare           bucket = "bare"
 	bucketBridged        bucket = "bridged"
+	bucketAliasOnly      bucket = "alias-only"
+	bucketRefCI          bucket = "ref-case"
 )
 
 // dateNearDays tolerates cross-source date drift: sources record different
@@ -44,7 +46,7 @@ func classifyPair(r pairRow) bucket {
 	if r.LaneA == "dlsite" && r.LaneB == "dlsite" {
 		return bucketOutOfScope
 	}
-	corroborated := r.RefOverlap || r.LabelOverlap || r.SharedNorms >= 2 || datesNear(r.DateA, r.DateB)
+	corroborated := r.RefOverlapCI || r.LabelOverlap || r.SharedNorms >= 2 || datesNear(r.DateA, r.DateB)
 	dateClash := r.DateA != nil && r.DateB != nil && r.DateA.Year() != r.DateB.Year()
 	switch {
 	case r.AnchorConflict:
@@ -53,6 +55,13 @@ func classifyPair(r pairRow) bucket {
 		return bucketRelConflict
 	case r.LaneA == "kungal" && r.LaneB == "kungal":
 		return bucketBothKungal
+	case r.RefOverlap:
+		// works 51010/222325 shared bangumi subject 524476 yet were filed manual because the year check ran first.
+		return bucketAuto
+	case r.SharedNorms == 0:
+		return bucketRefCI
+	case r.SharedOfficial == 0:
+		return bucketAliasOnly
 	case dateClash:
 		return bucketDateClash
 	case !corroborated:

--- a/apps/api/cmd/work-dedup/verdict_test.go
+++ b/apps/api/cmd/work-dedup/verdict_test.go
@@ -15,7 +15,7 @@ func day(t *testing.T, s string) *time.Time {
 }
 
 func TestClassifyPairBuckets(t *testing.T) {
-	base := pairRow{A: 1, B: 2, LaneA: "kungal", LaneB: "bgm", SharedNorms: 1}
+	base := pairRow{A: 1, B: 2, LaneA: "kungal", LaneB: "bgm", SharedNorms: 1, SharedOfficial: 1}
 	cases := []struct {
 		name string
 		row  func(pairRow) pairRow
@@ -54,6 +54,35 @@ func TestClassifyPairBuckets(t *testing.T) {
 			r.LaneA, r.LaneB, r.AnchorConflict = "dlsite", "dlsite", true
 			return r
 		}, bucketOutOfScope},
+		{"exact ref outranks a year clash", func(r pairRow) pairRow {
+			r.RefOverlap = true
+			r.DateA, r.DateB = day(t, "2024-01-01"), day(t, "2026-01-01")
+			return r
+		}, bucketAuto},
+		{"exact ref with no shared norms is auto", func(r pairRow) pairRow {
+			r.RefOverlap = true
+			r.SharedNorms, r.SharedOfficial = 0, 0
+			return r
+		}, bucketAuto},
+		{"case-insensitive ref only is never auto", func(r pairRow) pairRow {
+			r.RefOverlapCI = true
+			r.SharedNorms, r.SharedOfficial = 0, 0
+			return r
+		}, bucketRefCI},
+		{"alias-only title with a corroborator", func(r pairRow) pairRow {
+			r.SharedOfficial = 0
+			r.LabelOverlap = true
+			return r
+		}, bucketAliasOnly},
+		{"exact ref outranks alias-only", func(r pairRow) pairRow {
+			r.SharedOfficial = 0
+			r.RefOverlap = true
+			return r
+		}, bucketAuto},
+		{"ci ref corroborates an official title pair", func(r pairRow) pairRow {
+			r.RefOverlapCI = true
+			return r
+		}, bucketAuto},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -66,9 +95,9 @@ func TestClassifyPairBuckets(t *testing.T) {
 
 func TestClassifyDemotesBridgedComponents(t *testing.T) {
 	rows := []pairRow{
-		{A: 1, B: 2, LaneA: "kungal", LaneB: "bgm", RefOverlap: true, SharedNorms: 1},
-		{A: 2, B: 3, LaneA: "bgm", LaneB: "kungal", RefOverlap: true, SharedNorms: 1},
-		{A: 10, B: 11, LaneA: "bgm", LaneB: "vndb", RefOverlap: true, SharedNorms: 1},
+		{A: 1, B: 2, LaneA: "kungal", LaneB: "bgm", RefOverlap: true, SharedNorms: 1, SharedOfficial: 1},
+		{A: 2, B: 3, LaneA: "bgm", LaneB: "kungal", RefOverlap: true, SharedNorms: 1, SharedOfficial: 1},
+		{A: 10, B: 11, LaneA: "bgm", LaneB: "vndb", RefOverlap: true, SharedNorms: 1, SharedOfficial: 1},
 	}
 	verdicts, groups := classify(rows)
 	if verdicts[0] != bucketBridged || verdicts[1] != bucketBridged {
@@ -91,19 +120,19 @@ func TestClassifySurvivorSelection(t *testing.T) {
 		{
 			name: "claimed work beats anchor count",
 			row: pairRow{A: 10, B: 11, LaneA: "bgm", LaneB: "kungal",
-				AnchorsA: 5, AnchorsB: 0, RefOverlap: true, SharedNorms: 1},
+				AnchorsA: 5, AnchorsB: 0, RefOverlap: true, SharedNorms: 1, SharedOfficial: 1},
 			want: 11,
 		},
 		{
 			name: "anchors decide when neither is claimed",
 			row: pairRow{A: 20, B: 21, LaneA: "bgm", LaneB: "vndb",
-				AnchorsA: 1, AnchorsB: 3, RefOverlap: true, SharedNorms: 1},
+				AnchorsA: 1, AnchorsB: 3, RefOverlap: true, SharedNorms: 1, SharedOfficial: 1},
 			want: 21,
 		},
 		{
 			name: "an anchor tie keeps the lower id",
 			row: pairRow{A: 30, B: 31, LaneA: "bgm", LaneB: "vndb",
-				AnchorsA: 1, AnchorsB: 1, RefOverlap: true, SharedNorms: 1},
+				AnchorsA: 1, AnchorsB: 1, RefOverlap: true, SharedNorms: 1, SharedOfficial: 1},
 			want: 30,
 		},
 	}
@@ -136,5 +165,11 @@ func TestPairEvidenceNamesTheCorroborators(t *testing.T) {
 	}
 	if got := pairEvidence(pairRow{SharedNorms: 1}); got != "none" {
 		t.Fatalf("evidence = %q, want %q", got, "none")
+	}
+	if got := pairEvidence(pairRow{RefOverlapCI: true, SharedNorms: 0}); got != "ref_ci" {
+		t.Fatalf("evidence = %q, want %q", got, "ref_ci")
+	}
+	if got := pairEvidence(pairRow{RefOverlap: true, RefOverlapCI: true, SharedNorms: 1}); got != "ref" {
+		t.Fatalf("evidence = %q, want %q", got, "ref")
 	}
 }

--- a/apps/api/internal/platform/catalog/importer/bangumixmedia.go
+++ b/apps/api/internal/platform/catalog/importer/bangumixmedia.go
@@ -221,14 +221,15 @@ func (im *Importer) registerXmedia(subs []xmediaSubject, xWork map[int64]int64, 
 
 func (im *Importer) loadBangumiAnchorsByMedium() (galgame, all map[int64]int64, err error) {
 	var rows []struct {
-		Ext    string `gorm:"column:external_id"`
-		Wid    int64  `gorm:"column:entity_id"`
-		Medium int16  `gorm:"column:medium_id"`
+		Ext      string `gorm:"column:external_id"`
+		Wid      int64  `gorm:"column:entity_id"`
+		Medium   int16  `gorm:"column:medium_id"`
+		LinkKind int16  `gorm:"column:link_kind"`
 	}
-	if err := im.catalog.Raw(`SELECT r.external_id, r.entity_id, w.medium_id
+	if err := im.catalog.Raw(`SELECT r.external_id, r.entity_id, w.medium_id, r.link_kind
 		FROM catalog_external_ref r JOIN catalog_work w ON w.id = r.entity_id
-		WHERE r.source_id = ? AND r.entity_type = ? AND r.link_kind = ?`,
-		bangumiSource, model.EntityTypeWork, model.LinkKindExact).Scan(&rows).Error; err != nil {
+		WHERE r.source_id = ? AND r.entity_type = ?`,
+		bangumiSource, model.EntityTypeWork).Scan(&rows).Error; err != nil {
 		return nil, nil, err
 	}
 	galgame = make(map[int64]int64)
@@ -238,8 +239,10 @@ func (im *Importer) loadBangumiAnchorsByMedium() (galgame, all map[int64]int64, 
 		if e != nil {
 			continue
 		}
-		all[sid] = r.Wid
-		if r.Medium == mediumGalgame {
+		if _, ok := all[sid]; !ok || r.LinkKind == model.LinkKindExact {
+			all[sid] = r.Wid
+		}
+		if r.Medium == mediumGalgame && r.LinkKind == model.LinkKindExact {
 			galgame[sid] = r.Wid
 		}
 	}

--- a/apps/api/internal/platform/catalog/importer/bangumixmedia_test.go
+++ b/apps/api/internal/platform/catalog/importer/bangumixmedia_test.go
@@ -67,3 +67,39 @@ func TestBangumiXmedia(t *testing.T) {
 	assert.Equal(t, 3, st2.AlreadyWork)
 	assert.Equal(t, 3, st2.AlreadyEdge)
 }
+
+func TestBangumiXmediaProbableOccupancy(t *testing.T) {
+	if testDB == nil {
+		t.Skip("no test db")
+	}
+	clean(t)
+
+	gExact := seedAnchoredWork(t, 100)
+
+	var gProbable int64
+	require.NoError(t, testDB.Raw(`INSERT INTO catalog_work (medium_id, olang, display_name, content_rating, status, extra, field_provenance, display_nsfw)
+		VALUES (1,'ja','probable-galgame',0,0,'{}','{}',false) RETURNING id`).Scan(&gProbable).Error)
+	require.NoError(t, testDB.Exec(`INSERT INTO catalog_external_ref (entity_type, entity_id, source_id, external_id, link_kind, matched_by)
+		VALUES (5, ?, 3, '110', 1, 'test:probable-galgame')`, gProbable).Error)
+
+	var xHeld int64
+	require.NoError(t, testDB.Raw(`INSERT INTO catalog_work (medium_id, olang, display_name, content_rating, status, extra, field_provenance, display_nsfw)
+		VALUES (4,'ja','held-anime',0,0,'{}','{}',false) RETURNING id`).Scan(&xHeld).Error)
+	require.NoError(t, testDB.Exec(`INSERT INTO catalog_external_ref (entity_type, entity_id, source_id, external_id, link_kind, matched_by)
+		VALUES (5, ?, 3, '400', 1, 'test:probable-xmedia')`, xHeld).Error)
+
+	insertSubject(t, 400, 2, 0, "既存アニメ400", "")
+	insertSubject(t, 401, 2, 0, "未登録アニメ401", "")
+	require.NoError(t, testDB.Exec(`INSERT INTO src_bangumi.subject_relation (subject_id, relation_type, related_subject_id, item_order) VALUES
+		(100, 1, 400, 0),
+		(110, 1, 401, 0)`).Error)
+
+	st, err := New(testDB, nil, Options{}).RunBangumiXmedia()
+	require.NoError(t, err)
+	assert.Equal(t, 1, st.AlreadyWork)
+	assert.Zero(t, st.RegisteredAnime)
+	assert.Equal(t, 1, st.EdgesWritten)
+	assert.Equal(t, int64(1), scalarInt(t, `SELECT count(*) FROM catalog_work_relation WHERE a_work_id=`+itoa64(xHeld)+` AND b_work_id=`+itoa64(gExact)+` AND relation_type_id=1`))
+	assert.Zero(t, scalarInt(t, `SELECT count(*) FROM catalog_work_relation WHERE b_work_id=`+itoa64(gProbable)))
+	assert.Zero(t, scalarInt(t, `SELECT count(*) FROM catalog_external_ref WHERE matched_by='rule:bangumi-xmedia-import'`))
+}

--- a/apps/api/internal/platform/catalog/importer/bgmtype4gated_gate.go
+++ b/apps/api/internal/platform/catalog/importer/bgmtype4gated_gate.go
@@ -5,6 +5,8 @@ import (
 	"math/rand"
 	"strings"
 	"unicode"
+
+	"api/internal/platform/catalog/service"
 )
 
 func tallySignals(st *BgmGatedStats, p, t, x bool) {
@@ -62,11 +64,11 @@ func collide(r poolRow, wt map[string]wtNorm) (BgmGatedCollision, bool) {
 // raw one keeps the pre-fold behaviour, the folded one stops "A B C" from
 // becoming a 3-rune key that collides by genre rather than identity.
 func foldedGateKey(norm string) (string, bool) {
-	if runeLen(norm) < bgmGatedMinLen {
+	if !service.WorkDupeNormEligible(norm) {
 		return "", false
 	}
 	folded := foldSpace(norm)
-	if runeLen(folded) < bgmGatedMinLen {
+	if !service.WorkDupeNormEligible(folded) {
 		return "", false
 	}
 	return folded, true

--- a/apps/api/internal/platform/catalog/importer/bgmtype4gated_load.go
+++ b/apps/api/internal/platform/catalog/importer/bgmtype4gated_load.go
@@ -5,6 +5,7 @@ import (
 
 	"api/internal/platform/catalog/editspec"
 	"api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/service"
 
 	"gorm.io/gorm"
 )
@@ -54,7 +55,7 @@ func (im *Importer) loadExistingWorkTitleNorms() (map[string]wtNorm, error) {
 		}
 		for _, r := range rows {
 			folded := foldSpace(r.Norm)
-			if runeLen(folded) < bgmGatedMinLen {
+			if !service.WorkDupeNormEligible(folded) {
 				continue
 			}
 			if _, ok := out[folded]; !ok {
@@ -65,16 +66,14 @@ func (im *Importer) loadExistingWorkTitleNorms() (map[string]wtNorm, error) {
 	}
 	if err := collect(
 		`SELECT title_norm, work_id, title FROM catalog_work_title t
-		 WHERE length(title_norm) >= ? AND `+editspec.NotSuppressedWorkTitleSQL("t"),
-		bgmGatedMinLen,
+		 WHERE ` + service.WorkDupeNormEligibleSQL("title_norm") + ` AND ` + editspec.NotSuppressedWorkTitleSQL("t"),
 	); err != nil {
 		return nil, err
 	}
 	if err := collect(
 		`SELECT lower(normalize(w.display_name, NFKC)) AS title_norm, w.id AS work_id, w.display_name AS title
 		 FROM catalog_work w
-		 WHERE w.deleted_at IS NULL AND length(w.display_name) >= ?`,
-		bgmGatedMinLen,
+		 WHERE w.deleted_at IS NULL AND ` + service.WorkDupeNormEligibleSQL("w.display_name"),
 	); err != nil {
 		return nil, err
 	}

--- a/apps/api/internal/platform/catalog/importer/bgmtype4gated_test.go
+++ b/apps/api/internal/platform/catalog/importer/bgmtype4gated_test.go
@@ -198,6 +198,33 @@ func TestBgmType4GatedIntraCollisionFoldsSpace(t *testing.T) {
 	assert.Zero(t, dry.ToCreate)
 }
 
+func TestBgmType4GatedHanFloorCollisions(t *testing.T) {
+	clean(t)
+	require.NoError(t, testDB.Exec(`ALTER TABLE games ADD COLUMN IF NOT EXISTS gamename text`).Error)
+
+	seedSubject(t, 3201, "", "红楼梦", `["Galgame","PC","游戏"]`, "", false)
+	seedDisplayOnlyWork(t, "红楼梦")
+
+	seedSubject(t, 3202, "", "abc", `["Galgame","PC","游戏"]`, "", false)
+	seedDisplayOnlyWork(t, "abc")
+
+	dry, err := New(testDB, testDB, Options{DryRun: true}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, 2, dry.GatedTotal)
+	assert.Equal(t, 1, dry.SkippedTitleCollision)
+	assert.Equal(t, 1, dry.ToCreate)
+	require.Len(t, dry.CollisionSamples, 1)
+	assert.Equal(t, int64(3201), dry.CollisionSamples[0].SubjectID)
+
+	st, err := New(testDB, testDB, Options{}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, 1, st.WorksCreated)
+	assert.Equal(t, int64(1), scalarInt(t, `SELECT count(*) FROM catalog_external_ref
+		WHERE matched_by='rule:bgm-type4-gated' AND external_id='3202'`))
+	assert.Zero(t, scalarInt(t, `SELECT count(*) FROM catalog_external_ref
+		WHERE matched_by='rule:bgm-type4-gated' AND external_id='3201'`))
+}
+
 func seedDisplayOnlyWork(t *testing.T, displayName string) {
 	t.Helper()
 	require.NoError(t, testDB.Exec(`INSERT INTO catalog_work (medium_id, olang, display_name, content_rating, status, extra, field_provenance, display_nsfw)

--- a/apps/api/internal/platform/catalog/service/work_dupe.go
+++ b/apps/api/internal/platform/catalog/service/work_dupe.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"strconv"
-
 	"api/internal/platform/catalog/editspec"
 	"api/internal/platform/catalog/model"
 
@@ -24,21 +22,45 @@ func WorkTitleFoldSQL(expr string) string {
 	return `regexp_replace(` + expr + `, '[[:space:]　]', '', 'g')`
 }
 
+func WorkDupeNormEligibleSQL(expr string) string {
+	return `(length(` + expr + `) >= 4 OR ` + expr + ` ~ '^[一-鿿]{3}$')`
+}
+
+// The 0x4E00..0x9FFF range must equal WorkDupeNormEligibleSQL's [一-鿿] class.
+func WorkDupeNormEligible(n string) bool {
+	runes := []rune(n)
+	if len(runes) >= WorkDupeMinRunes {
+		return true
+	}
+	if len(runes) != 3 {
+		return false
+	}
+	for _, r := range runes {
+		if r < 0x4E00 || r > 0x9FFF {
+			return false
+		}
+	}
+	return true
+}
+
 // WorkDupeCorpusSQL selects every live work's folded identity norms as
-// (work_id, n): official titles plus display_name. display_name must be in
-// the corpus — wiki-claimed works were born with zero title rows, which is
-// the other hole the 2026-07 wave slipped through.
+// (work_id, n, official): official and alias titles plus display_name, with
+// official=false marking alias-sourced norms so the verdict can refuse to
+// auto-merge on alias evidence alone. display_name must be in the corpus —
+// wiki-claimed works were born with zero title rows, which is the other hole
+// the 2026-07 wave slipped through.
 func WorkDupeCorpusSQL() string {
-	minLen := strconv.Itoa(WorkDupeMinRunes)
-	return `SELECT t.work_id, ` + WorkTitleFoldSQL("t.title_norm") + ` AS n
+	foldTitle := WorkTitleFoldSQL("t.title_norm")
+	foldDisplay := WorkTitleFoldSQL("lower(normalize(w.display_name, NFKC))")
+	return `SELECT t.work_id, ` + foldTitle + ` AS n, (t.kind = 0) AS official
 		FROM catalog_work_title t
 		JOIN catalog_work tw ON tw.id = t.work_id AND tw.deleted_at IS NULL
-		WHERE t.kind = 0 AND length(t.title_norm) >= ` + minLen + `
+		WHERE t.kind IN (0, 1) AND ` + WorkDupeNormEligibleSQL(foldTitle) + `
 		  AND ` + editspec.NotSuppressedWorkTitleSQL("t") + `
 		UNION
-		SELECT w.id, ` + WorkTitleFoldSQL("lower(normalize(w.display_name, NFKC))") + `
+		SELECT w.id, ` + foldDisplay + `, true AS official
 		FROM catalog_work w
-		WHERE w.deleted_at IS NULL AND length(w.display_name) >= ` + minLen
+		WHERE w.deleted_at IS NULL AND ` + WorkDupeNormEligibleSQL(foldDisplay)
 }
 
 // recordWorkDupeSuspects files a pending match candidate for every live work
@@ -52,8 +74,8 @@ func recordWorkDupeSuspects(tx *gorm.DB, workID int64) error {
 		SELECT DISTINCT o.work_id
 		FROM corpus mine
 		JOIN corpus o ON o.n = mine.n AND o.work_id <> mine.work_id
-		WHERE mine.work_id = ? AND length(mine.n) >= ?
-		ORDER BY o.work_id`, workID, WorkDupeMinRunes).Scan(&hits).Error
+		WHERE mine.work_id = ? AND `+WorkDupeNormEligibleSQL("mine.n")+`
+		ORDER BY o.work_id`, workID).Scan(&hits).Error
 	if err != nil || len(hits) == 0 {
 		return err
 	}

--- a/apps/api/internal/platform/catalog/service/work_dupe_test.go
+++ b/apps/api/internal/platform/catalog/service/work_dupe_test.go
@@ -48,3 +48,57 @@ func TestSubmitWorkWithoutCollisionFilesNothing(t *testing.T) {
 	require.NoError(t, testDB.Model(&model.CatalogMatchCandidate{}).Count(&filed).Error)
 	assert.Zero(t, filed)
 }
+
+func TestWorkDupeNormEligible(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"红楼梦", true},
+		{"紅樓夢", true},
+		{"abc", false},
+		{"红楼", false},
+		{"ローズ", false},
+		{"abcd", true},
+		{"红楼梦x", true},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, WorkDupeNormEligible(tc.in), tc.in)
+	}
+}
+
+func TestSubmitWorkFilesHanThreeRuneDupeCandidate(t *testing.T) {
+	s := newLifecycle(t)
+	existing := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "红楼梦")
+
+	res, err := s.SubmitWork(t.Context(), SubmitWorkParams{
+		Site: submitSite, ProductWorkID: 90503, ActorUID: 7,
+		Fields: submitFields("红楼梦"),
+	})
+	require.NoError(t, err)
+
+	var cands []model.CatalogMatchCandidate
+	require.NoError(t, testDB.Order("a_id, b_id").Find(&cands).Error)
+	require.Len(t, cands, 1)
+	got := cands[0]
+	assert.Equal(t, model.EntityTypeWork, got.EntityType)
+	assert.Equal(t, min(existing.ID, res.WorkID), got.AID)
+	assert.Equal(t, max(existing.ID, res.WorkID), got.BID)
+	assert.Equal(t, model.CandidateReasonNameNormEqual, got.Reason)
+	assert.Equal(t, model.CandidateStatusPending, got.Status)
+}
+
+func TestSubmitWorkSkipsShortASCIICollision(t *testing.T) {
+	s := newLifecycle(t)
+	createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "abc")
+
+	_, err := s.SubmitWork(t.Context(), SubmitWorkParams{
+		Site: submitSite, ProductWorkID: 90504, ActorUID: 7,
+		Fields: submitFields("abc"),
+	})
+	require.NoError(t, err)
+
+	var filed int64
+	require.NoError(t, testDB.Model(&model.CatalogMatchCandidate{}).Count(&filed).Error)
+	assert.Zero(t, filed)
+}


### PR DESCRIPTION
## What

PR 1 of the duplicate-works mint-chain plan: detection-side widening only. No product-visible semantics change, no migration.

Four knives on the detector plus one importer occupancy fix:

1. **Han-aware norm floor** — 3-rune all-Han titles (红楼梦) become eligible; short ASCII (`abc`) stays excluded. One shared predicate `WorkDupeNormEligible` / `WorkDupeNormEligibleSQL` used by the census, `SubmitWork` suspects, and the bgm type4 gate. The Go rune-range mirror and the SQL char class are pinned equal by comment and test.
2. **Alias corpus** — kind 1 alias titles join the corpus with a per-norm `official` flag (`bool_or` over sources); abbreviations (kind 2) stay out. Alias-only matches route to the new `alias-only` manual bucket, never auto.
3. **Shared-external-ref pair source** — pairs are also generated from case-insensitively shared work-level refs. Identity kinds (exact/probable) pair outright; related-page refs (kind 2) pair only when no exact anchors prove the works distinct (the any-kind draft produced ~78k brand-hub pairs, 76,632 of them anchor-conflicted; the no-conflict residue sampled 15/15 true duplicates).
4. **Verdict order** — byte-identical identity-kind ref overlap now outranks the year clash (works 51010/222325 shared bangumi subject 524476 yet were filed manual because the year check ran first). CI/related overlap corroborates but never grants auto alone (`ref-case` bucket).
5. **bangumixmedia occupancy** — a work already holding the subject as probable is `AlreadyWork`, not reminted; the galgame join map stays exact-only.

## Acceptance (local kun_catalog snapshot, pre-dates the 08-29 prod merges)

- pairs 35k→39,378, in-scope 11,503: auto 3,499 / anchor-conflict 4,773 / alias-only 795 / ref-case 636.
- anchor-conflict decomposes as 2,115 official-title (the old baseline), 2,455 alias-driven (franchise aliases with distinct anchors — correctly human-only), 203 pure-ref.
- Motivating prod pairs: 51010↔222325 → auto; 31006↔215117 → auto (Han-3 + CI corroboration); 795↔215778 → alias-only; 213696↔215117 → anchor-conflict (two distinct bgm anchors, correctly held).
- ref-case sample is visibly true-dup punctuation variants (サクラノ詩, 心跳文学部↔DDLC, Ever17, FLIP＊FLOP ～/~).
- `go build` / `go vet` / `gofmt` clean; full DB suites green (`cmd/work-dedup` 2.9s, `catalog/service` 117.7s, `catalog/importer` 25.1s on an ephemeral DB).

PR 2 (quarantine mint for gate collisions) follows separately and needs a product-shape decision first.

https://claude.ai/code/session_01VfxKvHRwA5Vj28pdvoE4bY