### PR TITLE
fix(catalog): report to_quarantine/quarantined in the vndb works import summary

### DIFF
--- a/apps/api/cmd/import-vndb-works/main.go
+++ b/apps/api/cmd/import-vndb-works/main.go
@@ -71,6 +71,8 @@ func main() {
 		"pool_unanchored", st.PoolUnanchored,
 		"planned", st.Planned,
 		"planned_r18", st.PlannedR18,
+		"to_quarantine", st.ToQuarantine,
+		"quarantined", st.Quarantined,
 		"works_created", st.WorksCreated,
 		"titles_created", st.TitlesCreated,
 		"anchors_created", st.AnchorsCreated,


### PR DESCRIPTION
## What

Adds `to_quarantine` and `quarantined` to the `import-vndb-works summary` slog line, mirroring the field order of the `bgm-type4-gated summary` line.

## Why

#116 taught both importers to quarantine title-colliding mints, and its acceptance notes claim both dry-runs report `to_quarantine` — but only the bgm tool printed it. The vndb importer computes `VNDBWorksStats.ToQuarantine`/`Quarantined` and then drops them, so the weekly `vndb-refresh` cron's dry-run log (`state/vndb-works-dry.log`) cannot show whether a run would quarantine anything.

Verified today on prod (2026-09-02, image 6c3d2fd0): the bgm gated dry-run reports `to_quarantine=1292 quarantined=0`; the vndb dry-run computes the same class of counter but its summary line has no field to show it.

## Testing

- `go build ./cmd/import-vndb-works/` + `go vet` clean.
- Log-line-only change; no behavior or schema impact.

https://claude.ai/code/session_01VfxKvHRwA5Vj28pdvoE4bY