### PR TITLE
feat(store-price): route the DLsite lane through a configurable egress proxy

### DIFF
--- a/apps/api/cmd/catalog/main.go
+++ b/apps/api/cmd/catalog/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"time"
 
@@ -283,8 +284,18 @@ func setupPublicCatalog(
 	var priceSvc *price.Service
 	if cfg.Store.PriceEnabled {
 		ua := cfg.Store.PriceUserAgent
+		var dlsiteProxy *url.URL
+		if raw := cfg.Store.PriceDLsiteProxy; raw != "" {
+			u, err := url.Parse(raw)
+			if err != nil || u.Host == "" {
+				slog.Error("store price: KUN_STORE_PRICE_DLSITE_PROXY is not a proxy URL (scheme://host:port)", "error", err)
+				os.Exit(1)
+			}
+			dlsiteProxy = u
+			slog.Info("store price: dlsite lane egresses via proxy", "scheme", u.Scheme, "host", u.Host)
+		}
 		priceSvc = price.New(oauthDB, []price.Fetcher{
-			price.NewDLsite(ua, cfg.Store.PriceDLsiteCurrencies, ""),
+			price.NewDLsite(ua, cfg.Store.PriceDLsiteCurrencies, cfg.Store.PriceDLsiteBase, dlsiteProxy),
 			price.NewSteam(ua, cfg.Store.PriceSteamRegions, ""),
 		}, price.Options{})
 		priceSvc.Start()

--- a/apps/api/internal/platform/store/price/dlsite.go
+++ b/apps/api/internal/platform/store/price/dlsite.go
@@ -24,9 +24,19 @@ type dlsite struct {
 	jst        *time.Location
 }
 
-func NewDLsite(userAgent string, currencies []string, base string) Fetcher {
+// proxy is the lane's egress. DLsite answers the prod box's German egress with
+// `302 → https://www.google.com/` on every path, so the first deploy decoded
+// Google's HTML and every quote came back unavailable; the same request from a
+// Tokyo host returns the JSON.
+func NewDLsite(userAgent string, currencies []string, base string, proxy *url.URL) Fetcher {
 	if base == "" {
 		base = dlsiteDefaultBase
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	if proxy != nil {
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.Proxy = http.ProxyURL(proxy)
+		client.Transport = tr
 	}
 	want := make(map[string]struct{}, len(currencies))
 	for _, c := range currencies {
@@ -43,7 +53,7 @@ func NewDLsite(userAgent string, currencies []string, base string) Fetcher {
 		ua:         userAgent,
 		currencies: want,
 		base:       strings.TrimRight(base, "/"),
-		http:       &http.Client{Timeout: 10 * time.Second},
+		http:       client,
 		jst:        loc,
 	}
 }

--- a/apps/api/internal/platform/store/price/dlsite_test.go
+++ b/apps/api/internal/platform/store/price/dlsite_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -35,7 +37,7 @@ func TestDLsiteFetch(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	f := NewDLsite("Test-UA/1.0", []string{"CNY", "USD", "TWD", "HKD", "KRW", "EUR"}, srv.URL)
+	f := NewDLsite("Test-UA/1.0", []string{"CNY", "USD", "TWD", "HKD", "KRW", "EUR"}, srv.URL, nil)
 	out, err := f.Fetch(context.Background(), "jp", []string{"RJ00000001", "RJ01402486"})
 	require.NoError(t, err)
 	require.Equal(t, "/maniax/product/info/ajax", gotPath)
@@ -66,7 +68,7 @@ func TestDLsiteOnSaleZero(t *testing.T) {
 		})
 	}))
 	t.Cleanup(srv.Close)
-	f := NewDLsite("Test-UA/1.0", nil, srv.URL)
+	f := NewDLsite("Test-UA/1.0", nil, srv.URL, nil)
 	out, err := f.Fetch(context.Background(), "jp", []string{"RJ149770"})
 	require.NoError(t, err)
 	up, ok := out["RJ149770"]
@@ -74,8 +76,35 @@ func TestDLsiteOnSaleZero(t *testing.T) {
 	require.False(t, up.Found)
 }
 
+func TestDLsiteFetchViaProxy(t *testing.T) {
+	var originHits atomic.Int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originHits.Add(1)
+		http.Error(w, "must not be reached directly", http.StatusTeapot)
+	}))
+	t.Cleanup(origin.Close)
+	var proxied string
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxied = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"RJ149770": map[string]any{"price": 100, "official_price": 100, "discount_rate": 0, "on_sale": 1, "currency_price": map[string]any{}},
+		})
+	}))
+	t.Cleanup(proxy.Close)
+	proxyURL, err := url.Parse(proxy.URL)
+	require.NoError(t, err)
+
+	f := NewDLsite("Test-UA/1.0", nil, origin.URL, proxyURL)
+	out, err := f.Fetch(context.Background(), "jp", []string{"RJ149770"})
+	require.NoError(t, err)
+	require.True(t, out["RJ149770"].Found)
+	require.Equal(t, origin.URL+"/maniax/product/info/ajax?product_id=RJ149770", proxied)
+	require.Zero(t, originHits.Load())
+}
+
 func TestDLsiteAccepts(t *testing.T) {
-	f := NewDLsite("", nil, "")
+	f := NewDLsite("", nil, "", nil)
 	require.False(t, f.Accepts("RE149770"))
 	require.True(t, f.Accepts("RJ149770"))
 	require.True(t, f.Accepts("VJ012345"))
@@ -93,7 +122,7 @@ func TestDLsiteTimesaleTLayout(t *testing.T) {
 		})
 	}))
 	t.Cleanup(srv.Close)
-	f := NewDLsite("Test-UA/1.0", nil, srv.URL)
+	f := NewDLsite("Test-UA/1.0", nil, srv.URL, nil)
 	out, err := f.Fetch(context.Background(), "jp", []string{"RJ149770"})
 	require.NoError(t, err)
 	up := out["RJ149770"]

--- a/apps/api/pkg/config/config.go
+++ b/apps/api/pkg/config/config.go
@@ -82,6 +82,8 @@ type StoreConfig struct {
 	PriceUserAgent        string
 	PriceSteamRegions     []string
 	PriceDLsiteCurrencies []string
+	PriceDLsiteBase       string
+	PriceDLsiteProxy      string
 }
 
 type AIClientConfig struct {
@@ -563,6 +565,8 @@ func Load() (*Config, error) {
 		PriceUserAgent:        getEnv("KUN_STORE_PRICE_USER_AGENT", "NextMoe-PriceBot/1.0 (+https://www.kungal.com)"),
 		PriceSteamRegions:     steamRegions,
 		PriceDLsiteCurrencies: dlsiteCurrencies,
+		PriceDLsiteBase:       getEnv("KUN_STORE_PRICE_DLSITE_BASE", ""),
+		PriceDLsiteProxy:      getEnv("KUN_STORE_PRICE_DLSITE_PROXY", ""),
 	}
 
 	cfg.NewsModeration = NewsModerationConfig{

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -472,6 +472,8 @@ services:
       KUN_STORE_PRICE_USER_AGENT: "${KUN_STORE_PRICE_USER_AGENT:-NextMoe-PriceBot/1.0 (+https://www.kungal.com)}"
       KUN_STORE_PRICE_STEAM_REGIONS: ${KUN_STORE_PRICE_STEAM_REGIONS:-jp,cn,us}
       KUN_STORE_PRICE_DLSITE_CURRENCIES: ${KUN_STORE_PRICE_DLSITE_CURRENCIES:-CNY,USD,TWD,HKD,KRW,EUR}
+      KUN_STORE_PRICE_DLSITE_BASE: ${KUN_STORE_PRICE_DLSITE_BASE:-}
+      KUN_STORE_PRICE_DLSITE_PROXY: ${KUN_STORE_PRICE_DLSITE_PROXY:-}
     # S2S read/admin face stays internal — product backends (wiki/forum/moyu)
     # reach it at http://catalog:9281 over dokploy-network. The ONLY public path
     # is the open-API /v1/catalog projection routed by the labels block below.


### PR DESCRIPTION
## Why

Post-deploy verification of #117 on prod: the face, table, env and Steam lane are all live (a paid Steam app came back priced in jp/cn/us), but every DLsite quote lands as `unavailable` with

```
WARN store price: upstream fetch failed source=dlsite region=jp count=1 error="dlsite: decode: invalid character '<' looking for beginning of value"
```

Reproduced from the box with curl: DLsite answers the prod egress (DE) with `302 → https://www.google.com/` on **every** path (ajax, top page, work page), under the bot UA and a browser UA alike. The identical request from a Tokyo host returns the JSON. The lane needs a JP egress, not a parser change.

## What

- `KUN_STORE_PRICE_DLSITE_PROXY` — proxy URL (`http://`, `https://`, `socks5://`) used **only** by the DLsite fetcher's transport (cloned `DefaultTransport` with `Proxy` set). Empty = direct, unchanged behaviour. Malformed = catalog exits at startup with a named error instead of silently fetching direct.
- `KUN_STORE_PRICE_DLSITE_BASE` — wires the constructor's existing `base` override to an env var, for a relay that mirrors DLsite's path.
- Both interpolated in the prod compose `catalog` block so a Dokploy panel value reaches the container.
- Startup log line names the proxy scheme + host (never userinfo).
- Test `TestDLsiteFetchViaProxy`: the request reaches the proxy as an absolute URL for the DLsite base, and the origin is never hit directly.

Steam fetches from the box normally and is untouched.

## Gates

- `gofmt` clean, `go build ./...`, `go vet` on the three packages, `go test ./internal/platform/store/price/ -count=1` green.
- No route, schema or docs change (spec/portal/docs-model untouched).

## After merge

Operator sets `KUN_STORE_PRICE_DLSITE_PROXY` in the Dokploy panel to a JP egress and redeploys `catalog`; the 15-minute error rows expire on their own and the refresh loop re-fetches them.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
