### PR TITLE
feat(catalog): quarantine-mint colliding importer works and add the operator release exit

### DIFF
--- a/apps/api/cmd/expand-bgm-type4-gated/main.go
+++ b/apps/api/cmd/expand-bgm-type4-gated/main.go
@@ -57,8 +57,9 @@ func main() {
 		"pool_total", st.PoolTotal, "excluded_console_mobile", st.ExcludedConsoleMobile, "eligible_pool", st.EligiblePool,
 		"sig_p", st.SigP, "sig_t", st.SigT, "sig_x", st.SigX, "gated_total", st.GatedTotal,
 		"skipped_ascii_xonly", st.SkippedASCIIXOnly,
-		"skipped_title_collision", st.SkippedTitleCollision, "skipped_intra_collision", st.SkippedIntraCollision,
-		"to_create", st.ToCreate, "works_created", st.WorksCreated, "titles_created", st.TitlesCreated,
+		"title_collisions", st.TitleCollisions, "skipped_intra_collision", st.SkippedIntraCollision,
+		"to_create", st.ToCreate, "to_quarantine", st.ToQuarantine, "quarantined", st.Quarantined,
+		"works_created", st.WorksCreated, "titles_created", st.TitlesCreated,
 		"anchors_created", st.AnchorsCreated, "revisions_created", st.RevisionsCreated)
 	slog.Info("bgm-type4-gated overlap matrix",
 		"p_and_t", st.PT, "p_and_x", st.PX, "t_and_x", st.TX, "all_three", st.All3,

--- a/apps/api/internal/platform/catalog/handler/admin.go
+++ b/apps/api/internal/platform/catalog/handler/admin.go
@@ -51,6 +51,10 @@ func (s *AdminServer) register(api huma.API) {
 		Summary: "Decide a match candidate: accept (credit_name → link a person; else opens a merge proposal), reject (kept forever) or defer", Tags: tags,
 	}, s.decideCandidate)
 	huma.Register(api, huma.Operation{
+		OperationID: "releaseCatalogWork", Method: http.MethodPost, Path: "/api/v1/admin/catalog/works/release",
+		Summary: "Release a quarantined work to live (the reject-without-merge exit of the mint gate)", Tags: tags,
+	}, s.releaseWork)
+	huma.Register(api, huma.Operation{
 		OperationID: "detachCatalogName", Method: http.MethodPost, Path: "/api/v1/admin/catalog/names/detach",
 		Summary: "Detach a credit name from its person (reverses a person link; removes the person if it empties)", Tags: tags,
 	}, s.detachName)
@@ -199,11 +203,12 @@ type decideCandidateInput struct {
 }
 
 type decideCandidateData struct {
-	Decided       bool   `json:"decided"`
-	ProposalID    *int64 `json:"proposal_id,omitempty" doc:"Set when a merge-candidate accept opened a proposal"`
-	PersonID      *int64 `json:"person_id,omitempty"`
-	PersonCreated bool   `json:"person_created,omitempty"`
-	NeedsManual   bool   `json:"needs_manual,omitempty"`
+	Decided       bool    `json:"decided"`
+	ProposalID    *int64  `json:"proposal_id,omitempty" doc:"Set when a merge-candidate accept opened a proposal"`
+	PersonID      *int64  `json:"person_id,omitempty"`
+	PersonCreated bool    `json:"person_created,omitempty"`
+	NeedsManual   bool    `json:"needs_manual,omitempty"`
+	Released      []int64 `json:"released,omitempty"`
 }
 
 type decideCandidateOutput struct {
@@ -229,7 +234,7 @@ func (s *AdminServer) decideCandidate(ctx context.Context, in *decideCandidateIn
 		slog.Error("catalog admin decide candidate", "err", err)
 		return nil, apiErr(http.StatusInternalServerError, errors.ErrInternalServer)
 	}
-	data := decideCandidateData{Decided: true}
+	data := decideCandidateData{Decided: true, Released: outcome.Released}
 	if outcome.Proposal != nil {
 		data.ProposalID = &outcome.Proposal.ID
 	}

--- a/apps/api/internal/platform/catalog/handler/admin_release.go
+++ b/apps/api/internal/platform/catalog/handler/admin_release.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	"context"
+	stderrors "errors"
+	"log/slog"
+	"net/http"
+
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/service"
+	"api/pkg/errors"
+)
+
+type releaseWorkInput struct {
+	Body struct {
+		WorkID int64  `json:"work_id" minimum:"1" doc:"The quarantined work to release to live"`
+		Note   string `json:"note,omitempty"`
+	}
+}
+
+type releaseWorkData struct {
+	WorkID int64 `json:"work_id"`
+	Status int16 `json:"status"`
+}
+
+type releaseWorkOutput struct {
+	Body Envelope[releaseWorkData]
+}
+
+func (s *AdminServer) releaseWork(ctx context.Context, in *releaseWorkInput) (*releaseWorkOutput, error) {
+	err := s.queues.ReleaseWork(ctx, in.Body.WorkID, adminIDFromCtx(ctx), in.Body.Note)
+	if err != nil {
+		switch {
+		case stderrors.Is(err, service.ErrNotFound):
+			return nil, apiErr(http.StatusNotFound, errors.ErrNotFound)
+		case stderrors.Is(err, service.ErrProposalState):
+			return nil, apiErrMsg(http.StatusConflict, errors.ErrOperationFailed, err.Error())
+		}
+		slog.Error("catalog admin release work", "err", err)
+		return nil, apiErr(http.StatusInternalServerError, errors.ErrInternalServer)
+	}
+	return &releaseWorkOutput{Body: okEnvelope(releaseWorkData{
+		WorkID: in.Body.WorkID, Status: model.WorkStatusLive,
+	})}, nil
+}

--- a/apps/api/internal/platform/catalog/handler/handler_test.go
+++ b/apps/api/internal/platform/catalog/handler/handler_test.go
@@ -48,6 +48,7 @@ func TestSetupAdmin_RegistersQueueOperations(t *testing.T) {
 	for _, p := range []string{
 		"/api/v1/admin/catalog/candidates",
 		"/api/v1/admin/catalog/candidates/decide",
+		"/api/v1/admin/catalog/works/release",
 		"/api/v1/admin/catalog/names/detach",
 		"/api/v1/admin/catalog/proposals",
 		"/api/v1/admin/catalog/proposals/{id}/{action}",

--- a/apps/api/internal/platform/catalog/importer/bgmtype4gated.go
+++ b/apps/api/internal/platform/catalog/importer/bgmtype4gated.go
@@ -9,6 +9,7 @@ import (
 
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
@@ -54,9 +55,11 @@ type BgmGatedStats struct {
 
 	GatedTotal            int
 	SkippedASCIIXOnly     int
-	SkippedTitleCollision int
+	TitleCollisions       int
 	SkippedIntraCollision int
 	ToCreate              int
+	ToQuarantine          int
+	Quarantined           int
 
 	WorksCreated     int
 	TitlesCreated    int
@@ -104,8 +107,9 @@ type wtNorm struct {
 }
 
 type candidate struct {
-	row     poolRow
-	signals string
+	row            poolRow
+	signals        string
+	collidedWorkID int64
 }
 
 func (im *Importer) RunBgmType4Gated(dlsiteDB *gorm.DB) (BgmGatedStats, error) {
@@ -128,6 +132,7 @@ func (im *Importer) RunBgmType4Gated(dlsiteDB *gorm.DB) (BgmGatedStats, error) {
 	}
 
 	var toCreate []candidate
+	var toQuarantine []candidate
 	for _, r := range pool {
 		st.PoolTotal++
 		if r.Excluded {
@@ -173,10 +178,13 @@ func (im *Importer) RunBgmType4Gated(dlsiteDB *gorm.DB) (BgmGatedStats, error) {
 		}
 		st.GatedTotal++
 		if col, ok := collide(r, wt); ok {
-			st.SkippedTitleCollision++
+			st.TitleCollisions++
 			if len(st.CollisionSamples) < bgmCollisionSample {
 				st.CollisionSamples = append(st.CollisionSamples, col)
 			}
+			toQuarantine = append(toQuarantine, candidate{
+				row: r, signals: signalString(p, t, x), collidedWorkID: col.WorkID,
+			})
 			continue
 		}
 		toCreate = append(toCreate, candidate{row: r, signals: signalString(p, t, x)})
@@ -184,29 +192,42 @@ func (im *Importer) RunBgmType4Gated(dlsiteDB *gorm.DB) (BgmGatedStats, error) {
 
 	toCreate = dropIntraCollisions(toCreate, &st)
 	st.ToCreate = len(toCreate)
+	st.ToQuarantine = len(toQuarantine)
 	st.RandomSample = pickRandomSample(toCreate)
 
 	if im.dryRun {
 		logBgmGated(&st, true)
 		return st, nil
 	}
-	createSet := toCreate
-	if im.limit > 0 && im.limit < len(createSet) {
-		createSet = createSet[:im.limit]
+	createLive := toCreate
+	createQ := toQuarantine
+	if im.limit > 0 {
+		if len(createLive) > im.limit {
+			createLive = createLive[:im.limit]
+			createQ = createQ[:0]
+		} else {
+			remain := im.limit - len(createLive)
+			if remain < len(createQ) {
+				createQ = createQ[:remain]
+			}
+		}
 	}
-	if err := im.createGatedWorks(createSet, &st); err != nil {
+	if err := im.createGatedWorks(createLive, &st, model.WorkStatusLive); err != nil {
+		return st, err
+	}
+	if err := im.createGatedWorks(createQ, &st, model.WorkStatusQuarantine); err != nil {
 		return st, err
 	}
 	logBgmGated(&st, false)
 	return st, nil
 }
 
-func (im *Importer) createGatedWorks(cands []candidate, st *BgmGatedStats) error {
+func (im *Importer) createGatedWorks(cands []candidate, st *BgmGatedStats, status int16) error {
 	for start := 0; start < len(cands); start += bgmGatedChunk {
 		end := min(start+bgmGatedChunk, len(cands))
 		chunk := cands[start:end]
 		if err := im.catalog.Transaction(func(tx *gorm.DB) error {
-			return im.createGatedChunk(tx, chunk, st)
+			return im.createGatedChunk(tx, chunk, st, status)
 		}); err != nil {
 			return err
 		}
@@ -214,7 +235,7 @@ func (im *Importer) createGatedWorks(cands []candidate, st *BgmGatedStats) error
 	return nil
 }
 
-func (im *Importer) createGatedChunk(tx *gorm.DB, chunk []candidate, st *BgmGatedStats) error {
+func (im *Importer) createGatedChunk(tx *gorm.DB, chunk []candidate, st *BgmGatedStats, status int16) error {
 	works := make([]model.CatalogWork, len(chunk))
 	for i, c := range chunk {
 		display := c.row.Name
@@ -229,7 +250,7 @@ func (im *Importer) createGatedChunk(tx *gorm.DB, chunk []candidate, st *BgmGate
 		}
 		works[i] = model.CatalogWork{
 			MediumID: mediumGalgame, OLang: olang, DisplayName: display,
-			ContentRating: cr, Status: model.WorkStatusLive,
+			ContentRating: cr, Status: status,
 			Extra: datatypes.JSON(`{}`), FieldProvenance: datatypes.JSON(`{}`),
 		}
 	}
@@ -266,6 +287,30 @@ func (im *Importer) createGatedChunk(tx *gorm.DB, chunk []candidate, st *BgmGate
 		return err
 	}
 
+	if status == model.WorkStatusQuarantine {
+		var cands []model.CatalogMatchCandidate
+		for i, c := range chunk {
+			if c.collidedWorkID == 0 {
+				continue
+			}
+			a, b := works[i].ID, c.collidedWorkID
+			if b < a {
+				a, b = b, a
+			}
+			cands = append(cands, model.CatalogMatchCandidate{
+				EntityType: model.EntityTypeWork, AID: a, BID: b,
+				Reason: model.CandidateReasonNameNormEqual,
+				Status: model.CandidateStatusPending,
+			})
+		}
+		if len(cands) > 0 {
+			if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&cands).Error; err != nil {
+				return err
+			}
+		}
+		st.Quarantined += len(works)
+	}
+
 	st.WorksCreated += len(works)
 	st.TitlesCreated += len(titles)
 	st.AnchorsCreated += len(refs)
@@ -280,7 +325,8 @@ func logBgmGated(st *BgmGatedStats, dry bool) {
 		"gated_total", st.GatedTotal, "p_and_t", st.PT, "p_and_x", st.PX, "t_and_x", st.TX, "all_three", st.All3,
 		"p_only", st.POnly, "t_only", st.TOnly, "x_only", st.XOnly,
 		"skipped_ascii_xonly", st.SkippedASCIIXOnly,
-		"skipped_title_collision", st.SkippedTitleCollision, "skipped_intra_collision", st.SkippedIntraCollision,
-		"to_create", st.ToCreate, "works_created", st.WorksCreated, "titles_created", st.TitlesCreated,
+		"title_collisions", st.TitleCollisions, "skipped_intra_collision", st.SkippedIntraCollision,
+		"to_create", st.ToCreate, "to_quarantine", st.ToQuarantine, "quarantined", st.Quarantined,
+		"works_created", st.WorksCreated, "titles_created", st.TitlesCreated,
 		"anchors_created", st.AnchorsCreated, "revisions_created", st.RevisionsCreated)
 }

--- a/apps/api/internal/platform/catalog/importer/bgmtype4gated_gate.go
+++ b/apps/api/internal/platform/catalog/importer/bgmtype4gated_gate.go
@@ -44,19 +44,27 @@ func tallySignals(st *BgmGatedStats, p, t, x bool) {
 }
 
 func collide(r poolRow, wt map[string]wtNorm) (BgmGatedCollision, bool) {
-	for _, n := range []string{r.NameNorm, r.NameCNNorm} {
+	n, w, ok := firstCorpusHit(wt, r.NameNorm, r.NameCNNorm)
+	if !ok {
+		return BgmGatedCollision{}, false
+	}
+	return BgmGatedCollision{
+		SubjectID: r.ID, Name: r.Name, NameCN: r.NameCN,
+		CollidedNorm: n, WorkID: w.workID, WorkTitle: w.title,
+	}, true
+}
+
+func firstCorpusHit(wt map[string]wtNorm, norms ...string) (string, wtNorm, bool) {
+	for _, n := range norms {
 		folded, ok := foldedGateKey(n)
 		if !ok {
 			continue
 		}
 		if w, hit := wt[folded]; hit {
-			return BgmGatedCollision{
-				SubjectID: r.ID, Name: r.Name, NameCN: r.NameCN,
-				CollidedNorm: n, WorkID: w.workID, WorkTitle: w.title,
-			}, true
+			return n, w, true
 		}
 	}
-	return BgmGatedCollision{}, false
+	return "", wtNorm{}, false
 }
 
 // foldedGateKey reports the space-folded comparison key for a source norm, and

--- a/apps/api/internal/platform/catalog/importer/bgmtype4gated_load.go
+++ b/apps/api/internal/platform/catalog/importer/bgmtype4gated_load.go
@@ -66,6 +66,7 @@ func (im *Importer) loadExistingWorkTitleNorms() (map[string]wtNorm, error) {
 	}
 	if err := collect(
 		`SELECT title_norm, work_id, title FROM catalog_work_title t
+		 JOIN catalog_work w ON w.id = t.work_id AND w.deleted_at IS NULL
 		 WHERE ` + service.WorkDupeNormEligibleSQL("title_norm") + ` AND ` + editspec.NotSuppressedWorkTitleSQL("t"),
 	); err != nil {
 		return nil, err

--- a/apps/api/internal/platform/catalog/importer/bgmtype4gated_test.go
+++ b/apps/api/internal/platform/catalog/importer/bgmtype4gated_test.go
@@ -3,6 +3,8 @@ package importer
 import (
 	"testing"
 
+	"api/internal/platform/catalog/model"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +43,7 @@ func TestBgmType4GatedWave(t *testing.T) {
 	seedSubject(t, 1009, "家庭用専売乙女ゲーム", "主机专卖乙女", `["Galgame","NS","游戏"]`, "", false)
 
 	seedSubject(t, 1010, "既存衝突タイトル作品", "", `["Galgame","PC","游戏"]`, "", false)
-	seedExistingWork(t, "既存衝突タイトル作品")
+	existing1010 := seedExistingWork(t, "既存衝突タイトル作品")
 
 	seedSubject(t, 1011, "重複同名ゲーム作品", "", `["Galgame","PC","游戏"]`, "", false)
 	seedSubject(t, 1012, "重複同名ゲーム作品", "", `["Galgame","PC","游戏"]`, "", false)
@@ -61,7 +63,8 @@ func TestBgmType4GatedWave(t *testing.T) {
 	assert.Equal(t, 6, dry.SigT, "S5,S6,S10,S11,S12,S14")
 	assert.Equal(t, 1, dry.SigX, "S8")
 	assert.Equal(t, 9, dry.GatedTotal)
-	assert.Equal(t, 1, dry.SkippedTitleCollision, "S10")
+	assert.Equal(t, 1, dry.TitleCollisions, "S10")
+	assert.Equal(t, 1, dry.ToQuarantine, "S10 planned as quarantine")
 	assert.Equal(t, 2, dry.SkippedIntraCollision, "S11+S12")
 	assert.Equal(t, 6, dry.ToCreate)
 	assert.Zero(t, dry.WorksCreated, "dry writes nothing")
@@ -70,15 +73,16 @@ func TestBgmType4GatedWave(t *testing.T) {
 
 	st, err := New(testDB, testDB, Options{}).RunBgmType4Gated(testDB)
 	require.NoError(t, err)
-	assert.Equal(t, 6, st.WorksCreated)
-	assert.Equal(t, 6, st.AnchorsCreated)
-	assert.Equal(t, 6, st.RevisionsCreated)
-	assert.Equal(t, 6, st.TitlesCreated, "5 ja-only works + S14 zh-Hans-only = 6 title rows")
+	assert.Equal(t, 7, st.WorksCreated)
+	assert.Equal(t, 1, st.Quarantined)
+	assert.Equal(t, 7, st.AnchorsCreated)
+	assert.Equal(t, 7, st.RevisionsCreated)
+	assert.Equal(t, 7, st.TitlesCreated, "5 ja-only live + S14 zh-Hans-only + S10 quarantine")
 
 	assert.Equal(t, int64(6), scalarInt(t, `SELECT count(*) FROM catalog_work w
 		JOIN catalog_external_ref e ON e.entity_id=w.id AND e.entity_type=5 AND e.matched_by='rule:bgm-type4-gated' AND e.link_kind=0
 		WHERE w.medium_id=1 AND w.site IS NULL AND w.status=0`))
-	assert.Equal(t, int64(6), scalarInt(t, `SELECT count(*) FROM catalog_revision WHERE entity_type=5 AND action=5 AND revision=1
+	assert.Equal(t, int64(7), scalarInt(t, `SELECT count(*) FROM catalog_revision WHERE entity_type=5 AND action=5 AND revision=1
 		AND entity_id IN (SELECT entity_id FROM catalog_external_ref WHERE matched_by='rule:bgm-type4-gated')`))
 
 	assert.Equal(t, int64(1), scalarInt(t, `SELECT count(*) FROM catalog_work w
@@ -93,7 +97,16 @@ func TestBgmType4GatedWave(t *testing.T) {
 	assert.Equal(t, int64(1), scalarInt(t, `SELECT count(*) FROM catalog_work_title t
 		JOIN catalog_external_ref e ON e.entity_id=t.work_id AND e.external_id='1014' AND e.matched_by='rule:bgm-type4-gated'
 		WHERE t.lang='zh-Hans' AND t.title='中文限定galgame作品'`))
-	assert.Zero(t, scalarInt(t, `SELECT count(*) FROM catalog_external_ref WHERE matched_by='rule:bgm-type4-gated' AND external_id IN ('1009','1010','1011','1012','1013','1003','1004','1007')`))
+	assert.Zero(t, scalarInt(t, `SELECT count(*) FROM catalog_external_ref WHERE matched_by='rule:bgm-type4-gated' AND external_id IN ('1009','1011','1012','1013','1003','1004','1007')`))
+	q1010 := workIDByBgmExt(t, "1010")
+	require.NotZero(t, q1010)
+	assert.Equal(t, model.WorkStatusQuarantine, workStatusOf(t, q1010))
+	a, b := existing1010, q1010
+	if b < a {
+		a, b = b, a
+	}
+	assert.Equal(t, int64(1), countWhere(t, `SELECT count(*) FROM catalog_match_candidate WHERE entity_type = ? AND a_id = ? AND b_id = ? AND reason = ? AND status = ?`,
+		model.EntityTypeWork, a, b, model.CandidateReasonNameNormEqual, model.CandidateStatusPending))
 
 	st2, err := New(testDB, testDB, Options{}).RunBgmType4Gated(testDB)
 	require.NoError(t, err)
@@ -173,16 +186,22 @@ func TestBgmType4GatedFoldedCollisions(t *testing.T) {
 	dry, err := New(testDB, testDB, Options{DryRun: true}).RunBgmType4Gated(testDB)
 	require.NoError(t, err)
 	assert.Equal(t, 3, dry.GatedTotal)
-	assert.Equal(t, 2, dry.SkippedTitleCollision, "display-name-only and space-variant both collide")
+	assert.Equal(t, 2, dry.TitleCollisions, "display-name-only and space-variant both collide")
+	assert.Equal(t, 2, dry.ToQuarantine)
 	assert.Equal(t, 1, dry.ToCreate)
+	assert.Zero(t, dry.WorksCreated)
 
 	st, err := New(testDB, testDB, Options{}).RunBgmType4Gated(testDB)
 	require.NoError(t, err)
-	assert.Equal(t, 1, st.WorksCreated)
+	assert.Equal(t, 3, st.WorksCreated)
+	assert.Equal(t, 2, st.Quarantined)
 	assert.Equal(t, int64(1), scalarInt(t, `SELECT count(*) FROM catalog_external_ref
 		WHERE matched_by='rule:bgm-type4-gated' AND external_id='3003'`))
-	assert.Zero(t, scalarInt(t, `SELECT count(*) FROM catalog_external_ref
+	assert.Equal(t, int64(2), scalarInt(t, `SELECT count(*) FROM catalog_external_ref
 		WHERE matched_by='rule:bgm-type4-gated' AND external_id IN ('3001','3002')`))
+	assert.Equal(t, model.WorkStatusQuarantine, workStatusOf(t, workIDByBgmExt(t, "3001")))
+	assert.Equal(t, model.WorkStatusQuarantine, workStatusOf(t, workIDByBgmExt(t, "3002")))
+	assert.Equal(t, model.WorkStatusLive, workStatusOf(t, workIDByBgmExt(t, "3003")))
 }
 
 func TestBgmType4GatedIntraCollisionFoldsSpace(t *testing.T) {
@@ -211,18 +230,101 @@ func TestBgmType4GatedHanFloorCollisions(t *testing.T) {
 	dry, err := New(testDB, testDB, Options{DryRun: true}).RunBgmType4Gated(testDB)
 	require.NoError(t, err)
 	assert.Equal(t, 2, dry.GatedTotal)
-	assert.Equal(t, 1, dry.SkippedTitleCollision)
+	assert.Equal(t, 1, dry.TitleCollisions)
+	assert.Equal(t, 1, dry.ToQuarantine)
 	assert.Equal(t, 1, dry.ToCreate)
 	require.Len(t, dry.CollisionSamples, 1)
 	assert.Equal(t, int64(3201), dry.CollisionSamples[0].SubjectID)
 
 	st, err := New(testDB, testDB, Options{}).RunBgmType4Gated(testDB)
 	require.NoError(t, err)
-	assert.Equal(t, 1, st.WorksCreated)
+	assert.Equal(t, 2, st.WorksCreated)
+	assert.Equal(t, 1, st.Quarantined)
 	assert.Equal(t, int64(1), scalarInt(t, `SELECT count(*) FROM catalog_external_ref
 		WHERE matched_by='rule:bgm-type4-gated' AND external_id='3202'`))
-	assert.Zero(t, scalarInt(t, `SELECT count(*) FROM catalog_external_ref
+	assert.Equal(t, int64(1), scalarInt(t, `SELECT count(*) FROM catalog_external_ref
 		WHERE matched_by='rule:bgm-type4-gated' AND external_id='3201'`))
+	assert.Equal(t, model.WorkStatusQuarantine, workStatusOf(t, workIDByBgmExt(t, "3201")))
+}
+
+func TestBgmType4GatedSoftDeletedTitleDoesNotCollide(t *testing.T) {
+	clean(t)
+	require.NoError(t, testDB.Exec(`ALTER TABLE games ADD COLUMN IF NOT EXISTS gamename text`).Error)
+
+	dead := seedExistingWork(t, "削除済み衝突タイトル作品")
+	require.NoError(t, testDB.Exec(`UPDATE catalog_work SET deleted_at = now() WHERE id = ?`, dead).Error)
+	seedSubject(t, 3301, "削除済み衝突タイトル作品", "", `["Galgame","PC","游戏"]`, "", false)
+
+	dry, err := New(testDB, testDB, Options{DryRun: true}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Zero(t, dry.TitleCollisions)
+	assert.Zero(t, dry.ToQuarantine)
+	assert.Equal(t, 1, dry.ToCreate)
+
+	st, err := New(testDB, testDB, Options{}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, 1, st.WorksCreated)
+	assert.Zero(t, st.Quarantined)
+	assert.Equal(t, model.WorkStatusLive, workStatusOf(t, workIDByBgmExt(t, "3301")))
+}
+
+func TestBgmType4GatedQuarantineMint(t *testing.T) {
+	clean(t)
+	require.NoError(t, testDB.Exec(`ALTER TABLE games ADD COLUMN IF NOT EXISTS gamename text`).Error)
+
+	existing := seedExistingWork(t, "隔離ミント衝突作品名")
+	seedSubject(t, 3401, "隔離ミント衝突作品名", "", `["Galgame","PC","游戏"]`, "", false)
+	seedSubject(t, 3402, "隔離ミント新規作品名", "", `["Galgame","PC","游戏"]`, "", false)
+
+	dry, err := New(testDB, testDB, Options{DryRun: true}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, 1, dry.ToQuarantine)
+	assert.Equal(t, 1, dry.ToCreate)
+	assert.Zero(t, dry.WorksCreated)
+	assert.Zero(t, scalarInt(t, `SELECT count(*) FROM catalog_external_ref WHERE matched_by='rule:bgm-type4-gated'`))
+
+	st, err := New(testDB, testDB, Options{}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, 2, st.WorksCreated)
+	assert.Equal(t, 1, st.Quarantined)
+
+	qID := workIDByBgmExt(t, "3401")
+	require.NotZero(t, qID)
+	assert.Equal(t, model.WorkStatusQuarantine, workStatusOf(t, qID))
+	assert.Equal(t, int64(1), countWhere(t, `SELECT count(*) FROM catalog_external_ref
+		WHERE entity_type = ? AND entity_id = ? AND source_id = ? AND external_id = ? AND link_kind = ?`,
+		model.EntityTypeWork, qID, bangumiSource, "3401", model.LinkKindExact))
+	a, b := existing, qID
+	if b < a {
+		a, b = b, a
+	}
+	assert.Equal(t, int64(1), countWhere(t, `SELECT count(*) FROM catalog_match_candidate
+		WHERE entity_type = ? AND a_id = ? AND b_id = ? AND reason = ? AND status = ?`,
+		model.EntityTypeWork, a, b, model.CandidateReasonNameNormEqual, model.CandidateStatusPending))
+	assert.Equal(t, model.WorkStatusLive, workStatusOf(t, workIDByBgmExt(t, "3402")))
+}
+
+func TestBgmType4GatedLimitSpendsLiveFirst(t *testing.T) {
+	clean(t)
+	require.NoError(t, testDB.Exec(`ALTER TABLE games ADD COLUMN IF NOT EXISTS gamename text`).Error)
+
+	_ = seedExistingWork(t, "予算衝突タイトル作品")
+	seedSubject(t, 3501, "予算衝突タイトル作品", "", `["Galgame","PC","游戏"]`, "", false)
+	seedSubject(t, 3502, "予算公開タイトル作品", "", `["Galgame","PC","游戏"]`, "", false)
+
+	dry, err := New(testDB, testDB, Options{DryRun: true, Limit: 1}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, 1, dry.ToCreate)
+	assert.Equal(t, 1, dry.ToQuarantine)
+
+	st, err := New(testDB, testDB, Options{Limit: 1}).RunBgmType4Gated(testDB)
+	require.NoError(t, err)
+	assert.Equal(t, 1, st.WorksCreated)
+	assert.Zero(t, st.Quarantined)
+	assert.Equal(t, int64(1), scalarInt(t, `SELECT count(*) FROM catalog_external_ref
+		WHERE matched_by='rule:bgm-type4-gated' AND external_id='3502'`))
+	assert.Zero(t, scalarInt(t, `SELECT count(*) FROM catalog_external_ref
+		WHERE matched_by='rule:bgm-type4-gated' AND external_id='3501'`))
 }
 
 func seedDisplayOnlyWork(t *testing.T, displayName string) {
@@ -231,10 +333,26 @@ func seedDisplayOnlyWork(t *testing.T, displayName string) {
 		VALUES (1,'ja',?,0,0,'{}','{}',false)`, displayName).Error)
 }
 
-func seedExistingWork(t *testing.T, title string) {
+func seedExistingWork(t *testing.T, title string) int64 {
 	t.Helper()
 	var wid int64
 	require.NoError(t, testDB.Raw(`INSERT INTO catalog_work (medium_id, olang, display_name, content_rating, status, extra, field_provenance, display_nsfw)
 		VALUES (1,'ja',?,0,0,'{}','{}',false) RETURNING id`, title).Scan(&wid).Error)
 	require.NoError(t, testDB.Exec(`INSERT INTO catalog_work_title (work_id, lang, title, kind, provenance) VALUES (?,'ja',?,0,0)`, wid, title).Error)
+	return wid
+}
+
+func workIDByBgmExt(t *testing.T, ext string) int64 {
+	t.Helper()
+	var id int64
+	require.NoError(t, testDB.Raw(`SELECT entity_id FROM catalog_external_ref
+		WHERE matched_by='rule:bgm-type4-gated' AND external_id=?`, ext).Scan(&id).Error)
+	return id
+}
+
+func workStatusOf(t *testing.T, id int64) int16 {
+	t.Helper()
+	var status int16
+	require.NoError(t, testDB.Raw(`SELECT status FROM catalog_work WHERE id = ?`, id).Scan(&status).Error)
+	return status
 }

--- a/apps/api/internal/platform/catalog/importer/vndbworks.go
+++ b/apps/api/internal/platform/catalog/importer/vndbworks.go
@@ -5,12 +5,14 @@ import (
 
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
-	ruleVNDBWork    = "rule:vndb-work-import"
-	vndbWorksChunk  = 500
-	vndbLangEnglish = "en"
+	ruleVNDBWork        = "rule:vndb-work-import"
+	vndbWorksChunk      = 500
+	vndbLangEnglish     = "en"
+	vndbCollisionSample = 20
 )
 
 const (
@@ -19,11 +21,19 @@ const (
 )
 
 type VNDBWorkPlan struct {
-	VID     string
-	OLang   string
-	Title   string
-	ENTitle string
-	R18     bool
+	VID            string
+	OLang          string
+	Title          string
+	ENTitle        string
+	R18            bool
+	CollidedWorkID int64
+}
+
+type VNDBWorkCollision struct {
+	VID       string
+	Title     string
+	WorkID    int64
+	WorkTitle string
 }
 
 type VNDBWorksStats struct {
@@ -33,6 +43,9 @@ type VNDBWorksStats struct {
 	Planned             int
 	PlannedR18          int
 	CappedByLimit       int
+	TitleCollisions     int
+	ToQuarantine        int
+	Quarantined         int
 
 	WorksCreated     int
 	TitlesCreated    int
@@ -40,16 +53,19 @@ type VNDBWorksStats struct {
 	RevisionsCreated int
 	Errors           int
 
-	Plans []VNDBWorkPlan
+	Plans            []VNDBWorkPlan
+	CollisionSamples []VNDBWorkCollision
 }
 
 type vndbWorkRow struct {
-	VID       string `gorm:"column:vid"`
-	OLang     string `gorm:"column:olang"`
-	Devstatus int16  `gorm:"column:devstatus"`
-	Title     string `gorm:"column:title"`
-	ENTitle   string `gorm:"column:en_title"`
-	R18       bool   `gorm:"column:r18"`
+	VID         string `gorm:"column:vid"`
+	OLang       string `gorm:"column:olang"`
+	Devstatus   int16  `gorm:"column:devstatus"`
+	Title       string `gorm:"column:title"`
+	ENTitle     string `gorm:"column:en_title"`
+	TitleNorm   string `gorm:"column:title_norm"`
+	ENTitleNorm string `gorm:"column:en_title_norm"`
+	R18         bool   `gorm:"column:r18"`
 }
 
 // buildVNDBWorkPoolQuery lists every VN that no catalog_external_ref points at,
@@ -68,6 +84,8 @@ func buildVNDBWorkPoolQuery() string {
 	return `SELECT v.id AS vid, v.olang AS olang, v.devstatus AS devstatus,
 			coalesce(t.title, '') AS title,
 			coalesce(en.title, '') AS en_title,
+			coalesce(lower(normalize(t.title, NFKC)), '') AS title_norm,
+			coalesce(lower(normalize(en.title, NFKC)), '') AS en_title_norm,
 			EXISTS (SELECT 1 FROM src_vndb.releases_vn rv
 				JOIN src_vndb.releases r ON r.id = rv.id
 				WHERE rv.vid = v.id AND r.patch = false
@@ -82,6 +100,11 @@ func buildVNDBWorkPoolQuery() string {
 
 func (im *Importer) RunVNDBWorks() (VNDBWorksStats, error) {
 	var st VNDBWorksStats
+
+	wt, err := im.loadExistingWorkTitleNorms()
+	if err != nil {
+		return st, err
+	}
 
 	var pool []vndbWorkRow
 	if err := im.catalog.Raw(buildVNDBWorkPoolQuery(), model.EntityTypeWork, vndbSource).Scan(&pool).Error; err != nil {
@@ -102,6 +125,15 @@ func (im *Importer) RunVNDBWorks() (VNDBWorksStats, error) {
 		if r.OLang != vndbLangEnglish && r.ENTitle != "" {
 			p.ENTitle = r.ENTitle
 		}
+		if _, w, ok := firstCorpusHit(wt, r.TitleNorm, r.ENTitleNorm); ok {
+			p.CollidedWorkID = w.workID
+			st.TitleCollisions++
+			if len(st.CollisionSamples) < vndbCollisionSample {
+				st.CollisionSamples = append(st.CollisionSamples, VNDBWorkCollision{
+					VID: r.VID, Title: r.Title, WorkID: w.workID, WorkTitle: w.title,
+				})
+			}
+		}
 		st.Plans = append(st.Plans, p)
 	}
 	if im.limit > 0 && im.limit < len(st.Plans) {
@@ -112,6 +144,9 @@ func (im *Importer) RunVNDBWorks() (VNDBWorksStats, error) {
 	for _, p := range st.Plans {
 		if p.R18 {
 			st.PlannedR18++
+		}
+		if p.CollidedWorkID != 0 {
+			st.ToQuarantine++
 		}
 	}
 
@@ -156,9 +191,13 @@ func (im *Importer) createVNDBWorkChunk(tx *gorm.DB, chunk []VNDBWorkPlan, st *V
 		if p.R18 {
 			cr = model.ContentRatingR18
 		}
+		status := model.WorkStatusLive
+		if p.CollidedWorkID != 0 {
+			status = model.WorkStatusQuarantine
+		}
 		works[i] = model.CatalogWork{
 			MediumID: mediumGalgame, OLang: p.OLang, DisplayName: p.Title,
-			ContentRating: cr, Status: model.WorkStatusLive,
+			ContentRating: cr, Status: status,
 			Extra: datatypes.JSON(`{}`), FieldProvenance: datatypes.JSON(`{}`),
 		}
 	}
@@ -197,6 +236,28 @@ func (im *Importer) createVNDBWorkChunk(tx *gorm.DB, chunk []VNDBWorkPlan, st *V
 	}
 	if err := im.batchRefsRevs(tx, refs, revs); err != nil {
 		return err
+	}
+
+	var cands []model.CatalogMatchCandidate
+	for i, p := range chunk {
+		if p.CollidedWorkID == 0 {
+			continue
+		}
+		a, b := works[i].ID, p.CollidedWorkID
+		if b < a {
+			a, b = b, a
+		}
+		cands = append(cands, model.CatalogMatchCandidate{
+			EntityType: model.EntityTypeWork, AID: a, BID: b,
+			Reason: model.CandidateReasonNameNormEqual,
+			Status: model.CandidateStatusPending,
+		})
+		st.Quarantined++
+	}
+	if len(cands) > 0 {
+		if err := tx.Clauses(clause.OnConflict{DoNothing: true}).Create(&cands).Error; err != nil {
+			return err
+		}
 	}
 
 	st.WorksCreated += len(works)

--- a/apps/api/internal/platform/catalog/importer/vndbworks_test.go
+++ b/apps/api/internal/platform/catalog/importer/vndbworks_test.go
@@ -241,3 +241,56 @@ func planVIDs(st VNDBWorksStats) []string {
 	}
 	return out
 }
+
+func TestVNDBWorksMintQuarantineOnTitleCollision(t *testing.T) {
+	clean(t)
+	cleanReleases(t)
+	cleanVNPool(t)
+
+	liveID := seedExistingWork(t, "衝突する既存タイトル作品")
+	deadID := seedExistingWork(t, "削除済みタイトル作品")
+	require.NoError(t, testDB.Exec(`UPDATE catalog_work SET deleted_at = now() WHERE id = ?`, deadID).Error)
+
+	insVN(t, "v200", "ja", 0)
+	insVNTitle(t, "v200", "ja", true, "衝突する既存タイトル作品", "")
+	insVN(t, "v201", "ja", 0)
+	insVNTitle(t, "v201", "ja", true, "削除済みタイトル作品", "")
+	insVN(t, "v202", "ja", 0)
+	insVNTitle(t, "v202", "ja", true, "衝突しない新規タイトル作品", "")
+
+	dry, err := New(testDB, nil, Options{Source: "vndb", DryRun: true}).RunVNDBWorks()
+	require.NoError(t, err)
+	assert.Equal(t, 1, dry.TitleCollisions)
+	assert.Equal(t, 1, dry.ToQuarantine)
+	assert.Equal(t, 3, dry.Planned)
+	assert.Equal(t, 3, dry.WorksCreated)
+	assert.Zero(t, countWhere(t, `SELECT count(*) FROM catalog_external_ref WHERE matched_by = ?`, ruleVNDBWork))
+
+	st, err := New(testDB, nil, Options{Source: "vndb"}).RunVNDBWorks()
+	require.NoError(t, err)
+	assert.Equal(t, 3, st.WorksCreated)
+	assert.Equal(t, 1, st.Quarantined)
+
+	workOf := func(vid string) int64 {
+		t.Helper()
+		var id int64
+		require.NoError(t, testDB.Raw(`SELECT entity_id FROM catalog_external_ref
+			WHERE entity_type = ? AND source_id = ? AND external_id = ? AND link_kind = ?`,
+			model.EntityTypeWork, vndbSource, vid, model.LinkKindExact).Scan(&id).Error)
+		return id
+	}
+
+	qID := workOf("v200")
+	require.NotZero(t, qID)
+	assert.Equal(t, model.WorkStatusQuarantine, workStatusOf(t, qID))
+	a, b := liveID, qID
+	if b < a {
+		a, b = b, a
+	}
+	assert.Equal(t, int64(1), countWhere(t, `SELECT count(*) FROM catalog_match_candidate
+		WHERE entity_type = ? AND a_id = ? AND b_id = ? AND reason = ? AND status = ?`,
+		model.EntityTypeWork, a, b, model.CandidateReasonNameNormEqual, model.CandidateStatusPending))
+
+	assert.Equal(t, model.WorkStatusLive, workStatusOf(t, workOf("v201")))
+	assert.Equal(t, model.WorkStatusLive, workStatusOf(t, workOf("v202")))
+}

--- a/apps/api/internal/platform/catalog/model/constants.go
+++ b/apps/api/internal/platform/catalog/model/constants.go
@@ -156,9 +156,10 @@ const (
 )
 
 const (
-	WorkStatusLive   int16 = 0
-	WorkStatusStub   int16 = 1
-	WorkStatusMerged int16 = 2
+	WorkStatusLive       int16 = 0
+	WorkStatusStub       int16 = 1
+	WorkStatusMerged     int16 = 2
+	WorkStatusQuarantine int16 = 3
 )
 
 const (

--- a/apps/api/internal/platform/catalog/model/constants_test.go
+++ b/apps/api/internal/platform/catalog/model/constants_test.go
@@ -31,7 +31,7 @@ func TestConstantGroupsHaveUniqueValues(t *testing.T) {
 		},
 		"relation_domain": {RelationDomainWork, RelationDomainEntity},
 		"content_rating":  {ContentRatingAllAges, ContentRatingSensitive, ContentRatingR18},
-		"work_status":     {WorkStatusLive, WorkStatusStub, WorkStatusMerged},
+		"work_status":     {WorkStatusLive, WorkStatusStub, WorkStatusMerged, WorkStatusQuarantine},
 		"work_title_kind": {
 			WorkTitleKindOfficial, WorkTitleKindAlias,
 			WorkTitleKindAbbreviation, WorkTitleKindSearchHint,
@@ -47,7 +47,7 @@ func TestConstantGroupsHaveUniqueValues(t *testing.T) {
 		},
 		"candidate_status": {
 			CandidateStatusPending, CandidateStatusAccepted,
-			CandidateStatusRejected, CandidateStatusDeferred,
+			CandidateStatusRejected, CandidateStatusDeferred, CandidateStatusNeedsManual,
 		},
 		"proposal_status": {
 			ProposalStatusOpen, ProposalStatusApproved, ProposalStatusExecuted,
@@ -135,4 +135,11 @@ func TestEntityTypeValuesArePinned(t *testing.T) {
 	assert.Equal(t, int16(6), EntityTypeRelease)
 	assert.Equal(t, int16(7), EntityTypeTag)
 	assert.Equal(t, int16(8), EntityTypeEngine)
+}
+
+func TestWorkStatusValuesArePinned(t *testing.T) {
+	assert.Equal(t, int16(0), WorkStatusLive)
+	assert.Equal(t, int16(1), WorkStatusStub)
+	assert.Equal(t, int16(2), WorkStatusMerged)
+	assert.Equal(t, int16(3), WorkStatusQuarantine)
 }

--- a/apps/api/internal/platform/catalog/service/admin_queue.go
+++ b/apps/api/internal/platform/catalog/service/admin_queue.go
@@ -44,12 +44,23 @@ type EntitySummary struct {
 	DisplayName string `json:"display_name"`
 	CreditCount *int64 `json:"credit_count,omitempty"`
 	SourceID    *int16 `json:"source_id,omitempty"`
+	WorkStatus  *int16 `json:"work_status,omitempty"`
 }
 
 func entitySummary(db *gorm.DB, entityType int16, id int64) EntitySummary {
 	table, ok := entityTableName(entityType)
 	if !ok {
 		return EntitySummary{ID: id}
+	}
+	if entityType == model.EntityTypeWork {
+		var row struct {
+			DisplayName string
+			Status      int16
+		}
+		if res := db.Raw(`SELECT display_name, status FROM catalog_work WHERE id = ?`, id).Scan(&row); res.Error != nil || res.RowsAffected == 0 {
+			return EntitySummary{ID: id}
+		}
+		return EntitySummary{ID: id, DisplayName: row.DisplayName, WorkStatus: &row.Status}
 	}
 	column := "display_name"
 	if entityType == model.EntityTypeCreditName {
@@ -171,6 +182,7 @@ type CandidateDecision struct {
 type CandidateOutcome struct {
 	Proposal *model.CatalogMergeProposal
 	Link     *PersonLinkResult
+	Released []int64
 }
 
 func (s *AdminQueueService) DecideCandidate(ctx context.Context, d CandidateDecision) (*CandidateOutcome, error) {
@@ -196,6 +208,9 @@ func (s *AdminQueueService) DecideCandidate(ctx context.Context, d CandidateDeci
 
 	if d.Action == "accept" && d.EntityType == model.EntityTypeCreditName {
 		return s.acceptAsPersonLink(ctx, d)
+	}
+	if d.Action == "reject" && d.EntityType == model.EntityTypeWork {
+		return s.rejectWorkCandidate(ctx, d)
 	}
 
 	status := model.CandidateStatusRejected

--- a/apps/api/internal/platform/catalog/service/admin_queue_release.go
+++ b/apps/api/internal/platform/catalog/service/admin_queue_release.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"api/internal/platform/catalog/model"
+
+	"gorm.io/gorm"
+)
+
+func (s *AdminQueueService) rejectWorkCandidate(ctx context.Context, d CandidateDecision) (*CandidateOutcome, error) {
+	var released []int64
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		rows, err := s.flipCandidate(tx, d, model.CandidateStatusRejected)
+		if err != nil {
+			return err
+		}
+		if rows != 1 {
+			return fmt.Errorf("%w: candidate decided concurrently", ErrProposalState)
+		}
+		out, err := releaseQuarantinedPair(tx, d.AID, d.BID, d.DecidedBy, d.Note)
+		if err != nil {
+			return err
+		}
+		released = out
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &CandidateOutcome{Released: released}, nil
+}
+
+func (s *AdminQueueService) ReleaseWork(ctx context.Context, workID, actor int64, note string) error {
+	var row struct {
+		ID        int64
+		Status    int16
+		DeletedAt *time.Time `gorm:"column:deleted_at"`
+	}
+	if err := s.db.WithContext(ctx).Raw(
+		`SELECT id, status, deleted_at FROM catalog_work WHERE id = ?`, workID,
+	).Scan(&row).Error; err != nil {
+		return err
+	}
+	if row.ID == 0 {
+		return fmt.Errorf("%w: work %d", ErrNotFound, workID)
+	}
+	if row.DeletedAt != nil || row.Status != model.WorkStatusQuarantine {
+		return fmt.Errorf("%w: work %d is not quarantined", ErrProposalState, workID)
+	}
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return releaseWorkTx(tx, workID, actor, note)
+	})
+}
+
+func releaseQuarantinedPair(tx *gorm.DB, aID, bID, actor int64, note string) ([]int64, error) {
+	var released []int64
+	for _, id := range []int64{aID, bID} {
+		ok, err := shouldReleaseQuarantine(tx, id)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if err := releaseWorkTx(tx, id, actor, note); err != nil {
+			return nil, err
+		}
+		released = append(released, id)
+	}
+	return released, nil
+}
+
+func shouldReleaseQuarantine(tx *gorm.DB, id int64) (bool, error) {
+	var row struct {
+		ID     int64
+		Status int16
+	}
+	if err := tx.Raw(
+		`SELECT id, status FROM catalog_work WHERE id = ? AND deleted_at IS NULL`, id,
+	).Scan(&row).Error; err != nil {
+		return false, err
+	}
+	if row.ID == 0 || row.Status != model.WorkStatusQuarantine {
+		return false, nil
+	}
+	var open int64
+	if err := tx.Raw(
+		`SELECT count(*) FROM catalog_match_candidate
+		 WHERE entity_type = ? AND status IN ? AND (a_id = ? OR b_id = ?)`,
+		model.EntityTypeWork, decidableCandidateStatuses, id, id,
+	).Scan(&open).Error; err != nil {
+		return false, err
+	}
+	return open == 0, nil
+}
+
+func releaseWorkTx(tx *gorm.DB, id, actor int64, note string) error {
+	res := tx.Exec(
+		`UPDATE catalog_work SET status = ?, updated_at = now() WHERE id = ? AND status = ? AND deleted_at IS NULL`,
+		model.WorkStatusLive, id, model.WorkStatusQuarantine,
+	)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("%w: work %d is not quarantined", ErrProposalState, id)
+	}
+	snap, err := takeSnapshot(tx, model.EntityTypeWork, id)
+	if err != nil {
+		return fmt.Errorf("snapshot work %d: %w", id, err)
+	}
+	changed, err := marshalChangedFields(map[string]any{"status": model.WorkStatusLive})
+	if err != nil {
+		return err
+	}
+	actorID := actor
+	return writeRevision(tx, model.EntityTypeWork, id, model.RevisionActionUpdated, snap, changed, &actorID, note)
+}

--- a/apps/api/internal/platform/catalog/service/admin_queue_test.go
+++ b/apps/api/internal/platform/catalog/service/admin_queue_test.go
@@ -239,3 +239,119 @@ func TestRejectRefRefusesCuratedLink(t *testing.T) {
 	require.NoError(t, testDB.Where("entity_id = ? AND source_id = ?", person.ID, 2).First(&rej).Error)
 	assert.Equal(t, "wrong person", rej.Reason)
 }
+
+func fileWorkCandidate(t *testing.T, a, b int64, status int16) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&model.CatalogMatchCandidate{
+		EntityType: model.EntityTypeWork, AID: min(a, b), BID: max(a, b),
+		Reason: model.CandidateReasonNameNormEqual, Status: status,
+	}).Error)
+}
+
+func TestDecideCandidateRejectReleasesQuarantine(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+
+	live := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "公開")
+	q := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusQuarantine, "隔離")
+	fileWorkCandidate(t, live.ID, q.ID, model.CandidateStatusPending)
+
+	et := model.EntityTypeWork
+	items, _, err := testQueues.ListCandidates(ctx, CandidateFilters{EntityType: &et})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	if items[0].A.ID == q.ID {
+		require.NotNil(t, items[0].A.WorkStatus)
+		assert.Equal(t, model.WorkStatusQuarantine, *items[0].A.WorkStatus)
+	} else {
+		require.NotNil(t, items[0].B.WorkStatus)
+		assert.Equal(t, model.WorkStatusQuarantine, *items[0].B.WorkStatus)
+	}
+
+	outcome, err := testQueues.DecideCandidate(ctx, CandidateDecision{
+		EntityType: model.EntityTypeWork, AID: min(live.ID, q.ID), BID: max(live.ID, q.ID),
+		Action: "reject", DecidedBy: 9,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []int64{q.ID}, outcome.Released)
+
+	var got model.CatalogWork
+	require.NoError(t, testDB.First(&got, q.ID).Error)
+	assert.Equal(t, model.WorkStatusLive, got.Status)
+
+	var n int64
+	require.NoError(t, testDB.Model(&model.CatalogRevision{}).
+		Where("entity_type = ? AND entity_id = ? AND action = ?",
+			model.EntityTypeWork, q.ID, model.RevisionActionUpdated).Count(&n).Error)
+	assert.Equal(t, int64(1), n)
+}
+
+func TestDecideCandidateRejectHoldsUntilLastOpenCandidate(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+
+	q := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusQuarantine, "隔離")
+	live1 := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "公開1")
+	live2 := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "公開2")
+	fileWorkCandidate(t, q.ID, live1.ID, model.CandidateStatusPending)
+	fileWorkCandidate(t, q.ID, live2.ID, model.CandidateStatusNeedsManual)
+
+	first, err := testQueues.DecideCandidate(ctx, CandidateDecision{
+		EntityType: model.EntityTypeWork, AID: min(q.ID, live1.ID), BID: max(q.ID, live1.ID),
+		Action: "reject", DecidedBy: 9,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, first.Released)
+	var still model.CatalogWork
+	require.NoError(t, testDB.First(&still, q.ID).Error)
+	assert.Equal(t, model.WorkStatusQuarantine, still.Status)
+
+	second, err := testQueues.DecideCandidate(ctx, CandidateDecision{
+		EntityType: model.EntityTypeWork, AID: min(q.ID, live2.ID), BID: max(q.ID, live2.ID),
+		Action: "reject", DecidedBy: 9,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []int64{q.ID}, second.Released)
+	var got model.CatalogWork
+	require.NoError(t, testDB.First(&got, q.ID).Error)
+	assert.Equal(t, model.WorkStatusLive, got.Status)
+}
+
+func TestReleaseWork(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+
+	live := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "公開")
+	err := testQueues.ReleaseWork(ctx, live.ID, 9, "no")
+	require.ErrorIs(t, err, ErrProposalState)
+
+	q := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusQuarantine, "隔離")
+	require.NoError(t, testQueues.ReleaseWork(ctx, q.ID, 9, "escape"))
+	var got model.CatalogWork
+	require.NoError(t, testDB.First(&got, q.ID).Error)
+	assert.Equal(t, model.WorkStatusLive, got.Status)
+
+	err = testQueues.ReleaseWork(ctx, 999999, 9, "")
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestDecideCandidateAcceptDoesNotReleaseQuarantine(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+
+	live := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "公開")
+	q := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusQuarantine, "隔離")
+	fileWorkCandidate(t, live.ID, q.ID, model.CandidateStatusPending)
+
+	outcome, err := testQueues.DecideCandidate(ctx, CandidateDecision{
+		EntityType: model.EntityTypeWork, AID: min(live.ID, q.ID), BID: max(live.ID, q.ID),
+		Action: "accept", SourceID: q.ID, TargetID: live.ID, Note: "same work", DecidedBy: 9,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, outcome.Proposal)
+	assert.Empty(t, outcome.Released)
+
+	var got model.CatalogWork
+	require.NoError(t, testDB.First(&got, q.ID).Error)
+	assert.Equal(t, model.WorkStatusQuarantine, got.Status)
+}

--- a/apps/api/internal/platform/catalog/service/merge_execute.go
+++ b/apps/api/internal/platform/catalog/service/merge_execute.go
@@ -86,6 +86,19 @@ func (s *MergeService) ExecuteMerge(ctx context.Context, proposalID int64, execu
 		if err := writeRevision(tx, et, src, model.RevisionActionMergedSource, sourceSnap, nil, executedBy, note); err != nil {
 			return err
 		}
+		if et == model.EntityTypeWork {
+			res := tx.Exec(`UPDATE catalog_work SET status = ? WHERE id = ? AND status = ?`,
+				model.WorkStatusLive, dst, model.WorkStatusQuarantine)
+			if res.Error != nil {
+				return res.Error
+			}
+			if res.RowsAffected > 0 {
+				if changed == nil {
+					changed = map[string]any{}
+				}
+				changed["status"] = model.WorkStatusLive
+			}
+		}
 		targetSnap, err := takeSnapshot(tx, et, dst)
 		if err != nil {
 			return fmt.Errorf("snapshot target: %w", err)

--- a/apps/api/internal/platform/catalog/service/merge_work_facets_test.go
+++ b/apps/api/internal/platform/catalog/service/merge_work_facets_test.go
@@ -257,3 +257,14 @@ func TestMergeWorkAxisKeepsHumanRoster(t *testing.T) {
 	assert.Equal(t, model.WorkCharacterKindUnknown, edge.Kind, "a human 0 survives the kind upgrade")
 	assert.EqualValues(t, model.SpoilerNone, edge.Spoiler, "a human 0 survives GREATEST")
 }
+
+func TestExecuteMergeReleasesQuarantinedTarget(t *testing.T) {
+	cleanTables(t)
+	target := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusQuarantine, "隔離先")
+	source := createWork(t, "隔離元")
+	executeMerge(t, model.EntityTypeWork, source.ID, target.ID, "quarantine target")
+
+	var got model.CatalogWork
+	require.NoError(t, testDB.First(&got, target.ID).Error)
+	assert.Equal(t, model.WorkStatusLive, got.Status)
+}

--- a/apps/api/internal/platform/catalog/service/public_quarantine_test.go
+++ b/apps/api/internal/platform/catalog/service/public_quarantine_test.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"testing"
+
+	"api/internal/platform/catalog/dto"
+	"api/internal/platform/catalog/model"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicQuarantineInvisibleOnReadFaces(t *testing.T) {
+	cleanTables(t)
+	ctx := t.Context()
+	svc := newPublicSvc()
+
+	live := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "公開側")
+	q := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusQuarantine, "隔離側")
+
+	labelID := addWorkLabel(t, live.ID, "共有ブランド", model.LabelKindGameBrand, model.WorkLabelKindBrand)
+	require.NoError(t, testDB.Create(&model.CatalogWorkLabel{
+		WorkID: q.ID, LabelID: labelID, Kind: model.WorkLabelKindBrand,
+	}).Error)
+
+	name := createCreditName(t, nil, "共有名義")
+	roleID := seededRoleID(t)
+	createCredit(t, live.ID, name.ID, roleID, nil)
+	createCredit(t, q.ID, name.ID, roleID, nil)
+
+	ch := createCharacter(t, "共有キャラ")
+	createWorkCharacter(t, live.ID, ch.ID, model.WorkCharacterKindMain, model.SpoilerNone)
+	createWorkCharacter(t, q.ID, ch.ID, model.WorkCharacterKindMain, model.SpoilerNone)
+
+	var relTypeID int64
+	require.NoError(t, testDB.Raw(`SELECT id FROM catalog_relation_type WHERE id <> ? ORDER BY id LIMIT 1`,
+		seriesRelationTypeID).Scan(&relTypeID).Error)
+	if relTypeID != 0 {
+		require.NoError(t, testDB.Create(&model.CatalogWorkRelation{
+			AWorkID: live.ID, BWorkID: q.ID, RelationTypeID: relTypeID,
+		}).Error)
+	}
+	createSameSeriesEdge(t, live.ID, q.ID)
+
+	addExternalRef(t, model.EntityTypeWork, live.ID, srcVNDB, "v9001", model.LinkKindExact)
+	addExternalRef(t, model.EntityTypeWork, q.ID, srcVNDB, "v9002", model.LinkKindExact)
+
+	page, err := svc.WorksList(ctx, WorksListFilter{Sort: "id"}, "", 50)
+	require.NoError(t, err)
+	got := make([]int64, 0, len(page.Items))
+	for _, it := range page.Items {
+		got = append(got, it.ID)
+	}
+	assert.Equal(t, []int64{live.ID}, got)
+
+	_, found, err := svc.WorkDetail(ctx, q.ID, PublicInclude{Relations: true}, true, 0, PublicFields{})
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	label, ok, err := svc.Label(ctx, labelID, true, true, 50, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	labelIDs := make([]int64, 0, len(label.Works))
+	for _, w := range label.Works {
+		labelIDs = append(labelIDs, w.Work.ID)
+	}
+	assert.Equal(t, []int64{live.ID}, labelIDs)
+
+	nm, ok, err := svc.Name(ctx, name.ID, true, true, 50, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	creditIDs := make([]int64, 0, len(nm.Credits))
+	for _, c := range nm.Credits {
+		creditIDs = append(creditIDs, c.Work.ID)
+	}
+	assert.Equal(t, []int64{live.ID}, creditIDs)
+
+	charRec, ok, err := svc.Character(ctx, ch.ID, true, true, 0, 50, 0)
+	require.NoError(t, err)
+	require.True(t, ok)
+	appearIDs := make([]int64, 0, len(charRec.Works))
+	for _, w := range charRec.Works {
+		appearIDs = append(appearIDs, w.Work.ID)
+	}
+	assert.Equal(t, []int64{live.ID}, appearIDs)
+
+	detail, found, err := svc.WorkDetail(ctx, live.ID, PublicInclude{Relations: true}, true, 0, PublicFields{})
+	require.NoError(t, err)
+	require.True(t, found)
+	for _, r := range detail.Relations {
+		assert.NotEqual(t, q.ID, r.Work.ID)
+	}
+	for _, sb := range detail.SeriesSiblings {
+		assert.NotEqual(t, q.ID, sb.ID)
+	}
+
+	_, found, err = svc.Lookup(ctx, "vndb", "v9002", true)
+	require.NoError(t, err)
+	assert.False(t, found)
+	batch, err := svc.LookupBatch(ctx, []dto.PublicLookupPair{{Source: "vndb", ExternalID: "v9002"}}, true)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	assert.Nil(t, batch[0].Work)
+
+	settleWorks(t)
+	changes, err := svc.Changes(ctx, "", 500)
+	require.NoError(t, err)
+	var qGone *bool
+	for _, it := range changes.Items {
+		if it.ID == q.ID {
+			g := it.Gone
+			qGone = &g
+		}
+	}
+	require.NotNil(t, qGone)
+	assert.True(t, *qGone)
+}

--- a/apps/api/internal/platform/catalog/service/public_service.go
+++ b/apps/api/internal/platform/catalog/service/public_service.go
@@ -1086,7 +1086,7 @@ func (s *PublicService) loadWorkBriefs(ctx context.Context, ids []int64, nsfw bo
 		SELECT w.id, w.medium_id, w.display_name, w.content_rating, w.status, w.site, w.product_work_id, w.claim_state,
 		       w.display_nsfw
 		FROM catalog_work w
-		WHERE w.id IN ? AND w.deleted_at IS NULL`, ids).Scan(&rows).Error; err != nil {
+		WHERE w.id IN ? AND w.deleted_at IS NULL AND w.status = ?`, ids, model.WorkStatusLive).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	out := make(map[int64]*dto.PublicWorkBrief, len(rows))

--- a/apps/api/internal/platform/catalog/service/read_relations.go
+++ b/apps/api/internal/platform/catalog/service/read_relations.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+
+	"api/internal/platform/catalog/model"
 )
 
 type WorkRelationRow struct {
@@ -24,7 +26,7 @@ func (s *ReadService) loadWorkRelations(ctx context.Context, workID int64) ([]Wo
 		       w.medium_id, w.content_rating, w.status, w.site, w.product_work_id, w.claim_state
 		FROM catalog_work_relation r
 		JOIN catalog_relation_type rt ON rt.id = r.relation_type_id
-		JOIN catalog_work w ON w.id = r.b_work_id AND w.deleted_at IS NULL
+		JOIN catalog_work w ON w.id = r.b_work_id AND w.deleted_at IS NULL AND w.status = ?
 		WHERE r.a_work_id = ?
 		UNION ALL
 		SELECT rt.key,
@@ -33,9 +35,9 @@ func (s *ReadService) loadWorkRelations(ctx context.Context, workID int64) ([]Wo
 		       w.medium_id, w.content_rating, w.status, w.site, w.product_work_id, w.claim_state
 		FROM catalog_work_relation r
 		JOIN catalog_relation_type rt ON rt.id = r.relation_type_id
-		JOIN catalog_work w ON w.id = r.a_work_id AND w.deleted_at IS NULL
+		JOIN catalog_work w ON w.id = r.a_work_id AND w.deleted_at IS NULL AND w.status = ?
 		WHERE r.b_work_id = ?
-		ORDER BY key, other_id`, workID, workID).Scan(&rows).Error; err != nil {
+		ORDER BY key, other_id`, model.WorkStatusLive, workID, model.WorkStatusLive, workID).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
@@ -76,9 +78,9 @@ func (s *ReadService) loadSeriesSiblings(ctx context.Context, workID int64) ([]S
 		)
 		SELECT w.id AS work_id, w.display_name, w.medium_id, w.content_rating, w.status, w.site, w.product_work_id, w.claim_state
 		FROM catalog_work w
-		WHERE w.id IN (SELECT node FROM reach WHERE node <> ?) AND w.deleted_at IS NULL
+		WHERE w.id IN (SELECT node FROM reach WHERE node <> ?) AND w.deleted_at IS NULL AND w.status = ?
 		ORDER BY w.id`,
-		workID, seriesRelationTypeID, seriesRelationTypeID, workID).Scan(&rows).Error; err != nil {
+		workID, seriesRelationTypeID, seriesRelationTypeID, workID, model.WorkStatusLive).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/apps/api/internal/platform/catalog/service/read_service.go
+++ b/apps/api/internal/platform/catalog/service/read_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	stderrors "errors"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -722,12 +723,14 @@ func (s *ReadService) LabelWorks(ctx context.Context, labelID int64, limit, offs
 	if h.ID != 0 {
 		head = &h
 	}
-	if err = db.Raw(`SELECT count(*) FROM catalog_work_label WHERE label_id = ?`, labelID).Scan(&total).Error; err != nil {
+	if err = db.Raw(`SELECT count(*) FROM catalog_work_label wl JOIN catalog_work w ON w.id = wl.work_id
+		WHERE wl.label_id = ? AND w.deleted_at IS NULL AND w.status = ?`, labelID, model.WorkStatusLive).Scan(&total).Error; err != nil {
 		return nil, nil, 0, err
 	}
 	err = db.Raw(`SELECT w.id AS work_id, w.display_name, w.medium_id, w.content_rating, w.status, wl.kind
 		FROM catalog_work_label wl JOIN catalog_work w ON w.id = wl.work_id
-		WHERE wl.label_id = ? ORDER BY w.id LIMIT ? OFFSET ?`, labelID, limit, offset).Scan(&items).Error
+		WHERE wl.label_id = ? AND w.deleted_at IS NULL AND w.status = ? ORDER BY w.id LIMIT ? OFFSET ?`,
+		labelID, model.WorkStatusLive, limit, offset).Scan(&items).Error
 	return head, items, total, err
 }
 
@@ -761,7 +764,7 @@ func (s *ReadService) SearchWorks(ctx context.Context, q string, mediumID int16,
 	}
 
 	var hits []WorkSearchHit
-	args := []any{model.WorkStatusMerged, mediumID, mediumID}
+	args := []any{model.WorkStatusLive, mediumID, mediumID}
 	args = append(args, claimArgs...)
 	args = append(args, siteArgs...)
 	args = append(args, q, limit)
@@ -770,7 +773,7 @@ func (s *ReadService) SearchWorks(ctx context.Context, q string, mediumID int16,
 		       w.status, COALESCE(w.site, '') AS site
 		FROM catalog_work w
 		WHERE w.deleted_at IS NULL
-		  AND w.status <> ?
+		  AND w.status = ?
 		  AND (? <= 0 OR w.medium_id = ?)`+claimGate+siteGate+`
 		  AND EXISTS (
 		      SELECT 1 FROM catalog_work_title t
@@ -834,7 +837,7 @@ func (s *ReadService) workBriefs(ctx context.Context, ids []int64) (map[int64]Wo
 	var rows []WorkBriefRow
 	if err := s.db.WithContext(ctx).Raw(`
 		SELECT id AS work_id, display_name, medium_id, content_rating, status, COALESCE(site, '') AS site
-		FROM catalog_work WHERE id IN ? AND deleted_at IS NULL`, ids).Scan(&rows).Error; err != nil {
+		FROM catalog_work WHERE id IN ? AND deleted_at IS NULL AND status = ?`, ids, model.WorkStatusLive).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 	m := make(map[int64]WorkBriefRow, len(rows))
@@ -868,7 +871,12 @@ type SiblingNameRow struct {
 // nameWorkScope is shared by NameWorks' total and its page: a total of 40 that
 // pages out 38 is a defect on its own.
 var nameWorkScope = `FROM catalog_credit c WHERE c.credit_name_id = ? AND ` +
-	editspec.NotSuppressedCreditSQL("c")
+	editspec.NotSuppressedCreditSQL("c") + ` AND ` + liveWorkSQL("c.work_id")
+
+func liveWorkSQL(workCol string) string {
+	return fmt.Sprintf(`EXISTS (SELECT 1 FROM catalog_work lw WHERE lw.id = %s AND lw.deleted_at IS NULL AND lw.status = %d)`,
+		workCol, model.WorkStatusLive)
+}
 
 type NameWorkRoleRow struct {
 	WorkID      int64   `gorm:"column:work_id"`
@@ -969,9 +977,9 @@ func (s *ReadService) NameWorks(ctx context.Context, nameID int64, limit, offset
 // carries the character: charter ruling 2 (read paths exclude suppressed rows
 // uniformly) is not given an exemption for the union's existence half.
 var unionWorks = `SELECT wc.work_id FROM catalog_work_character wc WHERE wc.character_id = ? AND ` +
-	editspec.NotSuppressedRosterSQL("wc") + `
+	editspec.NotSuppressedRosterSQL("wc") + ` AND ` + liveWorkSQL("wc.work_id") + `
 	UNION SELECT c.work_id FROM catalog_credit c WHERE c.character_id = ? AND ` +
-	editspec.NotSuppressedCreditSQL("c")
+	editspec.NotSuppressedCreditSQL("c") + ` AND ` + liveWorkSQL("c.work_id")
 
 type CharacterHeadRow struct {
 	ID          int64  `gorm:"column:id"`

--- a/apps/web/app/components/catalog/Candidates.vue
+++ b/apps/web/app/components/catalog/Candidates.vue
@@ -7,7 +7,9 @@ import {
   CANDIDATE_STATUS,
   CANDIDATE_STATUS_LABELS,
   CANDIDATE_STATUS_COLORS,
-  CANDIDATE_REASON_LABELS
+  CANDIDATE_REASON_LABELS,
+  WORK_STATUS,
+  WORK_STATUS_LABELS
 } from '~/constants/catalog'
 import type {
   CatalogCandidateItem,
@@ -18,6 +20,29 @@ import type {
 
 const isPersonLink = (c: CatalogCandidateItem) =>
   c.entity_type === CATALOG_ENTITY_TYPE.creditName
+
+const isDecidable = (c: CatalogCandidateItem) =>
+  (
+    [
+      CANDIDATE_STATUS.pending,
+      CANDIDATE_STATUS.deferred,
+      CANDIDATE_STATUS.needsManual
+    ] as number[]
+  ).includes(c.status)
+
+const quarantinedIds = (c: CatalogCandidateItem) =>
+  [
+    { id: c.a_id, s: c.a },
+    { id: c.b_id, s: c.b }
+  ]
+    .filter(({ s }) => s.work_status === WORK_STATUS.QUARANTINE)
+    .map(({ id }) => id)
+
+const quarantinedSide = (c: CatalogCandidateItem) => {
+  if (c.a.work_status === WORK_STATUS.QUARANTINE) return 'a' as const
+  if (c.b.work_status === WORK_STATUS.QUARANTINE) return 'b' as const
+  return null
+}
 
 const api = useApi('catalog')
 
@@ -83,7 +108,8 @@ const keyOf = (c: CatalogCandidateItem) =>
 const toggleExpand = (c: CatalogCandidateItem) => {
   const key = keyOf(c)
   expandedKey.value = expandedKey.value === key ? '' : key
-  direction.value = ''
+  const side = quarantinedSide(c)
+  direction.value = side === 'a' ? 'ab' : side === 'b' ? 'ba' : ''
   note.value = ''
 }
 
@@ -129,9 +155,33 @@ const decide = async (
           `已建合并提案 #${res.data?.proposal_id ?? ''}，请到提案桶审批`,
           'success'
         )
+      } else if (res.data?.released?.length) {
+        useKunMessage(
+          res.data.released.map((id) => `已放行 #${id}`).join('、'),
+          'success'
+        )
       } else {
         useKunMessage(action === 'reject' ? '已拒绝（永久保留）' : '已搁置', 'success')
       }
+      expandedKey.value = ''
+      await refresh()
+    } else {
+      useKunMessage(res.message || '操作失败', 'error')
+    }
+  } finally {
+    deciding.value = false
+  }
+}
+
+const releaseWork = async (workId: number) => {
+  deciding.value = true
+  try {
+    const res = await api.post<{ work_id: number; status: number }>(
+      '/admin/catalog/works/release',
+      { work_id: workId }
+    )
+    if (res.code === 0) {
+      useKunMessage(`已放行 #${workId}`, 'success')
       expandedKey.value = ''
       await refresh()
     } else {
@@ -247,16 +297,26 @@ const sourceLabel = (id: number | null | undefined) =>
               class="border-default-200 rounded-lg border p-3"
             >
               <p class="text-default-400 text-xs">{{ side.tag }} · #{{ side.s.id }}</p>
-              <p
-                class="text-lg font-medium"
-                :class="
-                  c.a.display_name !== c.b.display_name
-                    ? 'text-warning-600'
-                    : 'text-foreground'
-                "
-              >
-                {{ side.s.display_name || '（无显示名）' }}
-              </p>
+              <div class="flex flex-wrap items-center gap-1.5">
+                <p
+                  class="text-lg font-medium"
+                  :class="
+                    c.a.display_name !== c.b.display_name
+                      ? 'text-warning-600'
+                      : 'text-foreground'
+                  "
+                >
+                  {{ side.s.display_name || '（无显示名）' }}
+                </p>
+                <KunChip
+                  v-if="side.s.work_status === WORK_STATUS.QUARANTINE"
+                  color="warning"
+                  variant="flat"
+                  size="sm"
+                >
+                  {{ WORK_STATUS_LABELS[WORK_STATUS.QUARANTINE] }}
+                </KunChip>
+              </div>
               <div
                 v-if="isPersonLink(c)"
                 class="mt-1 flex flex-wrap items-center gap-1.5"
@@ -276,7 +336,7 @@ const sourceLabel = (id: number | null | undefined) =>
             </div>
           </div>
 
-          <template v-if="isPersonLink(c) && (c.status === 0 || c.status === 3)">
+          <template v-if="isPersonLink(c) && isDecidable(c)">
             <div class="flex flex-wrap gap-2">
               <KunButton
                 color="success"
@@ -309,7 +369,7 @@ const sourceLabel = (id: number | null | undefined) =>
             </div>
           </template>
 
-          <template v-else-if="c.status === 0 || c.status === 3">
+          <template v-else-if="isDecidable(c)">
             <div class="flex flex-wrap items-center gap-2">
               <span class="text-default-500 text-sm">合并方向：</span>
               <KunButton
@@ -349,7 +409,7 @@ const sourceLabel = (id: number | null | undefined) =>
                 :disabled="deciding"
                 @click="decide(c, 'reject')"
               >
-                拒绝（永久保留）
+                {{ quarantinedSide(c) ? '拒绝并放行' : '拒绝（永久保留）' }}
               </KunButton>
               <KunButton
                 color="default"
@@ -378,6 +438,16 @@ const sourceLabel = (id: number | null | undefined) =>
               @click="detachLink(c)"
             >
               撤销关联（摘离双方名义）
+            </KunButton>
+            <KunButton
+              v-for="id in quarantinedIds(c)"
+              :key="id"
+              color="warning"
+              variant="flat"
+              :disabled="deciding"
+              @click="releaseWork(id)"
+            >
+              放行 #{{ id }}
             </KunButton>
           </div>
         </div>

--- a/apps/web/app/constants/catalog.ts
+++ b/apps/web/app/constants/catalog.ts
@@ -23,6 +23,20 @@ export const CANDIDATE_STATUS = {
   needsManual: 4
 } as const
 
+export const WORK_STATUS = {
+  LIVE: 0,
+  STUB: 1,
+  MERGED: 2,
+  QUARANTINE: 3
+} as const
+
+export const WORK_STATUS_LABELS: Record<number, string> = {
+  0: '公开',
+  1: '未达标',
+  2: '已合并',
+  3: '隔离中'
+}
+
 export const CANDIDATE_STATUS_LABELS: Record<number, string> = {
   0: '待处理',
   1: '已接受',

--- a/apps/web/shared/types/generated/catalog-admin-api.ts
+++ b/apps/web/shared/types/generated/catalog-admin-api.ts
@@ -208,6 +208,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/catalog/works/release": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Release a quarantined work to live (the reject-without-merge exit of the mint gate) */
+        post: operations["releaseCatalogWork"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -263,6 +280,7 @@ export interface components {
              * @description Set when a merge-candidate accept opened a proposal
              */
             proposal_id?: number;
+            released?: number[] | null;
         };
         DecideCandidateInputBody: {
             /**
@@ -334,6 +352,8 @@ export interface components {
             id: number;
             /** Format: int32 */
             source_id?: number;
+            /** Format: int32 */
+            work_status?: number;
         };
         EnvelopeClaimActionResult: {
             /**
@@ -465,6 +485,18 @@ export interface components {
             /** Format: int64 */
             code: number;
             data?: components["schemas"]["RefActionData"];
+            message: string;
+        };
+        EnvelopeReleaseWorkData: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/EnvelopeReleaseWorkData.json
+             */
+            readonly $schema?: string;
+            /** Format: int64 */
+            code: number;
+            data?: components["schemas"]["ReleaseWorkData"];
             message: string;
         };
         HouseError: {
@@ -622,6 +654,26 @@ export interface components {
             reason: string;
             /** Format: int32 */
             source_id: number;
+        };
+        ReleaseWorkData: {
+            /** Format: int32 */
+            status: number;
+            /** Format: int64 */
+            work_id: number;
+        };
+        ReleaseWorkInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/ReleaseWorkInputBody.json
+             */
+            readonly $schema?: string;
+            note?: string;
+            /**
+             * Format: int64
+             * @description The quarantined work to release to live
+             */
+            work_id: number;
         };
         StaffClaimActionRequest: {
             /**
@@ -1045,6 +1097,39 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EnvelopeRefActionData"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HouseError"];
+                };
+            };
+        };
+    };
+    releaseCatalogWork: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReleaseWorkInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnvelopeReleaseWorkData"];
                 };
             };
             /** @description Error */

--- a/docs/catalog/admin-openapi.yaml
+++ b/docs/catalog/admin-openapi.yaml
@@ -117,6 +117,13 @@ components:
           description: Set when a merge-candidate accept opened a proposal
           format: int64
           type: integer
+        released:
+          items:
+            format: int64
+            type: integer
+          type:
+            - array
+            - "null"
       required:
         - decided
       type: object
@@ -232,6 +239,9 @@ components:
           format: int64
           type: integer
         source_id:
+          format: int32
+          type: integer
+        work_status:
           format: int32
           type: integer
       required:
@@ -463,6 +473,27 @@ components:
           type: integer
         data:
           $ref: "#/components/schemas/RefActionData"
+        message:
+          type: string
+      required:
+        - code
+        - message
+      type: object
+    EnvelopeReleaseWorkData:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/EnvelopeReleaseWorkData.json
+          format: uri
+          readOnly: true
+          type: string
+        code:
+          format: int64
+          type: integer
+        data:
+          $ref: "#/components/schemas/ReleaseWorkData"
         message:
           type: string
       required:
@@ -825,6 +856,39 @@ components:
         - source_id
         - external_id
         - reason
+      type: object
+    ReleaseWorkData:
+      additionalProperties: false
+      properties:
+        status:
+          format: int32
+          type: integer
+        work_id:
+          format: int64
+          type: integer
+      required:
+        - work_id
+        - status
+      type: object
+    ReleaseWorkInputBody:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/ReleaseWorkInputBody.json
+          format: uri
+          readOnly: true
+          type: string
+        note:
+          type: string
+        work_id:
+          description: The quarantined work to release to live
+          format: int64
+          minimum: 1
+          type: integer
+      required:
+        - work_id
       type: object
     StaffClaimActionRequest:
       additionalProperties: false
@@ -1275,5 +1339,30 @@ paths:
                 $ref: "#/components/schemas/HouseError"
           description: Error
       summary: "Reject a wrong external ref: deletes it and records first-class negative knowledge (reason required)"
+      tags:
+        - catalog-admin
+  /api/v1/admin/catalog/works/release:
+    post:
+      operationId: releaseCatalogWork
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReleaseWorkInputBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeReleaseWorkData"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseError"
+          description: Error
+      summary: Release a quarantined work to live (the reject-without-merge exit of the mint gate)
       tags:
         - catalog-admin


### PR DESCRIPTION
## Summary

PR2 of the duplicate-works track (PR1 = #115, detector). This closes the **mint** side: importers stop creating public duplicates without discarding identities.

- **New `WorkStatusQuarantine = 3`** (value of the existing `int16` column, zero migration). A Bangumi subject or VNDB VN whose folded title collides with an existing work is minted *into quarantine* with its exact identity anchor, its revision, and one pending `catalog_match_candidate` row against the collided work. Previously the bgm gate silently skipped the subject (identity lost forever) and the vndb importer had no title gate at all.
- **Read-face sweep**: every public work read that only filtered `deleted_at` now allow-lists `status = live` — company `include=works`, credit-name credits, character appearances, work relations, series siblings, `refs=` lookup — and their totals follow the same predicate. Changes feed reports a quarantined work as `gone`. Search index was already `status = 0`.
- **Operator exit**: rejecting a work candidate releases a quarantined side to live once no other open candidate involves it (one transaction, `RevisionActionUpdated` written); `ExecuteMerge` releases a quarantined survivor; `POST /api/v1/admin/catalog/works/release` is the explicit escape hatch. `EntitySummary.work_status` and `released[]` on the decide response are the new wire fields (admin spec + generated types regenerated).
- **Admin console**: decision buttons now render for `NeedsManual` (4) rows — the 7,943 machine-parked pairs were undecidable from the UI; quarantined sides get a `隔离中` chip, the reject button reads `拒绝并放行`, and non-decidable cards with a quarantined side get a `放行 #id` button.
- **Collision corpus fix**: the title half of `loadExistingWorkTitleNorms` joins live works, so merged works' title rows no longer gate their successors.

Deliberately unchanged: `SubmitWork` (already files candidates, keeps minting live), `egdlsite`/`dlsite`/`bangumixmedia` minters, `dropIntraCollisions`, the changes-feed `gone` semantics, enrichment jobs (a quarantined row is enriched so it is complete when adjudicated).

## Test plan

- [x] `go build ./... && go vet ./internal/platform/catalog/... ./cmd/...`
- [x] `gofmt -l` clean on every touched file
- [x] `REQUIRE_DB_TESTS=1 go test -count=1 -p 1 ./internal/platform/catalog/... ./cmd/work-dedup/...` on an ephemeral DB — all 22 packages pass, including `TestPublicQuarantineInvisibleOnReadFaces`, `TestBgmType4GatedQuarantineMint`, `TestBgmType4GatedSoftDeletedTitleDoesNotCollide`, `TestBgmType4GatedLimitSpendsLiveFirst`, `TestVNDBWorksMintQuarantineOnTitleCollision`, `TestDecideCandidateRejectReleasesQuarantine`, `TestDecideCandidateRejectHoldsUntilLastOpenCandidate`, `TestReleaseWork`, `TestDecideCandidateAcceptDoesNotReleaseQuarantine`, `TestExecuteMergeReleasesQuarantinedTarget`, `TestWorkStatusValuesArePinned`
- [x] `go run ./cmd/gen-openapi -catalog-admin` + `pnpm gen:types:catalog-admin`; `pnpm typecheck` and `pnpm lint` in `apps/web` clean
- [ ] After deploy: a released work reaches the search index on the next daily reindex (by design); bgm/vndb dry-runs report `to_quarantine`

No migration. No v2 public spec change.

https://claude.ai/code/session_01VfxKvHRwA5Vj28pdvoE4bY
