### PR TITLE
Configuration center wave 2: site scope, S2S read face, job scheduling keys

### DIFF
--- a/apps/api/cmd/oauth/main.go
+++ b/apps/api/cmd/oauth/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"strconv"
@@ -47,6 +48,7 @@ import (
 	storeService "api/internal/platform/store/service"
 
 	"github.com/gofiber/fiber/v3"
+	"gorm.io/gorm"
 )
 
 func main() {
@@ -336,10 +338,26 @@ func setupRoutes(a *app.App, cfg *config.Config, cleanupCtx context.Context) {
 	settingsH := settings.NewHandler(
 		settings.NewService(settingsReg, settings.NewStore(db), settingsDist),
 		func(roles []string) bool { return settingsPerm.Resolver.Can(roles, settingsPerm.Write) },
+		func(ctx context.Context, id uint) (bool, error) {
+			_, err := siteRepository.FindByID(ctx, id)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		},
 	)
 	settingsH.Register(admin,
 		middleware.RequirePermission(settingsPerm.Resolver, settingsPerm.View),
 		middleware.RequirePermission(settingsPerm.Resolver, settingsPerm.Write))
+	settingsH.RegisterS2S(v1, middleware.OAuthClientBasicAuth(oauthClientRepo), func(c fiber.Ctx) *uint {
+		if client := middleware.OAuthClientFromCtx(c); client != nil {
+			return client.SiteID
+		}
+		return nil
+	})
 
 	registerImageAdmin(a, cfg, admin)
 	registerArtifactAdmin(a, cfg, authSvc)
@@ -358,8 +376,8 @@ func registerJobsAdmin(admin fiber.Router, reg *jobs.Registry, runner *jobs.Runn
 		type jobView struct {
 			Name      string `json:"name"`
 			Desc      string `json:"desc"`
-			DailyAt   string `json:"daily_at,omitempty"`
-			Auto      bool   `json:"auto"`
+			Schedule  string `json:"schedule"`
+			Enabled   bool   `json:"enabled"`
 			LatestRun any    `json:"latest_run"`
 		}
 		out := make([]jobView, 0)
@@ -368,11 +386,12 @@ func registerJobsAdmin(admin fiber.Router, reg *jobs.Registry, runner *jobs.Runn
 			if err != nil {
 				slog.Error("jobs admin: latest run", "job", j.Name, "err", err)
 			}
+			jk, _ := keys.Job(j.Name)
 			out = append(out, jobView{
 				Name:      j.Name,
 				Desc:      j.Desc,
-				DailyAt:   j.Schedule.DailyAt,
-				Auto:      !j.Schedule.Zero(),
+				Schedule:  jk.Schedule.Get(),
+				Enabled:   jk.Enabled.Get(),
 				LatestRun: latest,
 			})
 		}

--- a/apps/api/internal/jobs/all.go
+++ b/apps/api/internal/jobs/all.go
@@ -13,72 +13,64 @@ import (
 
 func RegisterAll(r *Registry) {
 	r.Register(Job{
-		Name:     "image-gc",
-		Desc:     "image_service TTL 生命周期（冷候选/软删/物删）",
-		Schedule: Schedule{DailyAt: "03:30"},
+		Name: "image-gc",
+		Desc: "image_service TTL 生命周期（冷候选/软删/物删）",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return RunImageGC(ctx, cfg, DefaultImageGCOpts())
 		},
 	})
 
 	r.Register(Job{
-		Name:     "galgame-image-refping",
-		Desc:     "galgame banner reference-ping，防 image_service TTL 回收",
-		Schedule: Schedule{DailyAt: "04:00"},
+		Name: "galgame-image-refping",
+		Desc: "galgame banner reference-ping，防 image_service TTL 回收",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return RunGalgameImageRefping(ctx, cfg, DefaultGalgameImageRefpingOpts())
 		},
 	})
 
 	r.Register(Job{
-		Name:     "catalog-image-refping",
-		Desc:     "catalog 角色立绘 reference-ping，防 image_service TTL 回收（site=catalog）",
-		Schedule: Schedule{DailyAt: "04:15"},
+		Name: "catalog-image-refping",
+		Desc: "catalog 角色立绘 reference-ping，防 image_service TTL 回收（site=catalog）",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return RunCatalogImageRefping(ctx, cfg, DefaultCatalogImageRefpingOpts())
 		},
 	})
 
 	r.Register(Job{
-		Name:     "news-image-refping",
-		Desc:     "情报 banner 与文中图 reference-ping，防 image_service TTL 回收（site=news）",
-		Schedule: Schedule{DailyAt: "04:20"},
+		Name: "news-image-refping",
+		Desc: "情报 banner 与文中图 reference-ping，防 image_service TTL 回收（site=news）",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return RunNewsImageRefping(ctx, cfg, DefaultNewsImageRefpingOpts())
 		},
 	})
 
 	r.Register(Job{
-		Name:     "user-avatar-refping",
-		Desc:     "用户头像 reference-ping，防 image_service TTL 回收",
-		Schedule: Schedule{DailyAt: "04:30"},
+		Name: "user-avatar-refping",
+		Desc: "用户头像 reference-ping，防 image_service TTL 回收",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return RunUserAvatarRefping(ctx, cfg, DefaultUserAvatarRefpingOpts())
 		},
 	})
 
 	r.Register(Job{
-		Name:     JobImageRefAudit,
-		Desc:     "catalog 图片引用对账（引用指向已删字节即告警，赶在 30 天物删前抢救）",
-		Schedule: Schedule{DailyAt: "04:45"},
+		Name: JobImageRefAudit,
+		Desc: "catalog 图片引用对账（引用指向已删字节即告警，赶在 30 天物删前抢救）",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return RunImageRefAudit(ctx, cfg, DefaultImageRefAuditOpts())
 		},
 	})
 
 	r.Register(Job{
-		Name:     "artifact-gc",
-		Desc:     "artifact 生命周期（孤儿上传回收 + 软删物理回收）",
-		Schedule: Schedule{DailyAt: "05:30"},
+		Name: "artifact-gc",
+		Desc: "artifact 生命周期（孤儿上传回收 + 软删物理回收）",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return RunArtifactGC(ctx, cfg, DefaultArtifactGCOpts())
 		},
 	})
 
 	r.Register(Job{
-		Name:     "prune-developer-usage",
-		Desc:     "developer_api_usage 留存修剪（删除 day < 今天−400 天 的计量汇总行）",
-		Schedule: Schedule{DailyAt: "06:00"},
+		Name: "prune-developer-usage",
+		Desc: "developer_api_usage 留存修剪（删除 day < 今天−400 天 的计量汇总行）",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return RunPruneDeveloperUsage(ctx, cfg, DefaultPruneDeveloperUsageOpts())
 		},
@@ -88,14 +80,11 @@ func RegisterAll(r *Registry) {
 	// 应该问题不大」 — and this poll spends exactly one request per lane per tick
 	// (page 1 only), which stays well inside what he allowed.
 	//
-	// NOTE: this is the first registered job to use Schedule.Every. The field and
-	// scheduler.runLoop have always supported it, but no job had exercised it in
-	// production before 2026-08-11. First run happens Every after boot, not at
-	// boot — do not watch the logs at startup expecting it.
+	// NOTE: the cadence default lives in keys/jobs.go. The first run happens
+	// one interval after boot, not at boot.
 	r.Register(Job{
-		Name:     "ymgal-news-poll",
-		Desc:     "月幕情报/专栏增量轮询（每 lane 只取第 1 页）",
-		Schedule: Schedule{Every: 10 * time.Minute},
+		Name: "ymgal-news-poll",
+		Desc: "月幕情报/专栏增量轮询（每 lane 只取第 1 页）",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return runYmgalNews(ctx, cfg, ymgalnews.Opts{
 				Lanes: []string{ymgalnews.LaneNews, ymgalnews.LaneColumn},
@@ -108,9 +97,8 @@ func RegisterAll(r *Registry) {
 	// at page 1, so an ad 苍麟 removed from further back would never come up. It
 	// reports dead candidates and deliberately does not act on them.
 	r.Register(Job{
-		Name:     "ymgal-news-sweep",
-		Desc:     "月幕深巡（前 5 页）+ 上游消失候选报告（只报不打）",
-		Schedule: Schedule{DailyAt: "04:05"},
+		Name: "ymgal-news-sweep",
+		Desc: "月幕深巡（前 5 页）+ 上游消失候选报告（只报不打）",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return runYmgalNews(ctx, cfg, ymgalnews.Opts{
 				Lanes: []string{ymgalnews.LaneNews, ymgalnews.LaneColumn},
@@ -120,9 +108,8 @@ func RegisterAll(r *Registry) {
 	})
 
 	r.Register(Job{
-		Name:     "store-stats-sync",
-		Desc:     "DLsite 分销短链点击同步（JST 日桶，最近 3 日窗口；首轮从最早铸链日全量补齐）",
-		Schedule: Schedule{Every: time.Hour},
+		Name: "store-stats-sync",
+		Desc: "DLsite 分销短链点击同步（JST 日桶，最近 3 日窗口；首轮从最早铸链日全量补齐）",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return RunStoreStatsSync(ctx, cfg, storestats.DefaultOpts())
 		},
@@ -132,9 +119,8 @@ func RegisterAll(r *Registry) {
 	// the time a moderator opens the queue. Nothing here can publish: the gate
 	// only ever auto-REJECTS, and only on a deterministic Tier0 word match.
 	r.Register(Job{
-		Name:     "news-moderate",
-		Desc:     "情报审核评分（Tier0 + AI 顾问；降级不推进，只有人能发布）",
-		Schedule: Schedule{Every: 5 * time.Minute},
+		Name: "news-moderate",
+		Desc: "情报审核评分（Tier0 + AI 顾问；降级不推进，只有人能发布）",
 		Run: func(ctx context.Context, cfg *config.Config) (Summary, error) {
 			return runNewsModerate(ctx, cfg, newsmoderate.Opts{
 				Apply: true, Limit: 50, Gap: 200 * time.Millisecond,

--- a/apps/api/internal/jobs/image_ref_audit_test.go
+++ b/apps/api/internal/jobs/image_ref_audit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"api/internal/platform/catalog/imagerefs"
+	"api/internal/platform/settings/keys"
 )
 
 // The whole point of the diff is that an already-known breakage must NOT
@@ -62,7 +63,15 @@ func TestImageRefAuditRunsAfterGCAndRefpings(t *testing.T) {
 
 	at := map[string]string{}
 	for _, j := range r.List() {
-		at[j.Name] = j.Schedule.DailyAt
+		jk, ok := keys.Job(j.Name)
+		if !ok {
+			t.Fatalf("%s has no settings keys", j.Name)
+		}
+		s, err := ParseSchedule(jk.Schedule.Default().(string))
+		if err != nil {
+			t.Fatalf("%s: %v", j.Name, err)
+		}
+		at[j.Name] = s.DailyAt
 	}
 
 	audit, ok := at[JobImageRefAudit]

--- a/apps/api/internal/jobs/job.go
+++ b/apps/api/internal/jobs/job.go
@@ -2,6 +2,9 @@ package jobs
 
 import (
 	"context"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	jobmodel "api/internal/jobs/model"
@@ -18,10 +21,9 @@ type Summary map[string]any
 type RunFunc func(ctx context.Context, cfg *config.Config) (Summary, error)
 
 type Job struct {
-	Name     string
-	Schedule Schedule
-	Desc     string
-	Run      RunFunc
+	Name string
+	Desc string
+	Run  RunFunc
 }
 
 type Schedule struct {
@@ -50,4 +52,43 @@ func (s Schedule) Next(now time.Time) time.Time {
 		return now.Add(s.Every)
 	}
 	return time.Time{}
+}
+
+func (s Schedule) String() string {
+	if s.DailyAt != "" {
+		return "daily@" + s.DailyAt
+	}
+	if s.Every > 0 {
+		if s.Every%time.Hour == 0 {
+			return fmt.Sprintf("every:%dh", s.Every/time.Hour)
+		}
+		return fmt.Sprintf("every:%dm", s.Every/time.Minute)
+	}
+	return ""
+}
+
+func ParseSchedule(s string) (Schedule, error) {
+	if hhmm, ok := strings.CutPrefix(s, "daily@"); ok {
+		if _, err := time.Parse("15:04", hhmm); err != nil || len(hhmm) != 5 {
+			return Schedule{}, fmt.Errorf("jobs: invalid schedule %q", s)
+		}
+		return Schedule{DailyAt: hhmm}, nil
+	}
+	if rest, ok := strings.CutPrefix(s, "every:"); ok {
+		switch {
+		case strings.HasSuffix(rest, "m"):
+			n, err := strconv.Atoi(strings.TrimSuffix(rest, "m"))
+			if err != nil || n < 1 {
+				return Schedule{}, fmt.Errorf("jobs: invalid schedule %q", s)
+			}
+			return Schedule{Every: time.Duration(n) * time.Minute}, nil
+		case strings.HasSuffix(rest, "h"):
+			n, err := strconv.Atoi(strings.TrimSuffix(rest, "h"))
+			if err != nil || n < 1 {
+				return Schedule{}, fmt.Errorf("jobs: invalid schedule %q", s)
+			}
+			return Schedule{Every: time.Duration(n) * time.Hour}, nil
+		}
+	}
+	return Schedule{}, fmt.Errorf("jobs: invalid schedule %q", s)
 }

--- a/apps/api/internal/jobs/jobs_test.go
+++ b/apps/api/internal/jobs/jobs_test.go
@@ -1,8 +1,12 @@
 package jobs
 
 import (
+	"sort"
+	"strings"
 	"testing"
 	"time"
+
+	"api/internal/platform/settings/keys"
 )
 
 func TestScheduleZero(t *testing.T) {
@@ -57,42 +61,120 @@ func TestScheduleNextEveryAndBad(t *testing.T) {
 	}
 }
 
-// TestYmgalJobsAreActuallyScheduled guards the quiet failure: StartScheduler
-// treats a Zero() schedule as manual-only and merely logs it, so a poll whose
-// Every was dropped to 0 would never run again and nothing would report an
-// error. ymgal-news-poll is the first job in the registry to rely on Every.
-func TestYmgalJobsAreActuallyScheduled(t *testing.T) {
-	reg := NewRegistry()
-	RegisterAll(reg)
+func TestParseScheduleRoundTrip(t *testing.T) {
+	for _, in := range []string{
+		"daily@03:30", "daily@00:00", "daily@23:59",
+		"every:1m", "every:10m", "every:1h", "every:36h",
+	} {
+		s, err := ParseSchedule(in)
+		if err != nil {
+			t.Errorf("%q: %v", in, err)
+			continue
+		}
+		if got := s.String(); got != in {
+			t.Errorf("%q: String() = %q", in, got)
+		}
+	}
 
+	s, err := ParseSchedule("every:60m")
+	if err != nil {
+		t.Fatalf("every:60m: %v", err)
+	}
+	if got := s.String(); got != "every:1h" {
+		t.Errorf("every:60m String() = %q, want %q (60 minutes is a whole number of hours)", got, "every:1h")
+	}
+
+	for _, in := range []string{"", "daily@24:00", "daily@3:30", "every:0m", "every:90s", "weekly", "manual"} {
+		_, err := ParseSchedule(in)
+		if err == nil {
+			t.Errorf("%q: want error", in)
+			continue
+		}
+		if in != "" && !strings.Contains(err.Error(), in) {
+			t.Errorf("%q: error %q does not name the input", in, err)
+		}
+	}
+}
+
+// TestYmgalJobsAreActuallyScheduled guards the quiet failure: a poll whose
+// jobs.<name>.schedule default lost its every: cadence would sit idle until
+// the string changed and nothing would report an error at boot.
+// ymgal-news-poll is the first job in the registry to rely on an every: cadence.
+func TestYmgalJobsAreActuallyScheduled(t *testing.T) {
 	for name, want := range map[string]time.Duration{
 		"ymgal-news-poll": 10 * time.Minute,
 		"news-moderate":   5 * time.Minute,
 	} {
-		job, ok := reg.Get(name)
+		jk, ok := keys.Job(name)
 		if !ok {
-			t.Fatalf("%s is not registered", name)
+			t.Fatalf("%s has no settings keys", name)
 		}
-		if job.Schedule.Zero() {
-			t.Errorf("%s has a Zero schedule — it would be registered as manual-only and never poll", name)
+		s, err := ParseSchedule(jk.Schedule.Default().(string))
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
 		}
-		if job.Schedule.Every != want {
-			t.Errorf("%s Every = %v, want %v", name, job.Schedule.Every, want)
+		if s.Every != want {
+			t.Errorf("%s Every = %v, want %v", name, s.Every, want)
 		}
 	}
 
-	sweep, ok := reg.Get("ymgal-news-sweep")
+	jk, ok := keys.Job("ymgal-news-sweep")
 	if !ok {
-		t.Fatal("ymgal-news-sweep is not registered")
+		t.Fatal("ymgal-news-sweep has no settings keys")
 	}
-	if sweep.Schedule.DailyAt == "" {
+	s, err := ParseSchedule(jk.Schedule.Default().(string))
+	if err != nil {
+		t.Fatalf("ymgal-news-sweep: %v", err)
+	}
+	if s.DailyAt == "" {
 		t.Error("ymgal-news-sweep must keep a daily schedule: the poll only reads page 1, so the sweep is the only thing that can notice an upstream deletion")
 	}
 }
 
+func TestEveryRegisteredJobHasKeys(t *testing.T) {
+	reg := NewRegistry()
+	RegisterAll(reg)
+
+	got := make([]string, 0, len(reg.List()))
+	for _, j := range reg.List() {
+		got = append(got, j.Name)
+	}
+	want := append([]string(nil), keys.JobNames()...)
+	sort.Strings(got)
+	sort.Strings(want)
+
+	gotSet := make(map[string]bool, len(got))
+	for _, n := range got {
+		gotSet[n] = true
+	}
+	wantSet := make(map[string]bool, len(want))
+	for _, n := range want {
+		wantSet[n] = true
+	}
+	for _, n := range got {
+		if !wantSet[n] {
+			t.Errorf("registered job %q is missing from keys.JobNames()", n)
+		}
+	}
+	for _, n := range want {
+		if !gotSet[n] {
+			t.Errorf("keys.JobNames() has %q with no registered job", n)
+		}
+	}
+}
+
+func TestRegisterPanicsWithoutKeys(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal(`Register(Job{Name: "no-such-job"}) did not panic`)
+		}
+	}()
+	NewRegistry().Register(Job{Name: "no-such-job"})
+}
+
 func TestRegistryListSortedAndGet(t *testing.T) {
 	r := NewRegistry()
-	r.Register(Job{Name: "sync-vndb"})
+	r.Register(Job{Name: "store-stats-sync"})
 	r.Register(Job{Name: "image-gc"})
 	r.Register(Job{Name: "galgame-image-refping"})
 
@@ -100,7 +182,7 @@ func TestRegistryListSortedAndGet(t *testing.T) {
 	if len(list) != 3 {
 		t.Fatalf("want 3 jobs, got %d", len(list))
 	}
-	if list[0].Name != "galgame-image-refping" || list[2].Name != "sync-vndb" {
+	if list[0].Name != "galgame-image-refping" || list[2].Name != "store-stats-sync" {
 		t.Fatalf("not name-sorted: %v", []string{list[0].Name, list[1].Name, list[2].Name})
 	}
 	if _, ok := r.Get("image-gc"); !ok {

--- a/apps/api/internal/jobs/registry.go
+++ b/apps/api/internal/jobs/registry.go
@@ -1,6 +1,10 @@
 package jobs
 
-import "sort"
+import (
+	"sort"
+
+	"api/internal/platform/settings/keys"
+)
 
 type Registry struct {
 	jobs map[string]Job
@@ -11,6 +15,9 @@ func NewRegistry() *Registry {
 }
 
 func (r *Registry) Register(j Job) {
+	if _, ok := keys.Job(j.Name); !ok {
+		panic("jobs: " + j.Name + " has no settings keys; add it to internal/platform/settings/keys/jobs.go")
+	}
 	r.jobs[j.Name] = j
 }
 

--- a/apps/api/internal/jobs/scheduler.go
+++ b/apps/api/internal/jobs/scheduler.go
@@ -4,42 +4,62 @@ import (
 	"context"
 	"log/slog"
 	"time"
+
+	"api/internal/platform/settings/keys"
 )
 
 const staleMaxAge = 6 * time.Hour
 
+const rescheduleTick = 30 * time.Second
+
 func StartScheduler(ctx context.Context, reg *Registry, runner *Runner) {
 	runner.ReapStale(ctx, staleMaxAge)
-
-	scheduled := 0
 	for _, job := range reg.List() {
-		if job.Schedule.Zero() {
-			slog.Info("jobs: registered (manual-only)", "job", job.Name)
-			continue
-		}
-		next := job.Schedule.Next(time.Now())
-		slog.Info("jobs: scheduled", "job", job.Name, "next", next.Format(time.RFC3339))
-		scheduled++
 		go runLoop(ctx, job, runner)
 	}
-	slog.Info("jobs: scheduler started", "total", len(reg.List()), "auto", scheduled)
+	slog.Info("jobs: scheduler started", "total", len(reg.List()))
 }
 
 func runLoop(ctx context.Context, job Job, runner *Runner) {
+	jk, _ := keys.Job(job.Name)
+	var (
+		spec  string
+		sched Schedule
+		next  time.Time
+	)
 	for {
-		next := job.Schedule.Next(time.Now())
-		if next.IsZero() {
-			slog.Error("jobs: bad schedule, loop exiting", "job", job.Name)
-			return
+		if cur := jk.Schedule.Get(); cur != spec {
+			spec = cur
+			s, err := ParseSchedule(cur)
+			if err != nil {
+				slog.Error("jobs: bad schedule; job idle until it changes", "job", job.Name, "schedule", cur, "err", err)
+				next = time.Time{}
+			} else {
+				sched = s
+				next = s.Next(time.Now())
+				slog.Info("jobs: scheduled", "job", job.Name, "schedule", cur, "next", next.Format(time.RFC3339))
+			}
 		}
-		timer := time.NewTimer(time.Until(next))
+		wait := rescheduleTick
+		if !next.IsZero() {
+			if d := time.Until(next); d < wait {
+				wait = d
+			}
+		}
 		select {
 		case <-ctx.Done():
-			timer.Stop()
 			slog.Info("jobs: scheduler loop stopped", "job", job.Name)
 			return
-		case <-timer.C:
-			runner.Run(ctx, job, TriggerSchedule)
+		case <-time.After(wait):
 		}
+		if next.IsZero() || time.Now().Before(next) {
+			continue
+		}
+		if jk.Enabled.Get() {
+			runner.Run(ctx, job, TriggerSchedule)
+		} else {
+			slog.Info("jobs: skipped, disabled", "job", job.Name, "schedule", spec)
+		}
+		next = sched.Next(time.Now())
 	}
 }

--- a/apps/api/internal/platform/settings/distributor.go
+++ b/apps/api/internal/platform/settings/distributor.go
@@ -35,7 +35,7 @@ func NewDistributor(db *gorm.DB, reg *Registry, bus Broadcaster) *Distributor {
 }
 
 func (d *Distributor) Refresh(ctx context.Context) error {
-	rows, err := d.store.Values(ctx)
+	rows, err := d.store.Values(ctx, PlatformScope)
 	if err != nil {
 		return err
 	}

--- a/apps/api/internal/platform/settings/handler.go
+++ b/apps/api/internal/platform/settings/handler.go
@@ -1,10 +1,12 @@
 package settings
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	apperrors "api/pkg/errors"
 	"api/pkg/response"
@@ -12,13 +14,19 @@ import (
 	"github.com/gofiber/fiber/v3"
 )
 
+type SiteLookup func(ctx context.Context, id uint) (bool, error)
+
+type SiteOf func(c fiber.Ctx) *uint
+
 type Handler struct {
 	svc      *Service
 	canWrite func(roles []string) bool
+	sites    SiteLookup
+	siteOf   SiteOf
 }
 
-func NewHandler(svc *Service, canWrite func(roles []string) bool) *Handler {
-	return &Handler{svc: svc, canWrite: canWrite}
+func NewHandler(svc *Service, canWrite func(roles []string) bool, sites SiteLookup) *Handler {
+	return &Handler{svc: svc, canWrite: canWrite, sites: sites}
 }
 
 func (h *Handler) Register(admin fiber.Router, view fiber.Handler, write fiber.Handler) {
@@ -31,15 +39,45 @@ func (h *Handler) Register(admin fiber.Router, view fiber.Handler, write fiber.H
 	slog.Info("settings console registered under /api/v1/admin/settings/*")
 }
 
+func (h *Handler) RegisterS2S(v1 fiber.Router, clientAuth fiber.Handler, siteOf SiteOf) {
+	h.siteOf = siteOf
+	v1.Get("/settings", clientAuth, h.Effective)
+	slog.Info("settings read face registered at /api/v1/settings")
+}
+
 func callerFrom(c fiber.Ctx) (userID uint, roles []string) {
 	roles, _ = c.Locals("user_roles").([]string)
 	userID, _ = c.Locals("user_id").(uint)
 	return userID, roles
 }
 
+func (h *Handler) scopeFrom(c fiber.Ctx) (Scope, error) {
+	s := c.Query("site")
+	if s == "" {
+		return PlatformScope, nil
+	}
+	id, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return Scope{}, response.BadRequestMsg(c, apperrors.ErrInvalidParam, "invalid site")
+	}
+	exists, err := h.sites(c.Context(), uint(id))
+	if err != nil {
+		slog.Error("settings: site lookup failed", "err", err)
+		return Scope{}, response.InternalError(c, apperrors.ErrOperationFailed)
+	}
+	if !exists {
+		return Scope{}, response.NotFoundMsg(c, apperrors.ErrNotFound, "unknown site")
+	}
+	return SiteScope(uint(id)), nil
+}
+
 func (h *Handler) Overview(c fiber.Ctx) error {
+	scope, err := h.scopeFrom(c)
+	if err != nil {
+		return err
+	}
 	_, roles := callerFrom(c)
-	ov, err := h.svc.Overview(c.Context(), h.canWrite(roles))
+	ov, err := h.svc.Overview(c.Context(), h.canWrite(roles), scope)
 	if err != nil {
 		slog.Error("settings: overview failed", "err", err)
 		return response.InternalError(c, apperrors.ErrOperationFailed)
@@ -64,13 +102,17 @@ type setRequest struct {
 }
 
 func (h *Handler) Set(c fiber.Ctx) error {
+	scope, err := h.scopeFrom(c)
+	if err != nil {
+		return err
+	}
 	var req setRequest
 	if err := c.Bind().JSON(&req); err != nil {
 		return response.BadRequest(c, apperrors.ErrBadRequest)
 	}
 	userID, _ := callerFrom(c)
 	key := c.Params("key")
-	view, err := h.svc.Set(c.Context(), userID, key, req.Value, req.Note, req.Version)
+	view, err := h.svc.Set(c.Context(), userID, scope, key, req.Value, req.Note, req.Version)
 	if err != nil {
 		return h.writeErr(c, err, key)
 	}
@@ -78,19 +120,50 @@ func (h *Handler) Set(c fiber.Ctx) error {
 }
 
 func (h *Handler) Reset(c fiber.Ctx) error {
+	scope, err := h.scopeFrom(c)
+	if err != nil {
+		return err
+	}
 	userID, _ := callerFrom(c)
 	key := c.Params("key")
-	view, err := h.svc.Reset(c.Context(), userID, key, c.Query("note"))
+	view, err := h.svc.Reset(c.Context(), userID, scope, key, c.Query("note"))
 	if err != nil {
 		return h.writeErr(c, err, key)
 	}
 	return response.Success(c, view)
 }
 
+func (h *Handler) Effective(c fiber.Ctx) error {
+	view, err := h.svc.Effective(c.Context(), h.siteOf(c))
+	if err != nil {
+		slog.Error("settings: effective read failed", "err", err)
+		return response.InternalError(c, apperrors.ErrOperationFailed)
+	}
+	c.Set("ETag", view.ETag)
+	c.Set("Cache-Control", "no-cache")
+	if etagMatches(c.Get("If-None-Match"), view.ETag) {
+		c.Status(fiber.StatusNotModified)
+		return nil
+	}
+	return response.Success(c, view)
+}
+
+func etagMatches(header, etag string) bool {
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		if part == "*" || strings.TrimPrefix(part, "W/") == etag {
+			return true
+		}
+	}
+	return false
+}
+
 func (h *Handler) writeErr(c fiber.Ctx, err error, key string) error {
 	switch {
 	case errors.Is(err, ErrUnknownKey):
 		return response.NotFoundMsg(c, apperrors.ErrNotFound, "unknown setting key")
+	case errors.Is(err, ErrNotSiteScoped):
+		return response.BadRequestMsg(c, apperrors.ErrInvalidParam, "该配置不支持按站点覆盖")
 	case errors.Is(err, ErrInvalidValue), errors.Is(err, ErrNoteTooLong):
 		return response.BadRequestMsg(c, apperrors.ErrInvalidParam, err.Error())
 	case errors.Is(err, ErrVersionConflict):

--- a/apps/api/internal/platform/settings/key.go
+++ b/apps/api/internal/platform/settings/key.go
@@ -28,18 +28,21 @@ const (
 	SourceDefault Source = "default"
 	SourceEnv     Source = "env"
 	SourceDB      Source = "db"
+	SourceSite    Source = "site"
 )
 
 type Meta struct {
-	Name    string
-	Kind    Kind
-	EnvVar  string
-	DescEN  string
-	DescZH  string
-	Enum    []string
-	Min     *float64
-	Max     *float64
-	Pattern string
+	Name       string
+	Kind       Kind
+	EnvVar     string
+	DescEN     string
+	DescZH     string
+	Enum       []string
+	Min        *float64
+	Max        *float64
+	Pattern    string
+	SiteScoped bool
+	Public     bool
 }
 
 func F(v float64) *float64 { return &v }

--- a/apps/api/internal/platform/settings/keys/jobs.go
+++ b/apps/api/internal/platform/settings/keys/jobs.go
@@ -1,0 +1,72 @@
+package keys
+
+import (
+	"strings"
+
+	"api/internal/platform/settings"
+)
+
+const JobSchedulePattern = `^(daily@(?:[01][0-9]|2[0-3]):[0-5][0-9]|every:[1-9][0-9]*[mh])$`
+
+type JobKeys struct {
+	Enabled  *settings.Key[bool]
+	Schedule *settings.Key[string]
+}
+
+var jobSpecs = []struct{ Name, Schedule string }{
+	{"image-gc", "daily@03:30"},
+	{"galgame-image-refping", "daily@04:00"},
+	{"catalog-image-refping", "daily@04:15"},
+	{"news-image-refping", "daily@04:20"},
+	{"user-avatar-refping", "daily@04:30"},
+	{"image-ref-audit", "daily@04:45"},
+	{"artifact-gc", "daily@05:30"},
+	{"prune-developer-usage", "daily@06:00"},
+	{"ymgal-news-poll", "every:10m"},
+	{"ymgal-news-sweep", "daily@04:05"},
+	{"store-stats-sync", "every:1h"},
+	{"news-moderate", "every:5m"},
+}
+
+var jobKeys, jobsDomain = buildJobKeys()
+
+func buildJobKeys() (map[string]JobKeys, settings.Domain) {
+	byName := make(map[string]JobKeys, len(jobSpecs))
+	entries := make([]settings.Entry, 0, len(jobSpecs)*2)
+	for _, spec := range jobSpecs {
+		n := strings.ReplaceAll(spec.Name, "-", "_")
+		jk := JobKeys{
+			Enabled: settings.Bool(settings.Meta{
+				Name:   "jobs." + n + ".enabled",
+				DescEN: "Whether the scheduler runs " + spec.Name + " on its schedule; off leaves it manual-only (run-now from the console still works).",
+				DescZH: "调度器是否按计划自动运行 " + spec.Name + ";关闭后只能在控制台手动触发。",
+			}, true),
+			Schedule: settings.String(settings.Meta{
+				Name:    "jobs." + n + ".schedule",
+				DescEN:  "When " + spec.Name + " runs: daily@HH:MM (server local time, UTC in production) or every:<N>m / every:<N>h.",
+				DescZH:  spec.Name + " 的运行计划:daily@HH:MM(服务器本地时间,生产为 UTC)或 every:<N>m / every:<N>h。",
+				Pattern: JobSchedulePattern,
+			}, spec.Schedule),
+		}
+		byName[spec.Name] = jk
+		entries = append(entries, jk.Enabled, jk.Schedule)
+	}
+	return byName, settings.Domain{
+		Name:    "jobs",
+		TitleZH: "后台任务",
+		Keys:    entries,
+	}
+}
+
+func Job(name string) (JobKeys, bool) {
+	jk, ok := jobKeys[name]
+	return jk, ok
+}
+
+func JobNames() []string {
+	out := make([]string, len(jobSpecs))
+	for i, spec := range jobSpecs {
+		out[i] = spec.Name
+	}
+	return out
+}

--- a/apps/api/internal/platform/settings/keys/keys.go
+++ b/apps/api/internal/platform/settings/keys/keys.go
@@ -2,6 +2,23 @@ package keys
 
 import "api/internal/platform/settings"
 
+var PlatformReadOnly = settings.Bool(settings.Meta{
+	Name:       "platform.read_only",
+	DescEN:     "Tells every site to refuse writes (posting, editing, uploads) and show a maintenance notice; used during platform-wide maintenance such as a database move.",
+	DescZH:     "通知所有站点拒绝写操作(发帖/编辑/上传)并展示维护提示,用于数据库迁移等全平台维护窗口。",
+	SiteScoped: true,
+	Public:     true,
+}, false)
+
+var PlatformNotice = settings.String(settings.Meta{
+	Name:       "platform.notice",
+	DescEN:     "A one-line notice every site should show at the top of its pages; empty shows nothing.",
+	DescZH:     "各站点应在页面顶部展示的一行公告,留空则不展示。",
+	Pattern:    `^[^\n]{0,500}$`,
+	SiteScoped: true,
+	Public:     true,
+}, "")
+
 var AuthVerificationCodeTTLMinutes = settings.Int(settings.Meta{
 	Name:   "auth.verification_code_ttl_minutes",
 	EnvVar: "KUN_AUTH_VERIFICATION_CODE_TTL_MINUTES",
@@ -16,6 +33,7 @@ var ImageUploadEnabled = settings.Bool(settings.Meta{
 	EnvVar: "KUN_IMAGE_UPLOAD_ENABLED",
 	DescEN: "Master switch for accepting new image uploads; off rejects every upload.",
 	DescZH: "图床上传总开关,关闭后拒绝所有新上传。",
+	Public: true,
 }, false)
 
 var ArtifactUploadEnabled = settings.Bool(settings.Meta{
@@ -23,6 +41,7 @@ var ArtifactUploadEnabled = settings.Bool(settings.Meta{
 	EnvVar: "KUN_ARTIFACT_UPLOAD_ENABLED",
 	DescEN: "Master switch for accepting new artifact uploads; off rejects every upload.",
 	DescZH: "文件存储上传总开关,关闭后拒绝所有新上传。",
+	Public: true,
 }, false)
 
 var ArtifactMultipartThresholdBytes = settings.Int(settings.Meta{
@@ -156,6 +175,11 @@ var StoreLinkQuotaPerClient = settings.Int(settings.Meta{
 
 var live = settings.NewRegistry(
 	settings.Domain{
+		Name:    "platform",
+		TitleZH: "平台策略",
+		Keys:    []settings.Entry{PlatformReadOnly, PlatformNotice},
+	},
+	settings.Domain{
 		Name:    "auth",
 		TitleZH: "账号与验证",
 		Keys:    []settings.Entry{AuthVerificationCodeTTLMinutes},
@@ -203,6 +227,7 @@ var live = settings.NewRegistry(
 		TitleZH: "DLsite 分销",
 		Keys:    []settings.Entry{StoreLinkQuotaPerClient},
 	},
+	jobsDomain,
 )
 
 func Live() *settings.Registry { return live }

--- a/apps/api/internal/platform/settings/keys/keys_test.go
+++ b/apps/api/internal/platform/settings/keys/keys_test.go
@@ -1,6 +1,7 @@
 package keys_test
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -8,6 +9,8 @@ import (
 )
 
 var goldenNames = []string{
+	"platform.read_only",
+	"platform.notice",
 	"auth.verification_code_ttl_minutes",
 	"image.upload_enabled",
 	"artifact.upload_enabled",
@@ -26,6 +29,30 @@ var goldenNames = []string{
 	"ai.negative_sample_rate",
 	"ai.force_escalate",
 	"store.link_quota_per_client",
+	"jobs.image_gc.enabled",
+	"jobs.image_gc.schedule",
+	"jobs.galgame_image_refping.enabled",
+	"jobs.galgame_image_refping.schedule",
+	"jobs.catalog_image_refping.enabled",
+	"jobs.catalog_image_refping.schedule",
+	"jobs.news_image_refping.enabled",
+	"jobs.news_image_refping.schedule",
+	"jobs.user_avatar_refping.enabled",
+	"jobs.user_avatar_refping.schedule",
+	"jobs.image_ref_audit.enabled",
+	"jobs.image_ref_audit.schedule",
+	"jobs.artifact_gc.enabled",
+	"jobs.artifact_gc.schedule",
+	"jobs.prune_developer_usage.enabled",
+	"jobs.prune_developer_usage.schedule",
+	"jobs.ymgal_news_poll.enabled",
+	"jobs.ymgal_news_poll.schedule",
+	"jobs.ymgal_news_sweep.enabled",
+	"jobs.ymgal_news_sweep.schedule",
+	"jobs.store_stats_sync.enabled",
+	"jobs.store_stats_sync.schedule",
+	"jobs.news_moderate.enabled",
+	"jobs.news_moderate.schedule",
 }
 
 func TestLiveRegistryIsWellFormed(t *testing.T) {
@@ -42,7 +69,10 @@ func TestLiveRegistryIsWellFormed(t *testing.T) {
 		if m.DescEN == "" || m.DescZH == "" {
 			t.Errorf("%s: missing description", m.Name)
 		}
-		if m.EnvVar == "" || !strings.HasPrefix(m.EnvVar, "KUN_") {
+		if m.Public && (m.DescEN == "" || m.DescZH == "") {
+			t.Errorf("%s: Public key is missing a description", m.Name)
+		}
+		if m.EnvVar != "" && !strings.HasPrefix(m.EnvVar, "KUN_") {
 			t.Errorf("%s: EnvVar %q must start with KUN_", m.Name, m.EnvVar)
 		}
 		if err := e.Validate(e.Default()); err != nil {
@@ -79,6 +109,9 @@ func TestLiveRegistryIsWellFormed(t *testing.T) {
 	envVars := make(map[string]string)
 	for _, e := range entries {
 		m := e.Meta()
+		if m.EnvVar == "" {
+			continue
+		}
 		if other, ok := envVars[m.EnvVar]; ok {
 			t.Errorf("EnvVar %q is used by both %q and %q", m.EnvVar, other, m.Name)
 		}
@@ -91,6 +124,50 @@ func TestLiveRegistryIsWellFormed(t *testing.T) {
 			if !strings.HasPrefix(e.Meta().Name, prefix) {
 				t.Errorf("%s: name %q does not start with %q", d.Name, e.Meta().Name, prefix)
 			}
+		}
+	}
+}
+
+func TestJobKeysLookup(t *testing.T) {
+	jk, ok := keys.Job("image-gc")
+	if !ok {
+		t.Fatal(`Job("image-gc") missing`)
+	}
+	if got := jk.Enabled.Name(); got != "jobs.image_gc.enabled" {
+		t.Errorf("enabled name %q, want jobs.image_gc.enabled", got)
+	}
+	if got := jk.Schedule.Name(); got != "jobs.image_gc.schedule" {
+		t.Errorf("schedule name %q, want jobs.image_gc.schedule", got)
+	}
+	if jk.Enabled.Default() != true {
+		t.Errorf("enabled default %v, want true", jk.Enabled.Default())
+	}
+	if jk.Schedule.Default() != "daily@03:30" {
+		t.Errorf("schedule default %v, want daily@03:30", jk.Schedule.Default())
+	}
+	if _, ok := keys.Job("nope"); ok {
+		t.Error(`Job("nope") should be missing`)
+	}
+
+	names := keys.JobNames()
+	if len(names) != 12 {
+		t.Fatalf("JobNames() = %d, want 12", len(names))
+	}
+	seen := make(map[string]bool, len(names))
+	re := regexp.MustCompile(keys.JobSchedulePattern)
+	for _, name := range names {
+		if seen[name] {
+			t.Errorf("duplicate JobNames entry %q", name)
+		}
+		seen[name] = true
+		jk, ok := keys.Job(name)
+		if !ok {
+			t.Errorf("Job(%q) missing", name)
+			continue
+		}
+		def, _ := jk.Schedule.Default().(string)
+		if !re.MatchString(def) {
+			t.Errorf("%s default %q does not match JobSchedulePattern", name, def)
 		}
 	}
 }

--- a/apps/api/internal/platform/settings/model.go
+++ b/apps/api/internal/platform/settings/model.go
@@ -1,12 +1,28 @@
 package settings
 
 import (
+	"strconv"
 	"time"
 
 	"gorm.io/datatypes"
 )
 
 const ScopePlatform = "platform"
+
+const ScopeSite = "site"
+
+type Scope struct {
+	Kind string
+	ID   string
+}
+
+var PlatformScope = Scope{Kind: ScopePlatform, ID: ""}
+
+func SiteScope(siteID uint) Scope {
+	return Scope{Kind: ScopeSite, ID: strconv.FormatUint(uint64(siteID), 10)}
+}
+
+func (s Scope) IsPlatform() bool { return s.Kind == ScopePlatform }
 
 type SettingOverride struct {
 	ID              uint           `gorm:"primaryKey" json:"id"`

--- a/apps/api/internal/platform/settings/scope_db_test.go
+++ b/apps/api/internal/platform/settings/scope_db_test.go
@@ -1,0 +1,375 @@
+package settings_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"api/internal/platform/settings"
+
+	"gorm.io/datatypes"
+)
+
+func TestStoreSiteScopeIsolated(t *testing.T) {
+	reset(t)
+	seedActor(t)
+	ctx := context.Background()
+	store := settings.NewStore(testDB)
+	key := "t.siteflag"
+
+	if _, err := store.Set(ctx, settings.SiteScope(3), key, json.RawMessage(`true`), "site3", nil, 7); err != nil {
+		t.Fatalf("set site 3: %v", err)
+	}
+
+	plat, err := store.Values(ctx, settings.PlatformScope)
+	if err != nil {
+		t.Fatalf("platform values: %v", err)
+	}
+	if _, ok := plat[key]; ok {
+		t.Errorf("platform values has site key: %s", plat[key])
+	}
+
+	s3, err := store.Values(ctx, settings.SiteScope(3))
+	if err != nil {
+		t.Fatalf("site 3 values: %v", err)
+	}
+	if string(s3[key]) != "true" {
+		t.Errorf("site 3 value = %s, want true", s3[key])
+	}
+
+	s4, err := store.Values(ctx, settings.SiteScope(4))
+	if err != nil {
+		t.Fatalf("site 4 values: %v", err)
+	}
+	if _, ok := s4[key]; ok {
+		t.Errorf("site 4 values has site 3 key: %s", s4[key])
+	}
+
+	platO, err := store.Overrides(ctx, settings.PlatformScope)
+	if err != nil {
+		t.Fatalf("platform overrides: %v", err)
+	}
+	if len(platO) != 0 {
+		t.Errorf("platform overrides = %+v", platO)
+	}
+
+	o3, err := store.Overrides(ctx, settings.SiteScope(3))
+	if err != nil {
+		t.Fatalf("site 3 overrides: %v", err)
+	}
+	if len(o3) != 1 || o3[0].Key != key {
+		t.Errorf("site 3 overrides = %+v", o3)
+	}
+
+	o4, err := store.Overrides(ctx, settings.SiteScope(4))
+	if err != nil {
+		t.Fatalf("site 4 overrides: %v", err)
+	}
+	if len(o4) != 0 {
+		t.Errorf("site 4 overrides = %+v", o4)
+	}
+
+	entries, err := store.RecentAudit(ctx, 50)
+	if err != nil {
+		t.Fatalf("audit: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("audit has %d rows, want 1: %+v", len(entries), entries)
+	}
+	if entries[0].ScopeKind != settings.ScopeSite || entries[0].ScopeID != "3" {
+		t.Errorf("audit scope = %q %q, want site 3", entries[0].ScopeKind, entries[0].ScopeID)
+	}
+}
+
+func TestStoreSiteVersionConflict(t *testing.T) {
+	reset(t)
+	seedActor(t)
+	ctx := context.Background()
+	store := settings.NewStore(testDB)
+	key := "t.sitever"
+	scope := settings.SiteScope(3)
+
+	row, err := store.Set(ctx, scope, key, json.RawMessage(`true`), "first", nil, 7)
+	if err != nil {
+		t.Fatalf("first set: %v", err)
+	}
+	if row.Version != 1 {
+		t.Errorf("first version = %d, want 1", row.Version)
+	}
+
+	v1 := int64(1)
+	if _, err := store.Set(ctx, scope, key, json.RawMessage(`false`), "second", &v1, 7); err != nil {
+		t.Fatalf("expectVersion 1 on version 1 = %v, want nil", err)
+	}
+
+	got, err := store.Values(ctx, scope)
+	if err != nil {
+		t.Fatalf("values after v1 write: %v", err)
+	}
+	if string(got[key]) != "false" {
+		t.Errorf("v1 write = %s, want false", got[key])
+	}
+
+	if _, err := store.Set(ctx, scope, key, json.RawMessage(`true`), "stale", &v1, 7); err != settings.ErrVersionConflict {
+		t.Errorf("stale version = %v, want ErrVersionConflict", err)
+	}
+	got, err = store.Values(ctx, scope)
+	if err != nil {
+		t.Fatalf("values after conflict: %v", err)
+	}
+	if string(got[key]) != "false" {
+		t.Errorf("conflict wrote a value: %s", got[key])
+	}
+
+	v99 := int64(99)
+	if _, err := store.Set(ctx, scope, "t.missing", json.RawMessage(`true`), "", &v99, 7); err != settings.ErrVersionConflict {
+		t.Errorf("non-zero expectVersion on missing = %v, want ErrVersionConflict", err)
+	}
+
+	plat, err := store.Values(ctx, settings.PlatformScope)
+	if err != nil {
+		t.Fatalf("platform values: %v", err)
+	}
+	if _, ok := plat[key]; ok {
+		t.Errorf("site writes leaked to platform: %s", plat[key])
+	}
+}
+
+func TestServiceSiteScope(t *testing.T) {
+	reset(t)
+	seedActor(t)
+	ctx := context.Background()
+
+	scoped := settings.Bool(settings.Meta{
+		Name: "sc.flag", DescEN: "e", DescZH: "z",
+		SiteScoped: true,
+	}, false)
+	plain := settings.Int(settings.Meta{
+		Name: "pl.count", DescEN: "e", DescZH: "z",
+		Min: settings.F(0), Max: settings.F(10),
+	}, 1)
+	reg := settings.NewRegistry(
+		settings.Domain{Name: "sc", TitleZH: "sc", Keys: []settings.Entry{scoped}},
+		settings.Domain{Name: "pl", TitleZH: "pl", Keys: []settings.Entry{plain}},
+	)
+	dist := settings.NewDistributor(testDB, reg, nil)
+	svc := settings.NewService(reg, settings.NewStore(testDB), dist)
+	site := settings.SiteScope(3)
+
+	_, err := svc.Set(ctx, 7, site, plain.Name(), json.RawMessage(`2`), "", nil)
+	if !errors.Is(err, settings.ErrNotSiteScoped) {
+		t.Errorf("plain key site set = %v, want ErrNotSiteScoped", err)
+	}
+	var n int64
+	testDB.Model(&settings.SettingOverride{}).Count(&n)
+	if n != 0 {
+		t.Errorf("rejected site write left %d override row(s)", n)
+	}
+
+	view, err := svc.Set(ctx, 7, site, scoped.Name(), json.RawMessage(`true`), "site", nil)
+	if err != nil {
+		t.Fatalf("set site scoped: %v", err)
+	}
+	if view.Source != settings.SourceSite || view.Effective != true {
+		t.Errorf("set view = %+v", view)
+	}
+	if view.Override == nil || view.Override.Version != 1 {
+		t.Errorf("set override = %+v", view.Override)
+	}
+	if view.Inherited != false {
+		t.Errorf("set view inherited = %v, want the platform default false", view.Inherited)
+	}
+	if scoped.Get() != false {
+		t.Errorf("in-process Get after site set = %v, want default false", scoped.Get())
+	}
+	if plain.Get() != 1 {
+		t.Errorf("plain Get = %d, want 1", plain.Get())
+	}
+
+	ov, err := svc.Overview(ctx, true, site)
+	if err != nil {
+		t.Fatalf("site overview: %v", err)
+	}
+	if len(ov.Domains) != 1 || ov.Domains[0].Name != "sc" || len(ov.Domains[0].Keys) != 1 {
+		t.Fatalf("site overview domains = %+v", ov.Domains)
+	}
+	kv := ov.Domains[0].Keys[0]
+	if kv.Source != settings.SourceSite || kv.Effective != true || kv.Override == nil || kv.Override.Version != 1 {
+		t.Errorf("site overview key = %+v", kv)
+	}
+	if kv.Inherited != false {
+		t.Errorf("site overview inherited = %v, want the platform default false", kv.Inherited)
+	}
+
+	plat, err := svc.Overview(ctx, true, settings.PlatformScope)
+	if err != nil {
+		t.Fatalf("platform overview: %v", err)
+	}
+	if len(plat.Domains) != 2 {
+		t.Fatalf("platform overview domains = %+v", plat.Domains)
+	}
+	found := false
+	for _, d := range plat.Domains {
+		for _, k := range d.Keys {
+			if k.Key == scoped.Name() {
+				found = true
+				if k.Source != settings.SourceDefault {
+					t.Errorf("platform view of scoped key source = %q, want default", k.Source)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("platform overview missing scoped key")
+	}
+
+	view, err = svc.Reset(ctx, 7, site, scoped.Name(), "undo")
+	if err != nil {
+		t.Fatalf("reset site: %v", err)
+	}
+	if view.Source != settings.SourceDefault || view.Override != nil {
+		t.Errorf("reset view = %+v", view)
+	}
+
+	ov, err = svc.Overview(ctx, false, site)
+	if err != nil {
+		t.Fatalf("overview after site reset: %v", err)
+	}
+	kv = ov.Domains[0].Keys[0]
+	if kv.Source != settings.SourceDefault || kv.Override != nil {
+		t.Errorf("overview after site reset = %+v", kv)
+	}
+
+	_, err = svc.Reset(ctx, 7, site, scoped.Name(), "")
+	if !errors.Is(err, settings.ErrNoOverride) {
+		t.Errorf("second reset = %v, want ErrNoOverride", err)
+	}
+}
+
+func TestServiceEffective(t *testing.T) {
+	reset(t)
+	seedActor(t)
+	ctx := context.Background()
+
+	a := settings.Bool(settings.Meta{
+		Name: "eff.a", DescEN: "e", DescZH: "z",
+		Public: true, SiteScoped: true,
+	}, false)
+	b := settings.Bool(settings.Meta{
+		Name: "eff.b", DescEN: "e", DescZH: "z",
+		Public: true,
+	}, false)
+	c := settings.Bool(settings.Meta{
+		Name: "eff.c", DescEN: "e", DescZH: "z",
+	}, false)
+	reg := settings.NewRegistry(settings.Domain{
+		Name: "eff", TitleZH: "eff", Keys: []settings.Entry{a, b, c},
+	})
+	dist := settings.NewDistributor(testDB, reg, nil)
+	svc := settings.NewService(reg, settings.NewStore(testDB), dist)
+
+	view, err := svc.Effective(ctx, nil)
+	if err != nil {
+		t.Fatalf("effective nil: %v", err)
+	}
+	if view.SiteID != nil {
+		t.Errorf("site_id = %v, want nil", view.SiteID)
+	}
+	if len(view.Settings) != 2 {
+		t.Errorf("settings = %+v, want a and b", view.Settings)
+	}
+	if _, ok := view.Settings[c.Name()]; ok {
+		t.Errorf("non-public key leaked: %+v", view.Settings)
+	}
+	if view.Settings[a.Name()] != false || view.Settings[b.Name()] != false {
+		t.Errorf("defaults = %+v", view.Settings)
+	}
+	etagNil := view.ETag
+
+	again, err := svc.Effective(ctx, nil)
+	if err != nil {
+		t.Fatalf("effective nil again: %v", err)
+	}
+	if again.ETag != etagNil {
+		t.Errorf("same settings etag %q vs %q", etagNil, again.ETag)
+	}
+
+	if _, err := svc.Set(ctx, 7, settings.PlatformScope, a.Name(), json.RawMessage(`true`), "plat", nil); err != nil {
+		t.Fatalf("platform set: %v", err)
+	}
+	view, err = svc.Effective(ctx, nil)
+	if err != nil {
+		t.Fatalf("effective after platform set: %v", err)
+	}
+	if view.Settings[a.Name()] != true {
+		t.Errorf("platform current not reflected: %+v", view.Settings)
+	}
+	if view.ETag == etagNil {
+		t.Error("etag did not change after platform set")
+	}
+	etagPlat := view.ETag
+
+	siteID := uint(5)
+	if _, err := svc.Set(ctx, 7, settings.SiteScope(siteID), a.Name(), json.RawMessage(`false`), "site", nil); err != nil {
+		t.Fatalf("site set: %v", err)
+	}
+	siteView, err := svc.Effective(ctx, &siteID)
+	if err != nil {
+		t.Fatalf("effective site 5: %v", err)
+	}
+	if siteView.SiteID == nil || *siteView.SiteID != 5 {
+		t.Errorf("site_id = %v, want 5", siteView.SiteID)
+	}
+	if siteView.Settings[a.Name()] != false {
+		t.Errorf("site 5 a = %v, want false", siteView.Settings[a.Name()])
+	}
+	if siteView.Settings[b.Name()] != false {
+		t.Errorf("site 5 b = %v, want false", siteView.Settings[b.Name()])
+	}
+
+	platView, err := svc.Effective(ctx, nil)
+	if err != nil {
+		t.Fatalf("effective nil after site set: %v", err)
+	}
+	if platView.Settings[a.Name()] != true {
+		t.Errorf("nil site still platform a = %v, want true", platView.Settings[a.Name()])
+	}
+	if platView.ETag != etagPlat {
+		t.Errorf("platform etag changed after site set: %q vs %q", etagPlat, platView.ETag)
+	}
+	if siteView.ETag == platView.ETag {
+		t.Error("site and platform etags must differ")
+	}
+
+	againSite, err := svc.Effective(ctx, &siteID)
+	if err != nil {
+		t.Fatalf("effective site 5 again: %v", err)
+	}
+	if againSite.ETag != siteView.ETag {
+		t.Errorf("same site settings etag %q vs %q", siteView.ETag, againSite.ETag)
+	}
+
+	if err := testDB.Where("scope_kind = ? AND scope_id = ? AND key = ?", settings.ScopeSite, "5", a.Name()).
+		Delete(&settings.SettingOverride{}).Error; err != nil {
+		t.Fatalf("delete site row: %v", err)
+	}
+	if err := testDB.Create(&settings.SettingOverride{
+		ScopeKind:       settings.ScopeSite,
+		ScopeID:         "5",
+		Key:             a.Name(),
+		Value:           datatypes.JSON(`1`),
+		Version:         1,
+		UpdatedByUserID: 7,
+		Note:            "bad",
+	}).Error; err != nil {
+		t.Fatalf("seed invalid site row: %v", err)
+	}
+	bad, err := svc.Effective(ctx, &siteID)
+	if err != nil {
+		t.Fatalf("effective invalid site row: %v", err)
+	}
+	if bad.Settings[a.Name()] != true {
+		t.Errorf("invalid site row must be ignored, a = %v, want platform true", bad.Settings[a.Name()])
+	}
+}

--- a/apps/api/internal/platform/settings/service.go
+++ b/apps/api/internal/platform/settings/service.go
@@ -2,16 +2,20 @@ package settings
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"unicode/utf8"
 )
 
 var (
-	ErrUnknownKey   = errors.New("settings: unknown key")
-	ErrInvalidValue = errors.New("settings: invalid value")
-	ErrNoteTooLong  = errors.New("settings: note exceeds 512 characters")
+	ErrUnknownKey    = errors.New("settings: unknown key")
+	ErrInvalidValue  = errors.New("settings: invalid value")
+	ErrNoteTooLong   = errors.New("settings: note exceeds 512 characters")
+	ErrNotSiteScoped = errors.New("settings: key does not accept a site override")
 )
 
 type OverrideView struct {
@@ -24,19 +28,22 @@ type OverrideView struct {
 }
 
 type KeyView struct {
-	Key       string        `json:"key"`
-	Kind      Kind          `json:"kind"`
-	DescEN    string        `json:"desc_en"`
-	DescZH    string        `json:"desc_zh"`
-	Default   any           `json:"default"`
-	EnvVar    string        `json:"env_var,omitempty"`
-	Enum      []string      `json:"enum,omitempty"`
-	Min       *float64      `json:"min,omitempty"`
-	Max       *float64      `json:"max,omitempty"`
-	Pattern   string        `json:"pattern,omitempty"`
-	Effective any           `json:"effective"`
-	Source    Source        `json:"source"`
-	Override  *OverrideView `json:"override"`
+	Key        string        `json:"key"`
+	Kind       Kind          `json:"kind"`
+	DescEN     string        `json:"desc_en"`
+	DescZH     string        `json:"desc_zh"`
+	Default    any           `json:"default"`
+	EnvVar     string        `json:"env_var,omitempty"`
+	Enum       []string      `json:"enum,omitempty"`
+	Min        *float64      `json:"min,omitempty"`
+	Max        *float64      `json:"max,omitempty"`
+	Pattern    string        `json:"pattern,omitempty"`
+	SiteScoped bool          `json:"site_scoped"`
+	Public     bool          `json:"public"`
+	Effective  any           `json:"effective"`
+	Source     Source        `json:"source"`
+	Override   *OverrideView `json:"override"`
+	Inherited  any           `json:"inherited,omitempty"`
 }
 
 type DomainView struct {
@@ -45,9 +52,21 @@ type DomainView struct {
 	Keys    []KeyView `json:"keys"`
 }
 
+type ScopeView struct {
+	Kind   string `json:"kind"`
+	SiteID *uint  `json:"site_id,omitempty"`
+}
+
 type Overview struct {
+	Scope    ScopeView    `json:"scope"`
 	Domains  []DomainView `json:"domains"`
 	Writable bool         `json:"writable"`
+}
+
+type EffectiveView struct {
+	SiteID   *uint          `json:"site_id"`
+	ETag     string         `json:"etag"`
+	Settings map[string]any `json:"settings"`
 }
 
 type Service struct {
@@ -60,26 +79,46 @@ func NewService(reg *Registry, store *Store, dist *Distributor) *Service {
 	return &Service{reg: reg, store: store, dist: dist}
 }
 
-func (s *Service) Overview(ctx context.Context, writable bool) (*Overview, error) {
-	byKey, err := s.overrideByKey(ctx)
+func (s *Service) Overview(ctx context.Context, writable bool, scope Scope) (*Overview, error) {
+	platformRows, err := s.overrideByKey(ctx, PlatformScope)
 	if err != nil {
 		return nil, err
 	}
-	out := &Overview{Writable: writable}
+	var siteRows map[string]*OverrideRow
+	if !scope.IsPlatform() {
+		siteRows, err = s.overrideByKey(ctx, scope)
+		if err != nil {
+			return nil, err
+		}
+	}
+	out := &Overview{Scope: scopeView(scope), Writable: writable}
 	for _, d := range s.reg.Domains() {
 		view := DomainView{Name: d.Name, TitleZH: d.TitleZH, Keys: make([]KeyView, 0, len(d.Keys))}
 		for _, e := range d.Keys {
-			view.Keys = append(view.Keys, keyView(e, byKey[e.Meta().Name]))
+			if !scope.IsPlatform() && !e.Meta().SiteScoped {
+				continue
+			}
+			v := keyView(e, platformRows[e.Meta().Name])
+			if !scope.IsPlatform() {
+				v = applySiteOverride(e, v, siteRows[e.Meta().Name])
+			}
+			view.Keys = append(view.Keys, v)
+		}
+		if !scope.IsPlatform() && len(view.Keys) == 0 {
+			continue
 		}
 		out.Domains = append(out.Domains, view)
 	}
 	return out, nil
 }
 
-func (s *Service) Set(ctx context.Context, actorID uint, key string, raw json.RawMessage, note string, expectVersion *int64) (*KeyView, error) {
+func (s *Service) Set(ctx context.Context, actorID uint, scope Scope, key string, raw json.RawMessage, note string, expectVersion *int64) (*KeyView, error) {
 	e, ok := s.reg.Lookup(key)
 	if !ok {
 		return nil, ErrUnknownKey
+	}
+	if !scope.IsPlatform() && !e.Meta().SiteScoped {
+		return nil, ErrNotSiteScoped
 	}
 	if utf8.RuneCountInString(note) > 512 {
 		return nil, ErrNoteTooLong
@@ -91,40 +130,92 @@ func (s *Service) Set(ctx context.Context, actorID uint, key string, raw json.Ra
 	if err := e.Validate(v); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidValue, err)
 	}
-	if _, err := s.store.Set(ctx, key, raw, note, expectVersion, actorID); err != nil {
+	if _, err := s.store.Set(ctx, scope, key, raw, note, expectVersion, actorID); err != nil {
 		return nil, err
 	}
-	if err := s.dist.Refresh(ctx); err != nil {
-		return nil, err
+	if scope.IsPlatform() {
+		if err := s.dist.Refresh(ctx); err != nil {
+			return nil, err
+		}
+		s.dist.Announce(ctx)
 	}
-	s.dist.Announce(ctx)
-	return s.viewFor(ctx, e)
+	return s.viewFor(ctx, e, scope)
 }
 
-func (s *Service) Reset(ctx context.Context, actorID uint, key string, note string) (*KeyView, error) {
+func (s *Service) Reset(ctx context.Context, actorID uint, scope Scope, key string, note string) (*KeyView, error) {
 	e, ok := s.reg.Lookup(key)
 	if !ok {
 		return nil, ErrUnknownKey
 	}
+	if !scope.IsPlatform() && !e.Meta().SiteScoped {
+		return nil, ErrNotSiteScoped
+	}
 	if utf8.RuneCountInString(note) > 512 {
 		return nil, ErrNoteTooLong
 	}
-	if err := s.store.Reset(ctx, key, note, actorID); err != nil {
+	if err := s.store.Reset(ctx, scope, key, note, actorID); err != nil {
 		return nil, err
 	}
-	if err := s.dist.Refresh(ctx); err != nil {
-		return nil, err
+	if scope.IsPlatform() {
+		if err := s.dist.Refresh(ctx); err != nil {
+			return nil, err
+		}
+		s.dist.Announce(ctx)
 	}
-	s.dist.Announce(ctx)
-	return s.viewFor(ctx, e)
+	return s.viewFor(ctx, e, scope)
 }
 
 func (s *Service) Audit(ctx context.Context, limit int) ([]AuditEntry, error) {
 	return s.store.RecentAudit(ctx, limit)
 }
 
-func (s *Service) overrideByKey(ctx context.Context) (map[string]*OverrideRow, error) {
-	rows, err := s.store.Overrides(ctx)
+func (s *Service) Effective(ctx context.Context, siteID *uint) (*EffectiveView, error) {
+	out := make(map[string]any)
+	for _, e := range s.reg.Entries() {
+		if !e.Meta().Public {
+			continue
+		}
+		out[e.Meta().Name] = e.Current()
+	}
+	if siteID != nil {
+		rows, err := s.store.Values(ctx, SiteScope(*siteID))
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range s.reg.Entries() {
+			m := e.Meta()
+			if !m.Public || !m.SiteScoped {
+				continue
+			}
+			raw, ok := rows[m.Name]
+			if !ok {
+				continue
+			}
+			v, err := e.Decode(raw)
+			if err != nil {
+				continue
+			}
+			if err := e.Validate(v); err != nil {
+				continue
+			}
+			out[m.Name] = v
+		}
+	}
+	return &EffectiveView{
+		SiteID:   siteID,
+		ETag:     etagFor(out),
+		Settings: out,
+	}, nil
+}
+
+func etagFor(settings map[string]any) string {
+	b, _ := json.Marshal(settings)
+	sum := sha256.Sum256(b)
+	return `"` + hex.EncodeToString(sum[:8]) + `"`
+}
+
+func (s *Service) overrideByKey(ctx context.Context, scope Scope) (map[string]*OverrideRow, error) {
+	rows, err := s.store.Overrides(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -135,34 +226,78 @@ func (s *Service) overrideByKey(ctx context.Context) (map[string]*OverrideRow, e
 	return byKey, nil
 }
 
-func (s *Service) viewFor(ctx context.Context, e Entry) (*KeyView, error) {
-	byKey, err := s.overrideByKey(ctx)
+func (s *Service) viewFor(ctx context.Context, e Entry, scope Scope) (*KeyView, error) {
+	platformRows, err := s.overrideByKey(ctx, PlatformScope)
 	if err != nil {
 		return nil, err
 	}
-	v := keyView(e, byKey[e.Meta().Name])
+	v := keyView(e, platformRows[e.Meta().Name])
+	if scope.IsPlatform() {
+		return &v, nil
+	}
+	siteRows, err := s.overrideByKey(ctx, scope)
+	if err != nil {
+		return nil, err
+	}
+	v = applySiteOverride(e, v, siteRows[e.Meta().Name])
 	return &v, nil
+}
+
+func scopeView(scope Scope) ScopeView {
+	if scope.IsPlatform() {
+		return ScopeView{Kind: ScopePlatform}
+	}
+	id, _ := strconv.ParseUint(scope.ID, 10, 64)
+	u := uint(id)
+	return ScopeView{Kind: ScopeSite, SiteID: &u}
 }
 
 func keyView(e Entry, row *OverrideRow) KeyView {
 	m := e.Meta()
 	v := KeyView{
-		Key:       m.Name,
-		Kind:      m.Kind,
-		DescEN:    m.DescEN,
-		DescZH:    m.DescZH,
-		Default:   e.Default(),
-		EnvVar:    m.EnvVar,
-		Enum:      m.Enum,
-		Min:       m.Min,
-		Max:       m.Max,
-		Pattern:   m.Pattern,
-		Effective: e.Default(),
-		Source:    SourceDefault,
+		Key:        m.Name,
+		Kind:       m.Kind,
+		DescEN:     m.DescEN,
+		DescZH:     m.DescZH,
+		Default:    e.Default(),
+		EnvVar:     m.EnvVar,
+		Enum:       m.Enum,
+		Min:        m.Min,
+		Max:        m.Max,
+		Pattern:    m.Pattern,
+		SiteScoped: m.SiteScoped,
+		Public:     m.Public,
+		Effective:  e.Default(),
+		Source:     SourceDefault,
 	}
 	if row == nil {
 		return v
 	}
+	ov, decoded, ok := overrideFromRow(e, row)
+	v.Override = ov
+	if ok {
+		v.Effective = decoded
+		v.Source = SourceDB
+	}
+	return v
+}
+
+func applySiteOverride(e Entry, v KeyView, row *OverrideRow) KeyView {
+	v.Inherited = v.Effective
+	if row == nil {
+		v.Override = nil
+		return v
+	}
+	ov, decoded, ok := overrideFromRow(e, row)
+	v.Override = ov
+	if ok {
+		v.Effective = decoded
+		v.Source = SourceSite
+	}
+	return v
+}
+
+func overrideFromRow(e Entry, row *OverrideRow) (*OverrideView, any, bool) {
 	ov := &OverrideView{
 		Version:         row.Version,
 		UpdatedByUserID: row.UpdatedByUserID,
@@ -174,14 +309,14 @@ func keyView(e Entry, row *OverrideRow) KeyView {
 	if err == nil {
 		ov.Value = decoded
 		if e.Validate(decoded) == nil {
-			v.Effective = decoded
-			v.Source = SourceDB
+			return ov, decoded, true
 		}
-	} else if json.Valid(row.Value) {
+		return ov, decoded, false
+	}
+	if json.Valid(row.Value) {
 		var dumped any
 		_ = json.Unmarshal(row.Value, &dumped)
 		ov.Value = dumped
 	}
-	v.Override = ov
-	return v
+	return ov, nil, false
 }

--- a/apps/api/internal/platform/settings/service_db_test.go
+++ b/apps/api/internal/platform/settings/service_db_test.go
@@ -30,17 +30,17 @@ func TestServiceSetUnknownAndInvalid(t *testing.T) {
 	ctx := context.Background()
 	svc, _, _ := serviceHarness(t)
 
-	_, err := svc.Set(ctx, 7, "nope.key", json.RawMessage(`1`), "", nil)
+	_, err := svc.Set(ctx, 7, settings.PlatformScope, "nope.key", json.RawMessage(`1`), "", nil)
 	if !errors.Is(err, settings.ErrUnknownKey) {
 		t.Errorf("unknown key = %v, want ErrUnknownKey", err)
 	}
 
-	_, err = svc.Set(ctx, 7, "svc.count", json.RawMessage(`true`), "", nil)
+	_, err = svc.Set(ctx, 7, settings.PlatformScope, "svc.count", json.RawMessage(`true`), "", nil)
 	if !errors.Is(err, settings.ErrInvalidValue) {
 		t.Errorf("wrong kind = %v, want ErrInvalidValue", err)
 	}
 
-	_, err = svc.Set(ctx, 7, "svc.count", json.RawMessage(`99`), "", nil)
+	_, err = svc.Set(ctx, 7, settings.PlatformScope, "svc.count", json.RawMessage(`99`), "", nil)
 	if !errors.Is(err, settings.ErrInvalidValue) {
 		t.Errorf("out of bounds = %v, want ErrInvalidValue", err)
 	}
@@ -58,7 +58,7 @@ func TestServiceSetResetRefreshAndOverview(t *testing.T) {
 	ctx := context.Background()
 	svc, count, _ := serviceHarness(t)
 
-	view, err := svc.Set(ctx, 7, count.Name(), json.RawMessage(`8`), "up", nil)
+	view, err := svc.Set(ctx, 7, settings.PlatformScope, count.Name(), json.RawMessage(`8`), "up", nil)
 	if err != nil {
 		t.Fatalf("set: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestServiceSetResetRefreshAndOverview(t *testing.T) {
 		t.Errorf("set view = %+v", view)
 	}
 
-	ov, err := svc.Overview(ctx, true)
+	ov, err := svc.Overview(ctx, true, settings.PlatformScope)
 	if err != nil {
 		t.Fatalf("overview: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestServiceSetResetRefreshAndOverview(t *testing.T) {
 		t.Errorf("overview after set = %+v", kv)
 	}
 
-	view, err = svc.Reset(ctx, 7, count.Name(), "undo")
+	view, err = svc.Reset(ctx, 7, settings.PlatformScope, count.Name(), "undo")
 	if err != nil {
 		t.Fatalf("reset: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestServiceSetResetRefreshAndOverview(t *testing.T) {
 		t.Errorf("reset view = %+v", view)
 	}
 
-	ov, err = svc.Overview(ctx, false)
+	ov, err = svc.Overview(ctx, false, settings.PlatformScope)
 	if err != nil {
 		t.Fatalf("overview after reset: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestServiceOverviewKeepsInvalidOverride(t *testing.T) {
 		t.Fatalf("seed invalid row: %v", err)
 	}
 
-	ov, err := svc.Overview(ctx, false)
+	ov, err := svc.Overview(ctx, false, settings.PlatformScope)
 	if err != nil {
 		t.Fatalf("overview: %v", err)
 	}

--- a/apps/api/internal/platform/settings/service_test.go
+++ b/apps/api/internal/platform/settings/service_test.go
@@ -1,0 +1,34 @@
+package settings
+
+import "testing"
+
+func TestETagIsStableAndCanonical(t *testing.T) {
+	a := map[string]any{}
+	a["z"] = true
+	a["m"] = "x"
+	b := map[string]any{}
+	b["m"] = "x"
+	b["z"] = true
+
+	gotA := etagFor(a)
+	gotB := etagFor(b)
+	if gotA != gotB {
+		t.Errorf("etag depends on insertion order: %s vs %s", gotA, gotB)
+	}
+
+	c := map[string]any{"m": "y", "z": true}
+	if etagFor(c) == gotA {
+		t.Errorf("changed value kept etag %s", gotA)
+	}
+
+	if len(gotA) != 18 || gotA[0] != '"' || gotA[len(gotA)-1] != '"' {
+		t.Errorf("etag format = %q, want quoted 16 hex chars", gotA)
+	}
+	for _, r := range gotA[1:17] {
+		if r >= '0' && r <= '9' || r >= 'a' && r <= 'f' {
+			continue
+		}
+		t.Errorf("etag %q is not lowercase hex", gotA)
+		break
+	}
+}

--- a/apps/api/internal/platform/settings/store.go
+++ b/apps/api/internal/platform/settings/store.go
@@ -27,22 +27,22 @@ type OverrideRow struct {
 	UpdatedByName string
 }
 
-func (s *Store) Overrides(ctx context.Context) ([]OverrideRow, error) {
+func (s *Store) Overrides(ctx context.Context, scope Scope) ([]OverrideRow, error) {
 	var rows []OverrideRow
 	err := s.db.WithContext(ctx).
 		Model(&SettingOverride{}).
 		Select("setting_overrides.*, users.name AS updated_by_name").
 		Joins("LEFT JOIN users ON users.id = setting_overrides.updated_by_user_id").
-		Where("setting_overrides.scope_kind = ? AND setting_overrides.scope_id = ?", ScopePlatform, "").
+		Where("setting_overrides.scope_kind = ? AND setting_overrides.scope_id = ?", scope.Kind, scope.ID).
 		Order("setting_overrides.key").
 		Scan(&rows).Error
 	return rows, err
 }
 
-func (s *Store) Values(ctx context.Context) (map[string]json.RawMessage, error) {
+func (s *Store) Values(ctx context.Context, scope Scope) (map[string]json.RawMessage, error) {
 	var rows []SettingOverride
 	err := s.db.WithContext(ctx).
-		Where("scope_kind = ? AND scope_id = ?", ScopePlatform, "").
+		Where("scope_kind = ? AND scope_id = ?", scope.Kind, scope.ID).
 		Find(&rows).Error
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func (s *Store) Values(ctx context.Context) (map[string]json.RawMessage, error) 
 	return out, nil
 }
 
-func (s *Store) Set(ctx context.Context, key string, value json.RawMessage, note string, expectVersion *int64, actorID uint) (*SettingOverride, error) {
+func (s *Store) Set(ctx context.Context, scope Scope, key string, value json.RawMessage, note string, expectVersion *int64, actorID uint) (*SettingOverride, error) {
 	compacted, err := compactJSON(value)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (s *Store) Set(ctx context.Context, key string, value json.RawMessage, note
 	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var row SettingOverride
 		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Where("scope_kind = ? AND scope_id = ? AND key = ?", ScopePlatform, "", key).
+			Where("scope_kind = ? AND scope_id = ? AND key = ?", scope.Kind, scope.ID, key).
 			Take(&row).Error
 		exists := err == nil
 		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -92,8 +92,8 @@ func (s *Store) Set(ctx context.Context, key string, value json.RawMessage, note
 			}
 		} else {
 			row = SettingOverride{
-				ScopeKind:       ScopePlatform,
-				ScopeID:         "",
+				ScopeKind:       scope.Kind,
+				ScopeID:         scope.ID,
 				Key:             key,
 				Value:           compacted,
 				Version:         1,
@@ -109,8 +109,8 @@ func (s *Store) Set(ctx context.Context, key string, value json.RawMessage, note
 		return tx.Create(&SettingAuditLog{
 			ActorUserID: actorID,
 			Action:      ActionSet,
-			ScopeKind:   ScopePlatform,
-			ScopeID:     "",
+			ScopeKind:   scope.Kind,
+			ScopeID:     scope.ID,
 			Key:         key,
 			OldValue:    oldValue,
 			NewValue:    compacted,
@@ -123,11 +123,11 @@ func (s *Store) Set(ctx context.Context, key string, value json.RawMessage, note
 	return &out, nil
 }
 
-func (s *Store) Reset(ctx context.Context, key string, note string, actorID uint) error {
+func (s *Store) Reset(ctx context.Context, scope Scope, key string, note string, actorID uint) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var row SettingOverride
 		err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
-			Where("scope_kind = ? AND scope_id = ? AND key = ?", ScopePlatform, "", key).
+			Where("scope_kind = ? AND scope_id = ? AND key = ?", scope.Kind, scope.ID, key).
 			Take(&row).Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return ErrNoOverride
@@ -142,8 +142,8 @@ func (s *Store) Reset(ctx context.Context, key string, note string, actorID uint
 		return tx.Create(&SettingAuditLog{
 			ActorUserID: actorID,
 			Action:      ActionReset,
-			ScopeKind:   ScopePlatform,
-			ScopeID:     "",
+			ScopeKind:   scope.Kind,
+			ScopeID:     scope.ID,
 			Key:         key,
 			OldValue:    row.Value,
 			Note:        note,
@@ -156,6 +156,8 @@ type AuditEntry struct {
 	ActorUserID uint            `json:"actor_user_id"`
 	ActorName   string          `json:"actor_name"`
 	Action      string          `json:"action"`
+	ScopeKind   string          `json:"scope_kind"`
+	ScopeID     string          `json:"scope_id"`
 	Key         string          `json:"key"`
 	OldValue    json.RawMessage `json:"old_value"`
 	NewValue    json.RawMessage `json:"new_value"`
@@ -188,6 +190,8 @@ func (s *Store) RecentAudit(ctx context.Context, limit int) ([]AuditEntry, error
 			ActorUserID: r.ActorUserID,
 			ActorName:   r.ActorName,
 			Action:      r.Action,
+			ScopeKind:   r.ScopeKind,
+			ScopeID:     r.ScopeID,
 			Key:         r.Key,
 			OldValue:    jsonOrNull(r.OldValue),
 			NewValue:    jsonOrNull(r.NewValue),

--- a/apps/api/internal/platform/settings/store_db_test.go
+++ b/apps/api/internal/platform/settings/store_db_test.go
@@ -80,7 +80,7 @@ func TestStoreSetResetVersionAndAudit(t *testing.T) {
 	store := settings.NewStore(testDB)
 	key := "t.count"
 
-	row, err := store.Set(ctx, key, json.RawMessage(`15`), "first", nil, 7)
+	row, err := store.Set(ctx, settings.PlatformScope, key, json.RawMessage(`15`), "first", nil, 7)
 	if err != nil {
 		t.Fatalf("first set: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestStoreSetResetVersionAndAudit(t *testing.T) {
 		t.Errorf("first new_value = %q, want 15", entries[0].NewValue)
 	}
 
-	row, err = store.Set(ctx, key, json.RawMessage(`16`), "second", nil, 7)
+	row, err = store.Set(ctx, settings.PlatformScope, key, json.RawMessage(`16`), "second", nil, 7)
 	if err != nil {
 		t.Fatalf("second set: %v", err)
 	}
@@ -125,10 +125,10 @@ func TestStoreSetResetVersionAndAudit(t *testing.T) {
 	}
 
 	v1 := int64(1)
-	if _, err := store.Set(ctx, key, json.RawMessage(`17`), "stale", &v1, 7); err != settings.ErrVersionConflict {
+	if _, err := store.Set(ctx, settings.PlatformScope, key, json.RawMessage(`17`), "stale", &v1, 7); err != settings.ErrVersionConflict {
 		t.Errorf("stale version = %v, want ErrVersionConflict", err)
 	}
-	got, err := store.Values(ctx)
+	got, err := store.Values(ctx, settings.PlatformScope)
 	if err != nil {
 		t.Fatalf("values after conflict: %v", err)
 	}
@@ -137,17 +137,17 @@ func TestStoreSetResetVersionAndAudit(t *testing.T) {
 	}
 
 	v99 := int64(99)
-	if _, err := store.Set(ctx, "t.missing", json.RawMessage(`1`), "", &v99, 7); err != settings.ErrVersionConflict {
+	if _, err := store.Set(ctx, settings.PlatformScope, "t.missing", json.RawMessage(`1`), "", &v99, 7); err != settings.ErrVersionConflict {
 		t.Errorf("non-zero expectVersion on missing = %v, want ErrVersionConflict", err)
 	}
 
-	if err := store.Reset(ctx, key, "undo", 7); err != nil {
+	if err := store.Reset(ctx, settings.PlatformScope, key, "undo", 7); err != nil {
 		t.Fatalf("reset: %v", err)
 	}
-	if _, err := store.Values(ctx); err != nil {
+	if _, err := store.Values(ctx, settings.PlatformScope); err != nil {
 		t.Fatalf("values after reset: %v", err)
 	}
-	got, _ = store.Values(ctx)
+	got, _ = store.Values(ctx, settings.PlatformScope)
 	if _, ok := got[key]; ok {
 		t.Errorf("reset left a value: %s", got[key])
 	}
@@ -166,11 +166,11 @@ func TestStoreSetResetVersionAndAudit(t *testing.T) {
 		t.Errorf("reset new_value = %q, want JSON null", entries[0].NewValue)
 	}
 
-	if err := store.Reset(ctx, key, "", 7); err != settings.ErrNoOverride {
+	if err := store.Reset(ctx, settings.PlatformScope, key, "", 7); err != settings.ErrNoOverride {
 		t.Errorf("reset missing = %v, want ErrNoOverride", err)
 	}
 
-	overrides, err := store.Overrides(ctx)
+	overrides, err := store.Overrides(ctx, settings.PlatformScope)
 	if err != nil {
 		t.Fatalf("overrides after reset: %v", err)
 	}
@@ -178,11 +178,11 @@ func TestStoreSetResetVersionAndAudit(t *testing.T) {
 		t.Errorf("overrides after reset = %+v", overrides)
 	}
 
-	_, err = store.Set(ctx, key, json.RawMessage(`1`), "named", nil, 7)
+	_, err = store.Set(ctx, settings.PlatformScope, key, json.RawMessage(`1`), "named", nil, 7)
 	if err != nil {
 		t.Fatalf("set for name join: %v", err)
 	}
-	overrides, err = store.Overrides(ctx)
+	overrides, err = store.Overrides(ctx, settings.PlatformScope)
 	if err != nil {
 		t.Fatalf("overrides: %v", err)
 	}

--- a/apps/web/app/components/jobs/Container.vue
+++ b/apps/web/app/components/jobs/Container.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-import { jobStatusMeta, jobTriggerLabel } from '~/constants/jobs'
+import {
+  jobStatusMeta,
+  jobTriggerLabel,
+  formatJobSchedule,
+  JOB_DISABLED_LABEL
+} from '~/constants/jobs'
 import type { JobInfo } from '~~/shared/types/jobs'
 
 const api = useApi()
@@ -32,7 +37,8 @@ const openHistory = (name: string) => {
   historyOpen.value = true
 }
 
-const fmt = (s?: string | null) => (s ? new Date(s).toLocaleString('zh-CN') : '—')
+const fmt = (s?: string | null) =>
+  s ? new Date(s).toLocaleString('zh-CN') : '—'
 
 const duration = (run: JobInfo['latest_run']): string => {
   if (!run || !run.finished_at) return ''
@@ -42,9 +48,6 @@ const duration = (run: JobInfo['latest_run']): string => {
   if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
   return `${Math.floor(ms / 60_000)}m${Math.round((ms % 60_000) / 1000)}s`
 }
-
-const scheduleLabel = (job: JobInfo) =>
-  job.daily_at ? `每日 ${job.daily_at}` : job.auto ? '定时' : '手动'
 </script>
 
 <template>
@@ -53,7 +56,10 @@ const scheduleLabel = (job: JobInfo) =>
       <div>
         <h1 class="text-foreground text-2xl font-bold">后台任务</h1>
         <p class="text-default-500 mt-1">
-          调度状态、最近执行与手动触发 · 共 {{ jobs.length }} 个任务
+          调度状态、最近执行与手动触发 · 共 {{ jobs.length }} 个任务 ·
+          <NuxtLink to="/settings" class="text-primary hover:underline">
+            调度与开关在配置中心的「后台任务」域修改
+          </NuxtLink>
         </p>
       </div>
       <KunButton variant="flat" :disabled="isLoading" @click="() => refresh()">
@@ -97,9 +103,19 @@ const scheduleLabel = (job: JobInfo) =>
               {{ job.name }}
             </p>
           </div>
-          <KunChip color="default" variant="flat" size="xs" class="shrink-0">
-            {{ scheduleLabel(job) }}
-          </KunChip>
+          <div class="flex shrink-0 flex-wrap items-center justify-end gap-1">
+            <KunChip color="default" variant="flat" size="xs">
+              {{ formatJobSchedule(job.schedule) }}
+            </KunChip>
+            <KunChip
+              v-if="!job.enabled"
+              color="warning"
+              variant="flat"
+              size="xs"
+            >
+              {{ JOB_DISABLED_LABEL }}
+            </KunChip>
+          </div>
         </div>
 
         <div class="text-default-500 mt-3 space-y-1 text-sm">
@@ -113,10 +129,7 @@ const scheduleLabel = (job: JobInfo) =>
                 · {{ jobTriggerLabel(job.latest_run.trigger) }}触发
               </span>
             </p>
-            <p
-              v-if="job.latest_run.error"
-              class="text-danger-600 break-words"
-            >
+            <p v-if="job.latest_run.error" class="text-danger-600 break-words">
               {{ job.latest_run.error }}
             </p>
             <p

--- a/apps/web/app/components/settings/AuditList.vue
+++ b/apps/web/app/components/settings/AuditList.vue
@@ -10,6 +10,7 @@ defineProps<{
   entries: SettingsAuditEntry[]
   hasError: boolean
   kinds: Record<string, SettingKind>
+  siteNames: Record<string, string>
 }>()
 const emit = defineEmits<{ retry: [] }>()
 
@@ -17,6 +18,14 @@ const formatTime = (iso: string) => new Date(iso).toLocaleString()
 
 const kindOf = (kinds: Record<string, SettingKind>, key: string): SettingKind =>
   kinds[key] ?? 'string'
+
+const scopeLabel = (
+  entry: SettingsAuditEntry,
+  names: Record<string, string>
+) =>
+  entry.scope_kind === 'site'
+    ? names[entry.scope_id] || `站点 #${entry.scope_id}`
+    : '平台'
 </script>
 
 <template>
@@ -26,12 +35,13 @@ const kindOf = (kinds: Record<string, SettingKind>, key: string): SettingKind =>
     <CommonFetchError v-if="hasError" @retry="emit('retry')" />
 
     <div v-else class="overflow-x-auto">
-      <table class="w-full min-w-[52rem] text-sm">
+      <table class="w-full min-w-[60rem] text-sm">
         <thead class="text-default-500">
           <tr>
             <th class="px-3 py-2 text-left font-medium">时间</th>
             <th class="px-3 py-2 text-left font-medium">操作者</th>
             <th class="px-3 py-2 text-left font-medium">动作</th>
+            <th class="px-3 py-2 text-left font-medium">作用域</th>
             <th class="px-3 py-2 text-left font-medium">键</th>
             <th class="px-3 py-2 text-left font-medium">旧值 → 新值</th>
             <th class="px-3 py-2 text-left font-medium">备注</th>
@@ -58,6 +68,9 @@ const kindOf = (kinds: Record<string, SettingKind>, key: string): SettingKind =>
                 {{ AUDIT_ACTION_LABELS[entry.action] || entry.action }}
               </KunChip>
             </td>
+            <td class="text-foreground px-3 py-2">
+              {{ scopeLabel(entry, siteNames) }}
+            </td>
             <td class="text-foreground px-3 py-2 font-mono break-all">
               {{ entry.key }}
             </td>
@@ -75,7 +88,7 @@ const kindOf = (kinds: Record<string, SettingKind>, key: string): SettingKind =>
             </td>
           </tr>
           <tr v-if="!entries.length">
-            <td colspan="6" class="text-default-400 px-3 py-8 text-center">
+            <td colspan="7" class="text-default-400 px-3 py-8 text-center">
               暂无配置变更
             </td>
           </tr>

--- a/apps/web/app/components/settings/Container.vue
+++ b/apps/web/app/components/settings/Container.vue
@@ -6,18 +6,56 @@ import type {
   SettingKind,
   SettingValue
 } from '~~/shared/types/settings'
-import { AUDIT_LIST_LIMIT } from '~/constants/settings'
+import {
+  AUDIT_LIST_LIMIT,
+  PLATFORM_SCOPE_LABEL,
+  SITE_SCOPE_HINT
+} from '~/constants/settings'
 
 const CONFLICT_MESSAGE = '该配置已被其他人修改,请刷新后重试'
 
 const api = useApi()
+
+const siteId = ref(0)
+
+const { data: sitesData } = await useApiFetch<Site[]>('/sites')
+const sites = computed(() => sitesData.value ?? [])
+
+const scopeOptions = computed(() => [
+  { value: 0, label: PLATFORM_SCOPE_LABEL },
+  ...sites.value.map((site) => ({
+    value: site.id,
+    label: `${site.name} · ${site.domain}`
+  }))
+])
+
+const siteName = computed(() => {
+  if (siteId.value <= 0) return ''
+  return sites.value.find((site) => site.id === siteId.value)?.name ?? ''
+})
+
+const siteNames = computed<Record<string, string>>(() => {
+  const map: Record<string, string> = {}
+  for (const site of sites.value) {
+    map[String(site.id)] = site.name
+  }
+  return map
+})
+
+const scopeKind = computed<'platform' | 'site'>(() =>
+  siteId.value > 0 ? 'site' : 'platform'
+)
 
 const {
   data: overviewData,
   status,
   refresh: refreshOverview,
   error
-} = await useApiFetch<SettingsOverview>('/admin/settings')
+} = await useApiFetch<SettingsOverview>('/admin/settings', {
+  query: computed(() => ({
+    ...(siteId.value > 0 ? { site: siteId.value } : {})
+  }))
+})
 
 const {
   data: auditData,
@@ -29,23 +67,34 @@ const {
 
 const overview = computed(() => overviewData.value)
 const auditEntries = computed(() => auditData.value ?? [])
-const isLoading = computed(() => status.value === 'pending')
+const isLoading = computed(
+  () => status.value === 'pending' && !overviewData.value
+)
 const writable = computed(() => overview.value?.writable ?? false)
 
-const kinds = computed<Record<string, SettingKind>>(() => {
-  const map: Record<string, SettingKind> = {}
-  for (const domain of overview.value?.domains ?? []) {
-    for (const row of domain.keys) {
-      map[row.key] = row.kind
+const kinds = ref<Record<string, SettingKind>>({})
+watch(
+  overviewData,
+  (data) => {
+    for (const domain of data?.domains ?? []) {
+      for (const row of domain.keys) {
+        kinds.value[row.key] = row.kind
+      }
     }
-  }
-  return map
-})
+  },
+  { immediate: true }
+)
 
 const editOpen = ref(false)
 const resetOpen = ref(false)
 const pendingRow = ref<SettingsKeyView | null>(null)
 const submitting = ref(false)
+
+watch(siteId, () => {
+  editOpen.value = false
+  resetOpen.value = false
+  pendingRow.value = null
+})
 
 const settingPath = (key: string) =>
   `/admin/settings/${encodeURIComponent(key)}`
@@ -87,7 +136,11 @@ const saveOverride = async (value: SettingValue, note: string) => {
     if (row.override != null) {
       body.version = row.override.version
     }
-    const response = await api.put<SettingsKeyView>(settingPath(row.key), body)
+    const path =
+      siteId.value > 0
+        ? `${settingPath(row.key)}?site=${siteId.value}`
+        : settingPath(row.key)
+    const response = await api.put<SettingsKeyView>(path, body)
     if (response.code === 0) {
       useKunMessage('已保存', 'success')
       editOpen.value = false
@@ -107,7 +160,8 @@ const confirmReset = async (note: string) => {
   submitting.value = true
   try {
     const response = await api.delete<SettingsKeyView>(settingPath(row.key), {
-      note
+      note,
+      ...(siteId.value > 0 ? { site: siteId.value } : {})
     })
     if (response.code === 0) {
       useKunMessage('已撤销覆盖', 'success')
@@ -124,12 +178,25 @@ const confirmReset = async (note: string) => {
 
 <template>
   <div class="space-y-6">
-    <div>
-      <h1 class="text-foreground text-2xl font-bold">配置中心</h1>
-      <p class="text-default-500 mt-1">
-        生效顺序是代码默认 → 环境变量地板 → 这里的覆盖值；30
-        秒内生效；密钥与接线不在这里。
-      </p>
+    <div
+      class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"
+    >
+      <div>
+        <h1 class="text-foreground text-2xl font-bold">配置中心</h1>
+        <p class="text-default-500 mt-1">
+          生效顺序是代码默认 → 环境变量地板 → 这里的覆盖值；30
+          秒内生效；密钥与接线不在这里。
+        </p>
+        <p v-if="scopeKind === 'site'" class="text-default-500 mt-1">
+          {{ SITE_SCOPE_HINT }}
+        </p>
+      </div>
+      <KunSelect
+        v-model="siteId"
+        label="作用域"
+        :options="scopeOptions"
+        class-name="w-full shrink-0 sm:w-72"
+      />
     </div>
 
     <CommonFetchError v-if="error" @retry="refreshOverview" />
@@ -147,6 +214,7 @@ const confirmReset = async (note: string) => {
         :key="domain.name"
         :domain="domain"
         :writable="writable"
+        :scope-kind="scopeKind"
         @edit="askEdit"
         @reset="askReset"
       />
@@ -155,6 +223,7 @@ const confirmReset = async (note: string) => {
         :entries="auditEntries"
         :has-error="Boolean(auditError)"
         :kinds="kinds"
+        :site-names="siteNames"
         @retry="refreshAudit"
       />
 
@@ -162,6 +231,8 @@ const confirmReset = async (note: string) => {
         v-model:open="editOpen"
         :row="pendingRow"
         :submitting="submitting"
+        :scope-kind="scopeKind"
+        :site-name="siteName"
         @save="saveOverride"
       />
 
@@ -169,6 +240,7 @@ const confirmReset = async (note: string) => {
         v-model:open="resetOpen"
         :row="pendingRow"
         :submitting="submitting"
+        :scope-kind="scopeKind"
         @confirm="confirmReset"
       />
     </template>

--- a/apps/web/app/components/settings/DomainCard.vue
+++ b/apps/web/app/components/settings/DomainCard.vue
@@ -8,10 +8,18 @@ import {
   SOURCE_LABELS,
   SOURCE_COLORS,
   ENV_FLOOR_NOTE,
+  PUBLIC_BADGE,
+  PUBLIC_NOTE,
+  SITE_SCOPED_BADGE,
+  SITE_SCOPED_NOTE,
   formatSettingValue
 } from '~/constants/settings'
 
-defineProps<{ domain: SettingsDomainView; writable: boolean }>()
+defineProps<{
+  domain: SettingsDomainView
+  writable: boolean
+  scopeKind: 'platform' | 'site'
+}>()
 const emit = defineEmits<{
   edit: [row: SettingsKeyView]
   reset: [row: SettingsKeyView]
@@ -25,6 +33,9 @@ const rangeText = (row: SettingsKeyView): string => {
   if (row.max != null) return `≤ ${row.max}`
   return ''
 }
+
+const ownSource = (scopeKind: 'platform' | 'site') =>
+  scopeKind === 'site' ? 'site' : 'db'
 </script>
 
 <template>
@@ -60,6 +71,29 @@ const rangeText = (row: SettingsKeyView): string => {
                 </span>
               </KunTooltip>
               <p class="text-default-500 mt-0.5">{{ row.desc_zh }}</p>
+              <div
+                v-if="row.public || row.site_scoped"
+                class="mt-0.5 flex flex-wrap items-center gap-1"
+              >
+                <KunTooltip
+                  v-if="row.public"
+                  :text="PUBLIC_NOTE"
+                  position="top"
+                >
+                  <KunChip color="info" variant="flat" size="xs">
+                    {{ PUBLIC_BADGE }}
+                  </KunChip>
+                </KunTooltip>
+                <KunTooltip
+                  v-if="row.site_scoped"
+                  :text="SITE_SCOPED_NOTE"
+                  position="top"
+                >
+                  <KunChip color="secondary" variant="flat" size="xs">
+                    {{ SITE_SCOPED_BADGE }}
+                  </KunChip>
+                </KunTooltip>
+              </div>
             </td>
 
             <td class="px-3 py-2">
@@ -87,8 +121,17 @@ const rangeText = (row: SettingsKeyView): string => {
               <span class="text-foreground font-mono break-all">
                 {{ formatSettingValue(row.kind, row.effective) }}
               </span>
-              <p v-if="row.source === 'db'" class="text-default-400 mt-0.5">
+              <p
+                v-if="scopeKind === 'platform' && row.source === 'db'"
+                class="text-default-400 mt-0.5"
+              >
                 默认 {{ formatSettingValue(row.kind, row.default) }}
+              </p>
+              <p
+                v-else-if="scopeKind === 'site' && row.source === 'site'"
+                class="text-default-400 mt-0.5"
+              >
+                平台 {{ formatSettingValue(row.kind, row.inherited) }}
               </p>
             </td>
 
@@ -102,7 +145,9 @@ const rangeText = (row: SettingsKeyView): string => {
                   {{ SOURCE_LABELS[row.source] }}
                 </KunChip>
                 <KunChip
-                  v-if="row.override && row.source === 'default'"
+                  v-if="
+                    row.override != null && row.source !== ownSource(scopeKind)
+                  "
                   color="danger"
                   variant="flat"
                   size="xs"

--- a/apps/web/app/components/settings/EditModal.vue
+++ b/apps/web/app/components/settings/EditModal.vue
@@ -5,12 +5,20 @@ import { PROPAGATION_NOTE, formatSettingValue } from '~/constants/settings'
 const props = defineProps<{
   row: SettingsKeyView | null
   submitting: boolean
+  scopeKind: 'platform' | 'site'
+  siteName: string
 }>()
 const emit = defineEmits<{
   save: [value: SettingValue, note: string]
 }>()
 
 const open = defineModel<boolean>('open', { required: true })
+
+const title = computed(() =>
+  props.scopeKind === 'site'
+    ? `编辑(站点:${props.siteName})`
+    : (props.row?.key ?? '编辑配置')
+)
 
 const boolValue = ref(false)
 const numberValue = ref<number | null>(null)
@@ -122,12 +130,21 @@ const emitSave = () => {
 </script>
 
 <template>
-  <KunModal v-model="open" size="lg" :aria-label="row?.key ?? '编辑配置'">
+  <KunModal v-model="open" size="lg" :aria-label="title">
     <div v-if="row" class="space-y-4">
       <div>
-        <h2 class="text-foreground font-mono text-xl font-bold break-all">
-          {{ row.key }}
+        <h2
+          class="text-foreground text-xl font-bold"
+          :class="{ 'font-mono break-all': scopeKind !== 'site' }"
+        >
+          {{ title }}
         </h2>
+        <p
+          v-if="scopeKind === 'site'"
+          class="text-foreground mt-1 font-mono break-all"
+        >
+          {{ row.key }}
+        </p>
         <p class="text-default-500 mt-1">{{ row.desc_zh }}</p>
       </div>
 

--- a/apps/web/app/components/settings/ResetModal.vue
+++ b/apps/web/app/components/settings/ResetModal.vue
@@ -5,6 +5,7 @@ import { formatSettingValue } from '~/constants/settings'
 const props = defineProps<{
   row: SettingsKeyView | null
   submitting: boolean
+  scopeKind: 'platform' | 'site'
 }>()
 const emit = defineEmits<{ confirm: [note: string] }>()
 
@@ -24,7 +25,13 @@ watch([open, () => props.row], ([isOpen]) => {
       <h2 class="text-foreground text-xl font-bold">撤销覆盖</h2>
 
       <div v-if="row" class="space-y-2 text-sm">
-        <p class="text-default-500">
+        <p v-if="scopeKind === 'site'" class="text-default-500">
+          将删除站点覆盖值,该键回退到平台生效值
+          <span class="text-foreground font-mono">
+            {{ formatSettingValue(row.kind, row.inherited) }}
+          </span>
+        </p>
+        <p v-else class="text-default-500">
           将删除
           <span class="text-foreground font-mono font-semibold break-all">
             {{ row.key }}

--- a/apps/web/app/constants/jobs.ts
+++ b/apps/web/app/constants/jobs.ts
@@ -20,3 +20,18 @@ export const JOB_TRIGGER_LABEL: Record<JobTrigger, string> = {
 
 export const jobTriggerLabel = (t: string) =>
   JOB_TRIGGER_LABEL[t as JobTrigger] ?? t
+
+export const JOB_DISABLED_LABEL = '已停用'
+
+export const formatJobSchedule = (s: string): string => {
+  const daily = /^daily@(\d{2}:\d{2})$/.exec(s)
+  if (daily?.[1]) return `每日 ${daily[1]} (UTC)`
+
+  const minutes = /^every:(\d+)m$/.exec(s)
+  if (minutes?.[1]) return `每 ${minutes[1]} 分钟`
+
+  const hours = /^every:(\d+)h$/.exec(s)
+  if (hours?.[1]) return `每 ${hours[1]} 小时`
+
+  return s
+}

--- a/apps/web/app/constants/settings.ts
+++ b/apps/web/app/constants/settings.ts
@@ -25,12 +25,14 @@ export const KIND_LABELS: Record<SettingKind, string> = {
 
 export const SOURCE_LABELS: Record<SettingSource, string> = {
   db: '已覆盖',
-  default: '默认'
+  default: '默认',
+  site: '站点覆盖'
 }
 
 export const SOURCE_COLORS: Record<SettingSource, SettingsChipColor> = {
   db: 'primary',
-  default: 'default'
+  default: 'default',
+  site: 'secondary'
 }
 
 export const AUDIT_ACTION_LABELS: Record<SettingsAuditAction, string> = {
@@ -52,6 +54,19 @@ export const PROPAGATION_NOTE = '保存后所有服务在 30 秒内生效'
 
 export const ENV_FLOOR_NOTE =
   '若所属服务的环境里设置了该变量,它会覆盖默认值,直到这里设置了覆盖值'
+
+export const PLATFORM_SCOPE_LABEL = '平台(全局)'
+
+export const PUBLIC_BADGE = '公开'
+
+export const PUBLIC_NOTE = '通过 GET /api/v1/settings 下发给各站点(S2S 读面)'
+
+export const SITE_SCOPED_BADGE = '可按站点'
+
+export const SITE_SCOPED_NOTE = '选中某个站点后可单独覆盖'
+
+export const SITE_SCOPE_HINT =
+  '仅列出可按站点覆盖的键;没有站点覆盖值的键显示平台生效值'
 
 export const formatSettingValue = (
   kind: SettingKind,

--- a/apps/web/shared/types/jobs.ts
+++ b/apps/web/shared/types/jobs.ts
@@ -1,4 +1,3 @@
-
 export type JobStatus = 'running' | 'success' | 'failed' | 'skipped'
 export type JobTrigger = 'schedule' | 'admin'
 
@@ -17,7 +16,7 @@ export interface JobRun {
 export interface JobInfo {
   name: string
   desc: string
-  daily_at?: string
-  auto: boolean
+  schedule: string
+  enabled: boolean
   latest_run: JobRun | null
 }

--- a/apps/web/shared/types/settings.ts
+++ b/apps/web/shared/types/settings.ts
@@ -6,7 +6,7 @@ export type SettingKind =
   | 'enum'
   | 'string_list'
 
-export type SettingSource = 'db' | 'default'
+export type SettingSource = 'db' | 'default' | 'site'
 
 export type SettingValue = boolean | number | string | string[]
 
@@ -33,6 +33,9 @@ export interface SettingsKeyView {
   effective: SettingValue
   source: SettingSource
   override: SettingsOverrideView | null
+  site_scoped: boolean
+  public: boolean
+  inherited?: SettingValue
 }
 
 export interface SettingsDomainView {
@@ -42,6 +45,7 @@ export interface SettingsDomainView {
 }
 
 export interface SettingsOverview {
+  scope: { kind: 'platform' | 'site'; site_id?: number }
   domains: SettingsDomainView[]
   writable: boolean
 }
@@ -58,4 +62,6 @@ export interface SettingsAuditEntry {
   new_value: SettingValue | null
   note: string
   created_at: string
+  scope_kind: 'platform' | 'site'
+  scope_id: string
 }

--- a/docs/deploy/18-config-center.md
+++ b/docs/deploy/18-config-center.md
@@ -15,14 +15,31 @@
 | 2. 环境变量地板 | 键声明的 `EnvVar`(和 15-environment 里的同名变量) | 进程启动时读一次 | 面板 / compose + 重部署 |
 | 3. 数据库覆盖值 | 主库 `kun_galgame_infra` 的 `setting_overrides` | 写入后 30 秒内所有服务生效(oauth / image / artifact 经 Redis 推送为毫秒级) | 控制台 `/settings`,需 `settings.write` |
 
-读取是进程内原子指针,请求路径零网络;每个服务每 30 秒向主库拉一次全表(几十行)。
+第 3 层有两种行:**平台行**(所有服务读的那一份)和**站点行**(`scope=site:<sites.id>`,只对声明了
+「可按站点覆盖」的键存在,只被 S2S 读面与控制台读,进程内 `keys.X.Get()` 不看它)。
+
+读取是进程内原子指针,请求路径零网络;每个服务每 30 秒向主库拉一次平台行(几十行)。
 刷新失败沿用上一份;启动时连续失败则只带 1+2 两层运行并打 `settings: initial load failed` 的
 ERROR 日志。数据库里的一行若类型不符、越界或枚举外,会被忽略并退回 2/1 层,日志有 WARN。
 
 **边界**:配置中心只收运行期可调项(开关、阈值、TTL、配额)。密钥、host/port/dsn/bucket、S3
 path style、PG 连接池、OIDC 签名算法、aff URL 模板等启动期接线永远留在环境变量里。
 
-## 18.1 现有键(W1,18 个)
+## 18.1 现有键(44 个:platform 2 + W1 18 + jobs 24)
+
+### 平台策略(`platform`,W2)
+
+没有环境变量地板;没有仓内消费者——它们是下发给各站点的契约,读面见 18.7。
+
+| 键 | 类型 | 默认 | 公开 | 可按站点覆盖 | 站点必须做什么 |
+|---|---|---|---|---|---|
+| `platform.read_only` | bool | false | 是 | 是 | 拒绝一切写操作并展示提示;为整机搬迁的只读窗口准备 |
+| `platform.notice` | string(≤ 500,单行) | 空 | 是 | 是 | 页面顶部展示这行公告 |
+
+### 运行期可调项(W1,18 个)
+
+`image.upload_enabled` 与 `artifact.upload_enabled` 同时是**公开键**(随读面下发,站点据此隐藏上传入口),
+但不可按站点覆盖:执法是平台级的,站点行只会撒谎。
 
 | 键 | 类型 | 默认 | 环境变量地板 | 生效位置 |
 |---|---|---|---|---|
@@ -47,6 +64,28 @@ path style、PG 连接池、OIDC 签名算法、aff URL 模板等启动期接线
 
 单位写在键名里,环境变量的写法与迁入前完全一致。
 
+### 后台任务(`jobs`,W2,12 × 2)
+
+oauth 上的调度器(`internal/jobs`)每个任务两把键,没有环境变量地板,默认值就是迁入前 `all.go`
+里写死的时刻;详见 18.6。
+
+| 任务 | `jobs.<n>.enabled` 默认 | `jobs.<n>.schedule` 默认 |
+|---|---|---|
+| `image-gc` | true | `daily@03:30` |
+| `galgame-image-refping` | true | `daily@04:00` |
+| `catalog-image-refping` | true | `daily@04:15` |
+| `news-image-refping` | true | `daily@04:20` |
+| `user-avatar-refping` | true | `daily@04:30` |
+| `image-ref-audit` | true | `daily@04:45` |
+| `artifact-gc` | true | `daily@05:30` |
+| `prune-developer-usage` | true | `daily@06:00` |
+| `ymgal-news-poll` | true | `every:10m` |
+| `ymgal-news-sweep` | true | `daily@04:05` |
+| `store-stats-sync` | true | `every:1h` |
+| `news-moderate` | true | `every:5m` |
+
+键名里的 `<n>` 是任务名把 `-` 换成 `_`(`jobs.image_gc.schedule`)。
+
 ## 18.2 怎么改
 
 控制台 `oauth.kungal.com` → 侧栏「配置中心」(`/settings`)。页面按域列出全部键:生效值、来源
@@ -54,17 +93,22 @@ path style、PG 连接池、OIDC 签名算法、aff URL 模板等启动期接线
 (默认只有 ren;可在权限矩阵委派给 admin)的人可「编辑」或「撤销覆盖」,每次变更记审计
 (旧值 → 新值 + 备注),页面底部可见。
 
+页面顶部的「作用域」默认是「平台(全局)」;选中某个站点后只列出可按站点覆盖的键,来源多一种
+`站点覆盖`,没有站点行的键显示它继承的平台生效值。站点行只影响 18.7 的读面,不影响任何服务进程。
+
 页面显示的「来源」不含环境变量:oauth 进程看不见其他容器的环境。所以当某键显示「默认」而所属
 服务的 compose 里仍设着同名变量时,该服务实际用的是变量值。真值看 18.3。
 
 API(供脚本):
 ```
-GET    /api/v1/admin/settings                总览(domains[].keys[]:key/kind/default/effective/source/override)
-GET    /api/v1/admin/settings/audit?limit=   最近变更
-PUT    /api/v1/admin/settings/{key}          {"value": <json>, "note": "...", "version": <上次看到的 version,可选>}
-DELETE /api/v1/admin/settings/{key}?note=    撤销覆盖
+GET    /api/v1/admin/settings                总览(domains[].keys[]:key/kind/default/effective/source/override/site_scoped/public)
+GET    /api/v1/admin/settings?site=<id>      某站点的总览(只含可按站点覆盖的键;source 可为 site;inherited = 平台生效值)
+GET    /api/v1/admin/settings/audit?limit=   最近变更(含 scope_kind / scope_id)
+PUT    /api/v1/admin/settings/{key}[?site=]  {"value": <json>, "note": "...", "version": <上次看到的 version,可选>}
+DELETE /api/v1/admin/settings/{key}?note=[&site=]   撤销覆盖
 ```
-`version` 不符返回 409;类型/范围/枚举不符返回 400 并带原因。
+`version` 不符返回 409;类型/范围/枚举不符返回 400 并带原因;对不可按站点覆盖的键带 `site` 写入返回
+400「该配置不支持按站点覆盖」;`site` 不存在返回 404。
 
 ## 18.3 怎么验证真的生效了
 
@@ -89,10 +133,35 @@ docker logs --since 2m <container> 2>&1 | rg 'settings: (loaded|applied|initial 
 ## 18.5 怎么新增一个键
 
 1. 在 `internal/platform/settings/keys/keys.go` 对应域声明(`settings.Bool/Int/Float/String/Enum/StringList`),
-   给默认值、范围/枚举、中英说明;要保留环境变量地板就填 `EnvVar`。
+   给默认值、范围/枚举、中英说明;要保留环境变量地板就填 `EnvVar`;要随读面下发给站点就标 `Public`,
+   允许站点单独覆盖就标 `SiteScoped`(两者都是契约,加了就不能撤)。新的定时任务不在这里声明,
+   而是在 `keys/jobs.go` 的表里加一行(见 18.6)。
 2. 把它加进该域的 `Keys` 列表;`TestLiveRegistryIsWellFormed` 的 golden 表补一行。
 3. 消费处在**使用时**读 `keys.X.Get()`,不要在构造时读进结构体字段(那正是迁走的东西)。
 4. 测试里用 `settings.Override(t, keys.X, v)` 注入,cleanup 自动还原。
 5. 不需要迁移、不需要改控制台:注册表即界面。
 
 不进配置中心的:密钥与接线(见 18.0 边界)、一次性 cmd 工具专用的 `KUN_*`(它们仍直接读 env)。
+
+## 18.6 后台任务的开关与时刻
+
+调度器只跑在 oauth 上。每个任务的 `jobs.<n>.enabled` / `jobs.<n>.schedule` 由调度循环每 30 秒重读:
+改了 `schedule`,下一次触发时刻按新值重算;`enabled=false` 到点时跳过并记一行
+`jobs: skipped, disabled`,再前进到下一个时刻;控制台「立即运行」不看 `enabled`。
+
+`schedule` 只有两种写法:`daily@HH:MM`(进程本地时间,生产容器是 UTC)与 `every:<N>m` / `every:<N>h`
+(N ≥ 1 的整数)。控制台按这个正则拦截其它写法;直接改库写了坏值,该任务空转并打
+`jobs: bad schedule` 的 ERROR,改回来即恢复。
+
+新增一个定时任务:`internal/jobs/all.go` 里 `Register`,并在 `internal/platform/settings/keys/jobs.go`
+的表里加 `{"<name>", "<默认 schedule>"}` 一行。漏了后者,进程启动即 panic,单元测试也会指名。
+
+## 18.7 下发给站点的读面
+
+`GET /api/v1/settings`(OAuth Client Basic Auth)返回调用方站点应遵守的全部公开键,带强 `ETag`,
+`If-None-Match` 相同回 304。站点每 30–60 秒轮询,内存快照,失败沿用上一份。契约与参考客户端见
+[docs/integration/oauth/14-settings.md](../integration/oauth/14-settings.md)。
+
+读面报告的是 oauth 进程看到的值(数据库行,否则代码默认),看不见其它服务的环境变量地板——这也是
+18.4「先建行再拔 env」的另一个理由。
+

--- a/docs/deploy/README.md
+++ b/docs/deploy/README.md
@@ -10,15 +10,14 @@
 >
 > **踩坑速查**:开荒/部署中实际翻过的车(SSH 权限 / Docker 绕过 ufw / Dokploy 面板 3000 / CF Tunnel 1033 / pg18 卷路径 / 按库迁移 …)集中在 [NOTES.md](./NOTES.md),遇到问题先翻这里。
 
-| 章节 | 文件 | 内容 |
-|---|---|---|
+| 章节 | 文件 |---|---|---|
 | 0 | [00-architecture.md](./00-architecture.md) | 架构总览:三仓、服务拓扑、网络、端口、数据库映射 |
 | 1 | [01-prerequisites.md](./01-prerequisites.md) | 前置条件:Docker、构建网络、buildx 现状、仓库布局 |
 | 2 | [02-build.md](./02-build.md) | 镜像构建:infra 的 cgo/distroless 拆分、moyu/kungal、构建参数 |
 | 3 | [03-bootstrap.md](./03-bootstrap.md) | **首次启动**:基础设施、建库、跨仓迁移顺序、OAuth 客户端注册 |
 | 16 | [16-data-cutover.md](./16-data-cutover.md) | **带数据上线**:从 dump 起,服务器容器化逐条命令(`*-tools` 镜像)把老库数据迁进新 5 库;本地 `go run` ↔ 容器对照表、校验、回滚(03-bootstrap §B 的可抄命令版) |
 | 17 | [17-go-live-checklist.md](./17-go-live-checklist.md) | **上线 Checklist**:Dokploy 装好后到三站上线的勾选清单,每步标注**在哪(面板/`docker/*.env`)配什么环境变量** + 密钥一致性铁律 + 验收/烟雾测试 |
-| 18 | [18-config-center.md](./18-config-center.md) | **配置中心**:运行期可调项(开关/阈值/TTL/配额)的三层解析(代码默认 → 环境变量地板 → 数据库覆盖值)、控制台 `/settings` 与 API、日志验证、从环境变量迁入的顺序、新增键的做法 |
+| 18 | [18-config-center.md](./18-config-center.md) | **配置中心**:运行期可调项(开关/阈值/TTL/配额)的三层解析(代码默认 → 环境变量地板 → 数据库覆盖值)、平台策略与站点覆盖、后台任务的开关与时刻、下发给站点的读面、控制台 `/settings` 与 API、日志验证、从环境变量迁入的顺序、新增键的做法 |
 | 4 | [04-run.md](./04-run.md) | 日常启停:增量启动 / 伞状编排、kungal 的 infra override |
 | 5 | [05-configuration.md](./05-configuration.md) | 配置参考:各服务 env、前端 public 配置烘焙、密钥(上线速查) |
 | 15 | [15-environment.md](./15-environment.md) | **环境变量大全**:三仓每个变量 + 构建参数 + CI secrets + 生产/Dokploy 注入 + Cloudflare/R2;分层模型、命名规律、跨服务一致性铁律、必改清单(配置层底层全集) |

--- a/docs/integration/oauth/14-settings.md
+++ b/docs/integration/oauth/14-settings.md
@@ -1,0 +1,190 @@
+# 14 — 平台配置下发(settings 读面)
+
+返回 [README](./README.md)
+
+> **状态:已实现**(配置中心 W2,2026-09-02)。端点 `GET /settings`;实现在
+> `internal/platform/settings/handler.go`(`Effective`),路由注册在 `cmd/oauth/main.go`。
+> 管理端是 OAuth 控制台的 `/settings` 页;内部模型(三层解析、审计、传播)见 infra
+> `docs/deploy/18-config-center.md`。
+
+## 0. 定位
+
+- 平台拥有、各站必须遵守的**运行期策略**(维护只读、全站公告、上传开关)由 OAuth 的配置中心统一
+  管理,通过本读面下发给 kungal / moyu / letmoe 等下游站。
+- 下游**只走这个 HTTP 端点**,永远不读共享库里的 `setting_overrides` 表。infra 整套(七个服务 +
+  Postgres + Redis)会在半年内整机搬迁,搬完之后这个契约一个字节都不变。
+- 站点自己的产品开关(moyu 的 `site_setting` 之类)留在站点自己那里;这里只放「平台说了算」的。
+
+## 1. GET /settings
+
+返回调用方站点应当遵守的全部**公开键**的生效值。
+
+**鉴权**:OAuth Client Basic Auth(`Authorization: Basic base64(client_id:client_secret)`),
+与 [03-cross-service.md](./03-cross-service.md) 相同。站点身份从 client 的站点绑定
+(`oauth_clients.site_id`)推导:有绑定 → 该站点的值(平台值 + 站点覆盖);无绑定 → 平台值。
+
+**请求头**:
+
+| 头 | 必填 | 说明 |
+|------|------|------|
+| If-None-Match | 否 | 上一次响应的 `ETag`;相同则 304 |
+
+**成功响应**(200):
+
+```json
+{
+  "code": 0,
+  "message": "成功",
+  "data": {
+    "site_id": 3,
+    "etag": "\"9f2c1a0b7e4d5c63\"",
+    "settings": {
+      "artifact.upload_enabled": true,
+      "image.upload_enabled": true,
+      "platform.notice": "",
+      "platform.read_only": false
+    }
+  }
+}
+```
+
+| 字段 | 说明 |
+|------|------|
+| site_id | 调用方 client 绑定的站点 id;无绑定为 `null` |
+| etag | 与响应头 `ETag` 相同,强 ETag;由 `settings` 对象整体计算,任一值变化即变化 |
+| settings | 键 → 生效值。只含 §2 里的公开键;值类型见 §2 |
+
+**响应头**:每次响应都带 `ETag` 与 `Cache-Control: no-cache`。
+
+**304 Not Modified**:`If-None-Match` 与当前 `ETag` 相同时返回 304、空 body、同一个 `ETag` 头。
+
+**错误响应**:
+
+| HTTP | code | 触发条件 |
+|------|------|----------|
+| 401  | 10001/15001/15009 | Basic Auth 缺失/格式错/client_id 不存在/secret 错误 |
+
+## 2. 公开键目录
+
+只有声明为 `Public` 的键出现在读面上。**新键只增不删**;要改语义就加新键,旧键至少保留一个版本。
+
+| 键 | 类型 | 默认 | 可按站点覆盖 | 站点必须做什么 |
+|------|------|------|------|------|
+| `platform.read_only` | bool | `false` | 是 | `true` 时拒绝一切写操作(发帖、评论、编辑、上传、点赞、后台修改),回一句可读提示;读不受影响。用于数据库迁移等全平台维护窗口 |
+| `platform.notice` | string | `""` | 是 | 非空时在页面顶部展示这一行公告(≤ 500 字,单行);空不展示 |
+| `image.upload_enabled` | bool | `false` | 否 | `false` 时隐藏或禁用图片上传入口(图床本身此时对上传回 503) |
+| `artifact.upload_enabled` | bool | `false` | 否 | `false` 时隐藏或禁用文件上传入口(artifact 服务此时对上传回 503) |
+
+「可按站点覆盖」= 管理员可以在控制台选中某个站点后单独设置(例如只让 letmoe 进入只读)。
+不可按站点覆盖的键,每个站点拿到的都是平台值。
+
+> 读面报告的是 OAuth 进程看到的值:数据库覆盖值,否则代码默认。上传两个开关在各自服务的
+> compose 里可能还设着同名环境变量地板,那个地板 OAuth 看不见——这正是 infra 侧「先在控制台建行、
+> 再拔 env」顺序的原因(`docs/deploy/18-config-center.md` §18.4)。建行之后两边一致。
+
+## 3. 轮询与缓存(MUST)
+
+1. 进程启动时拉一次;失败则用 §2 的默认值启动,**不阻塞启动**。
+2. 之后每 30–60 秒带 `If-None-Match` 轮询一次。304 → 什么都不做;200 → 整份替换内存快照;
+   网络错误 / 5xx → 沿用上一份快照(fail-open to last snapshot),连续失败超过 5 分钟打告警日志。
+3. 读值只读内存快照,请求路径零网络。
+4. 不做长轮询,不需要 Redis。
+5. 生效延迟上限 ≈ 控制台写入 → OAuth 进程(Redis 推送毫秒级,轮询兜底 30 秒)→ 站点下一次轮询
+   (≤ 60 秒),约 1.5 分钟。
+
+ETag 只由 `settings` 对象计算;不同站点的 ETag 互不相关,不要跨站点复用快照。
+
+## 4. 参考实现(Go)
+
+OAuth 这边**不发布 SDK**。下面是一个可直接复制的最小客户端(约 60 行):
+
+```go
+package platformsettings
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+type Snapshot struct {
+	ReadOnly              bool   `json:"platform.read_only"`
+	Notice                string `json:"platform.notice"`
+	ImageUploadEnabled    bool   `json:"image.upload_enabled"`
+	ArtifactUploadEnabled bool   `json:"artifact.upload_enabled"`
+}
+
+type Client struct {
+	base, clientID, secret string
+	http                    *http.Client
+	cur                     atomic.Pointer[Snapshot]
+	etag                    string
+}
+
+func New(base, clientID, secret string) *Client {
+	c := &Client{base: base, clientID: clientID, secret: secret, http: &http.Client{Timeout: 5 * time.Second}}
+	c.cur.Store(&Snapshot{})
+	return c
+}
+
+func (c *Client) Get() Snapshot { return *c.cur.Load() }
+
+func (c *Client) Run(ctx context.Context, every time.Duration) {
+	c.refresh(ctx)
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			c.refresh(ctx)
+		}
+	}
+}
+
+func (c *Client) refresh(ctx context.Context) {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/api/v1/settings", nil)
+	req.SetBasicAuth(c.clientID, c.secret)
+	if c.etag != "" {
+		req.Header.Set("If-None-Match", c.etag)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		slog.Warn("platform settings: refresh failed; keeping last snapshot", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotModified {
+		return
+	}
+	if resp.StatusCode != http.StatusOK {
+		slog.Warn("platform settings: unexpected status; keeping last snapshot", "status", resp.StatusCode)
+		return
+	}
+	var body struct {
+		Data struct {
+			ETag     string   `json:"etag"`
+			Settings Snapshot `json:"settings"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		slog.Warn("platform settings: bad body; keeping last snapshot", "err", err)
+		return
+	}
+	c.cur.Store(&body.Data.Settings)
+	c.etag = body.Data.ETag
+}
+```
+
+用法:启动时 `go client.Run(ctx, 45*time.Second)`,写路径中间件里 `if client.Get().ReadOnly { 503 + 提示 }`。
+Nuxt 站点在 server 侧做同样的事(`nitro` 插件起一个定时器,把快照放进 `useState` 或内存),不要在浏览器里直连本端点(需要 client secret)。
+
+## 5. 与控制台的关系
+
+管理员在 `oauth.kungal.com/settings` 的「平台策略」域设值;顶部作用域选择「平台(全局)」或某个站点。
+每次变更有审计(旧值 → 新值 + 备注)。哪些站点已经接入、接入后行为是否正确,以站点自己的日志为准——
+读面只保证「值已经这样」,不保证「站点已经照做」。

--- a/docs/integration/oauth/README.md
+++ b/docs/integration/oauth/README.md
@@ -45,6 +45,7 @@
 | 11 | [roles.md](./11-roles.md) | ⚖️ **角色与能力语义（权威定义，Tier A）**：全站五角色 `user`/`creator`/`moderator`/`admin`/`ren` 的唯一权威来源。`roles` claim = 角色名集合（普通用户为空数组，`user` 隐式）；管理轴逐级包含 `moderator ⊂ admin ⊂ ren`，`creator` 为正交的「直接发布」能力；**下游必须遵守的 MUST 规则** + 授予矩阵 + 当前 kungal/moyu 对 `ren` 的合规差距（必须整改）|
 | 12 | [site-roles.md](./12-site-roles.md) | 🧩 **站点域角色（site-scoped roles，权威定义，Tier A）**：让账号**只在某一个站点**持职（如「letmoe 的 moderator」），是 11 五角色契约的**加法扩展**（不改其语义）。`site_roles` claim = 按签发 client 站点定界的扁平角色名数组（access token / userinfo / `/users/batch` 三处出现）；下游**并入**既有角色集喂能力函数；名策略禁 `user`/`admin`/`ren`（安全不变量）+ 允许自定义捆名；授予/撤销仅 OAuth 后台（`admin`/`ren`）|
 | 13 | [standard-wire-migration.md](./13-standard-wire-migration.md) | 🚨 **协议端点线格式标准化迁移指南（第三方必读）**：`/oauth/{token,userinfo,revoke}` 的响应从自家 `{code,message,data}` 信封改为 RFC 6749 / RFC 6750 标准裸 JSON。含前后对照、**零停机双格式兼容读取器**（TS / Go / Kotlin 示例）、可离线自测的 fixture，以及三个必须做对的错误判定（`invalid_token` 视为凭据已死、只有 5xx 与未知错误算瞬态、封禁是 HTTP 403）|
+| 14 | [settings.md](./14-settings.md) | **平台配置下发(settings 读面,Tier A)**:`GET /settings`(OAuth Client Basic Auth)返回调用方站点必须遵守的公开策略键(`platform.read_only` 维护只读、`platform.notice` 全站公告、两个上传开关),强 `ETag` + `If-None-Match` → 304;站点每 30–60 秒轮询、fail-open 沿用上一份快照;含 Go 参考客户端。下游**只走此端点**,永远不读共享表 |
 
 ### 完整接入指南
 
@@ -88,7 +89,7 @@ OAuth 一共有三种鉴权方式，按场景区分：
 | 方式 | 用在哪 | 谁有 |
 |------|------|------|
 | **Bearer Token**（用户 JWT） | `/auth/*` 用户自助 + `/oauth/userinfo` | 已登录的终端用户 |
-| **OAuth Client Basic Auth** | `/users/batch`、`/users/search`（跨服务） | 已注册的 OAuth Client（kungal / moyu / wiki 等下游后端） |
+| **OAuth Client Basic Auth** | `/users/batch`、`/users/search`、`/settings`（跨服务） | 已注册的 OAuth Client（kungal / moyu / wiki 等下游后端） |
 | **Admin JWT**（Bearer + role=admin） | `/admin/*`（不在本文档范围） | OAuth 后台管理员 |
 
 终端用户 JWT 通过完整的 OAuth Authorization Code + PKCE 流程拿到（详见 [oauth-integration-guide.md](./oauth-integration-guide.md)）。Client Basic Auth 的 client_id / client_secret 在 OAuth 后台创建 Client 时生成。
@@ -96,6 +97,8 @@ OAuth 一共有三种鉴权方式，按场景区分：
 ---
 
 ## 变更摘要
+
+> **2026-09-02 平台配置下发读面**:新增 [14-settings.md](./14-settings.md)。配置中心(OAuth 控制台 `/settings`)里声明为公开的键通过 `GET /settings`(Client Basic Auth,ETag/304)下发到各站。首批四个键:`platform.read_only`(为 infra 整机搬迁的只读窗口准备,站点收到 `true` 必须拒绝写操作)、`platform.notice`(顶部公告)、`image.upload_enabled` / `artifact.upload_enabled`(隐藏上传入口)。前两个可按站点单独覆盖。**下游 kungal / moyu / letmoe 需接入**:启动拉一次 + 30–60 秒轮询,内存快照,读共享表属违规。
 
 > **2026-06-27 角色语义定权威（重要）**：新增 [11-roles.md](./11-roles.md)——把全站五角色 `user`/`creator`/`moderator`/`admin`/`ren` 及其能力语义定为 **Tier A 权威**，下游必须遵守。要点：① `roles` claim 是**角色名集合**，普通用户为**空数组**（`user` 隐式，下游不得用「数组含 `user`」判断登录）；② 管理轴**逐级包含** `moderator ⊂ admin ⊂ ren`，任何把 claim 映射成内部权限的逻辑必须让 `ren ⊇ admin ⊇ moderator`；③ `creator` 是**正交**的「直接发布 galgame」能力，不含审核/管理权。**下游 kungal / moyu 必须整改对 `ren` 的处理**：kungal 数值等级把 `ren` 塌成普通用户、moyu 完全不识别 `ren`——目前仅因「ren 账号必同时持 admin」未出事，违反健壮性要求，须修复（见 11 §6）。
 


### PR DESCRIPTION
## What

Wave 2 of the configuration center (wave 1 = #118).

- **Site scope**: `setting_overrides` rows with `scope=site:<sites.id>` override the platform value for keys declaring `SiteScoped`. Console reads/writes them with `?site=<id>`; source gains `site`; site views carry `inherited` (the platform value). In-process `keys.X.Get()` stays platform-only.
- **S2S read face**: `GET /api/v1/settings` (OAuth client Basic auth) returns every `Public` key for the caller's site with a strong `ETag`; `If-None-Match` (strong or weak) answers 304. Contract: `docs/integration/oauth/14-settings.md` (Tier A; forum/patch mirrors regenerated with `docs:sync`, audit 0 errors).
- **New `platform` domain**: `platform.read_only`, `platform.notice` (Public + SiteScoped, downstream contract, no consumer in this repo by design; prepared for the read-only window of the server move). `image.upload_enabled` / `artifact.upload_enabled` are now Public.
- **Jobs**: every scheduled job has `jobs.<name>.enabled` / `jobs.<name>.schedule` (`daily@HH:MM` | `every:<N>m|h`), declared once in `keys/jobs.go`; the scheduler re-reads them every 30 s, skips disabled jobs at fire time, `Register` panics for a job without keys, and a test asserts both directions. `/admin/jobs` reports `schedule` / `enabled`.
- **Console**: scope selector, `公开` / `可按站点` badges, audit scope column, live schedule + `已停用` chips on `/jobs`.

## Verification

- `gofmt` / `go vet` / `go build` clean; full `go test ./...` against an ephemeral DB (`-count=1 -p 1`): 168 packages ok, 0 FAIL.
- Nine OpenAPI specs regenerated: zero diff.
- `pnpm typecheck` / `pnpm lint` / prettier on touched web files: clean.
- Local oauth + console round trips: site override set → `站点覆盖` chip, audit row `一起萌`, S2S reflects it with a new ETag → reset restores the original ETag; platform `read_only` set/reset with `settings: applied` logs; `GET /api/v1/settings` 200 / 304 (strong and `W/`) / 401.
- Scheduler live: `jobs.news_moderate.schedule=every:1m` picked up within 30 s and fired a minute later; `enabled=false` logged `jobs: skipped, disabled` at the next fire time.

## Migrations

None. No schema change (the scope columns already exist from #118).

## Rollout notes

Key count 18 → 44 (`settings: loaded keys=44`). Downstream sites can start polling the read face after deploy; nothing changes for them until they do.

https://claude.ai/code/session_015kefkqiURPNwLbRE7xNfq7