### PR TITLE
feat(settings): per-site reads (ForSite) and site-scoped upload switches

### DIFF
--- a/apps/api/cmd/image/main.go
+++ b/apps/api/cmd/image/main.go
@@ -101,7 +101,7 @@ func main() {
 
 	application.Fiber.Use(middleware.CORS(cfg.Server.CORSOrigin))
 
-	application.Fiber.Post("/image/upload", uploadGate, imgMW.ClientAuth(clientRepo, cfg), h.Upload)
+	application.Fiber.Post("/image/upload", imgMW.ClientAuth(clientRepo, cfg), uploadGate, h.Upload)
 	if !keys.ImageUploadEnabled.Get() {
 		slog.Warn("image upload disabled at boot (image.upload_enabled=false); other endpoints still serve")
 	}
@@ -133,6 +133,12 @@ func main() {
 }
 
 func uploadGate(c fiber.Ctx) error {
+	if client := imgMW.ClientFromCtx(c); client != nil && client.SiteID != nil {
+		if !keys.ImageUploadEnabled.ForSite(*client.SiteID) {
+			return uploadDisabled(c)
+		}
+		return c.Next()
+	}
 	if !keys.ImageUploadEnabled.Get() {
 		return uploadDisabled(c)
 	}

--- a/apps/api/internal/platform/artifact/handler/huma_api.go
+++ b/apps/api/internal/platform/artifact/handler/huma_api.go
@@ -50,6 +50,13 @@ func userSubFromCtx(ctx context.Context) string {
 	return s
 }
 
+func uploadEnabled(ctx context.Context) bool {
+	if client := clientFromCtx(ctx); client != nil && client.SiteID != nil {
+		return keys.ArtifactUploadEnabled.ForSite(*client.SiteID)
+	}
+	return keys.ArtifactUploadEnabled.Get()
+}
+
 type uuidInput struct {
 	UUID string `path:"uuid" doc:"Artifact UUID"`
 }
@@ -203,7 +210,7 @@ func (s *HumaServer) download(ctx context.Context, in *uuidInput) (*downloadOutp
 }
 
 func (s *HumaServer) resumeUpload(ctx context.Context, in *uuidInput) (*resumeOutput, error) {
-	if !keys.ArtifactUploadEnabled.Get() {
+	if !uploadEnabled(ctx) {
 		return nil, apiErr(http.StatusServiceUnavailable, errors.ErrArtifactUploadDisabled)
 	}
 	site := siteFromCtx(ctx)
@@ -244,7 +251,7 @@ func (s *HumaServer) delete(ctx context.Context, in *uuidInput) (*deleteOutput, 
 }
 
 func (s *HumaServer) initUpload(ctx context.Context, in *initInput) (*initOutput, error) {
-	if !keys.ArtifactUploadEnabled.Get() {
+	if !uploadEnabled(ctx) {
 		return nil, apiErr(http.StatusServiceUnavailable, errors.ErrArtifactUploadDisabled)
 	}
 	site := siteFromCtx(ctx)
@@ -287,7 +294,7 @@ func (s *HumaServer) initUpload(ctx context.Context, in *initInput) (*initOutput
 }
 
 func (s *HumaServer) completeUpload(ctx context.Context, in *completeInput) (*artifactOutput, error) {
-	if !keys.ArtifactUploadEnabled.Get() {
+	if !uploadEnabled(ctx) {
 		return nil, apiErr(http.StatusServiceUnavailable, errors.ErrArtifactUploadDisabled)
 	}
 	site := siteFromCtx(ctx)

--- a/apps/api/internal/platform/settings/distributor.go
+++ b/apps/api/internal/platform/settings/distributor.go
@@ -39,8 +39,19 @@ func (d *Distributor) Refresh(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	siteRows, err := d.store.SiteValues(ctx)
+	if err != nil {
+		return err
+	}
 	for _, c := range Resolve(d.reg, rows, d.env) {
 		slog.Info("settings: applied", "key", c.Key, "value", c.New, "source", c.NewSource)
+	}
+	for _, c := range ResolveSites(d.reg, siteRows) {
+		if c.New == nil {
+			slog.Info("settings: site override removed", "key", c.Key, "site", c.SiteID)
+		} else {
+			slog.Info("settings: site override applied", "key", c.Key, "site", c.SiteID, "value", c.New)
+		}
 	}
 	return nil
 }
@@ -118,10 +129,11 @@ func (d *Distributor) initialLoad(ctx context.Context) {
 		"THIS PROCESS IS RUNNING ON THE CODE/ENV FLOOR ONLY — no database override is in force until a later poll succeeds",
 		"attempts", len(startupBackoff), "poll_interval", PollInterval, "err", lastErr)
 	Resolve(d.reg, nil, d.env)
+	ResolveSites(d.reg, nil)
 }
 
 func (d *Distributor) logLoaded() {
-	n, nDB, nEnv := 0, 0, 0
+	n, nDB, nEnv, nSite := 0, 0, 0, 0
 	for _, e := range d.reg.Entries() {
 		n++
 		switch e.Source() {
@@ -130,6 +142,7 @@ func (d *Distributor) logLoaded() {
 		case SourceEnv:
 			nEnv++
 		}
+		nSite += len(e.siteValues())
 	}
-	slog.Info("settings: loaded", "keys", n, "overrides", nDB, "env_floor", nEnv)
+	slog.Info("settings: loaded", "keys", n, "overrides", nDB, "env_floor", nEnv, "site_overrides", nSite)
 }

--- a/apps/api/internal/platform/settings/forsite_test.go
+++ b/apps/api/internal/platform/settings/forsite_test.go
@@ -1,0 +1,26 @@
+package settings
+
+import "testing"
+
+func TestForSite(t *testing.T) {
+	k := Int(Meta{Name: "t.n", DescEN: "e", DescZH: "z"}, 7)
+	if k.ForSite(7) != k.Get() {
+		t.Errorf("ForSite with no overlay = %d, want Get() %d", k.ForSite(7), k.Get())
+	}
+
+	k.applySites(map[uint]any{7: int64(42)})
+	if k.ForSite(7) != 42 {
+		t.Errorf("ForSite(7) after overlay = %d, want 42", k.ForSite(7))
+	}
+	if k.ForSite(8) != k.Get() {
+		t.Errorf("ForSite(8) without overlay = %d, want Get() %d", k.ForSite(8), k.Get())
+	}
+	if k.Get() != 7 {
+		t.Errorf("Get() after applySites = %d, want 7", k.Get())
+	}
+
+	k.applySites(map[uint]any{})
+	if k.ForSite(7) != k.Get() {
+		t.Errorf("ForSite(7) after empty overlay = %d, want Get() %d", k.ForSite(7), k.Get())
+	}
+}

--- a/apps/api/internal/platform/settings/key.go
+++ b/apps/api/internal/platform/settings/key.go
@@ -56,6 +56,8 @@ type Entry interface {
 	ParseEnv(s string) (any, error)
 	Validate(v any) error
 	apply(v any, src Source)
+	applySites(vals map[uint]any)
+	siteValues() map[uint]any
 }
 
 type snapshot[T any] struct {
@@ -67,11 +69,21 @@ type Key[T any] struct {
 	meta    Meta
 	def     T
 	current atomic.Pointer[snapshot[T]]
+	sites   atomic.Pointer[map[uint]T]
 	pattern *regexp.Regexp
 }
 
 func (k *Key[T]) Get() T {
 	return k.current.Load().value
+}
+
+func (k *Key[T]) ForSite(siteID uint) T {
+	if m := k.sites.Load(); m != nil {
+		if v, ok := (*m)[siteID]; ok {
+			return v
+		}
+	}
+	return k.Get()
 }
 
 func (k *Key[T]) Name() string { return k.meta.Name }
@@ -94,6 +106,28 @@ func (k *Key[T]) apply(v any, src Source) {
 		panic(fmt.Sprintf("settings: %s: apply got %T, want %T", k.meta.Name, v, *new(T)))
 	}
 	k.current.Store(&snapshot[T]{value: typed, src: src})
+}
+
+func (k *Key[T]) applySites(vals map[uint]any) {
+	m := make(map[uint]T, len(vals))
+	for id, v := range vals {
+		typed, ok := v.(T)
+		if !ok {
+			panic(fmt.Sprintf("settings: %s: applySites got %T, want %T", k.meta.Name, v, *new(T)))
+		}
+		m[id] = typed
+	}
+	k.sites.Store(&m)
+}
+
+func (k *Key[T]) siteValues() map[uint]any {
+	out := map[uint]any{}
+	if m := k.sites.Load(); m != nil {
+		for id, v := range *m {
+			out[id] = v
+		}
+	}
+	return out
 }
 
 var keyNameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(\.[a-z][a-z0-9_]*)+$`)

--- a/apps/api/internal/platform/settings/keys/keys.go
+++ b/apps/api/internal/platform/settings/keys/keys.go
@@ -29,19 +29,21 @@ var AuthVerificationCodeTTLMinutes = settings.Int(settings.Meta{
 }, 15)
 
 var ImageUploadEnabled = settings.Bool(settings.Meta{
-	Name:   "image.upload_enabled",
-	EnvVar: "KUN_IMAGE_UPLOAD_ENABLED",
-	DescEN: "Master switch for accepting new image uploads; off rejects every upload.",
-	DescZH: "图床上传总开关,关闭后拒绝所有新上传。",
-	Public: true,
+	Name:       "image.upload_enabled",
+	EnvVar:     "KUN_IMAGE_UPLOAD_ENABLED",
+	DescEN:     "Master switch for accepting new image uploads; off rejects every upload.",
+	DescZH:     "图床上传总开关,关闭后拒绝所有新上传。",
+	SiteScoped: true,
+	Public:     true,
 }, false)
 
 var ArtifactUploadEnabled = settings.Bool(settings.Meta{
-	Name:   "artifact.upload_enabled",
-	EnvVar: "KUN_ARTIFACT_UPLOAD_ENABLED",
-	DescEN: "Master switch for accepting new artifact uploads; off rejects every upload.",
-	DescZH: "文件存储上传总开关,关闭后拒绝所有新上传。",
-	Public: true,
+	Name:       "artifact.upload_enabled",
+	EnvVar:     "KUN_ARTIFACT_UPLOAD_ENABLED",
+	DescEN:     "Master switch for accepting new artifact uploads; off rejects every upload.",
+	DescZH:     "文件存储上传总开关,关闭后拒绝所有新上传。",
+	SiteScoped: true,
+	Public:     true,
 }, false)
 
 var ArtifactMultipartThresholdBytes = settings.Int(settings.Meta{

--- a/apps/api/internal/platform/settings/resolve.go
+++ b/apps/api/internal/platform/settings/resolve.go
@@ -83,3 +83,44 @@ func Resolve(reg *Registry, rows map[string]json.RawMessage, env map[string]any)
 	}
 	return changes
 }
+
+type SiteChange struct {
+	Key      string
+	SiteID   uint
+	Old, New any
+}
+
+func ResolveSites(reg *Registry, rows map[string]map[uint]json.RawMessage) []SiteChange {
+	var changes []SiteChange
+	for _, e := range reg.Entries() {
+		m := e.Meta()
+		if !m.SiteScoped {
+			continue
+		}
+		next := map[uint]any{}
+		for siteID, raw := range rows[m.Name] {
+			v, err := e.Decode(raw)
+			if err == nil {
+				err = e.Validate(v)
+			}
+			if err != nil {
+				slog.Warn("settings: site override row ignored", "key", m.Name, "site", siteID, "err", err)
+				continue
+			}
+			next[siteID] = v
+		}
+		prev := e.siteValues()
+		for siteID, v := range next {
+			if old, ok := prev[siteID]; !ok || !reflect.DeepEqual(old, v) {
+				changes = append(changes, SiteChange{Key: m.Name, SiteID: siteID, Old: prev[siteID], New: v})
+			}
+		}
+		for siteID, old := range prev {
+			if _, ok := next[siteID]; !ok {
+				changes = append(changes, SiteChange{Key: m.Name, SiteID: siteID, Old: old, New: nil})
+			}
+		}
+		e.applySites(next)
+	}
+	return changes
+}

--- a/apps/api/internal/platform/settings/resolve_test.go
+++ b/apps/api/internal/platform/settings/resolve_test.go
@@ -162,3 +162,89 @@ func TestResolveUnknownRowIgnored(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveSites(t *testing.T) {
+	scoped := settings.Int(settings.Meta{
+		Name: "t.scoped", DescEN: "e", DescZH: "z",
+		Min: settings.F(0), Max: settings.F(10),
+		SiteScoped: true,
+	}, 1)
+	plain := settings.Int(settings.Meta{
+		Name: "t.plain", DescEN: "e", DescZH: "z",
+		Min: settings.F(0), Max: settings.F(10),
+	}, 1)
+	reg := settings.NewRegistry(settings.Domain{
+		Name: "t", TitleZH: "t",
+		Keys: []settings.Entry{scoped, plain},
+	})
+
+	rows := map[string]map[uint]json.RawMessage{
+		"t.scoped": {
+			7: json.RawMessage(`5`),
+			8: json.RawMessage(`99`),
+		},
+		"t.plain": {
+			7: json.RawMessage(`5`),
+		},
+	}
+	changes := settings.ResolveSites(reg, rows)
+
+	if scoped.ForSite(7) != 5 {
+		t.Errorf("ForSite(7) after valid row = %d, want 5", scoped.ForSite(7))
+	}
+	if scoped.Get() != 1 {
+		t.Errorf("Get() after site resolve = %d, want 1", scoped.Get())
+	}
+	found := false
+	for _, c := range changes {
+		if c.Key == scoped.Name() && c.SiteID == 7 {
+			found = true
+			if c.Old != nil {
+				t.Errorf("first apply Old = %#v, want nil", c.Old)
+			}
+			if c.New != int64(5) {
+				t.Errorf("first apply New = %#v, want int64(5)", c.New)
+			}
+		}
+		if c.Key == scoped.Name() && c.SiteID == 8 {
+			t.Errorf("out-of-bounds site 8 must not emit a change: %+v", c)
+		}
+		if c.Key == plain.Name() {
+			t.Errorf("non-scoped key must not emit a change: %+v", c)
+		}
+	}
+	if !found {
+		t.Errorf("valid site 7 row must emit a change, got %+v", changes)
+	}
+	if scoped.ForSite(8) != scoped.Get() {
+		t.Errorf("ForSite(8) after out-of-bounds row = %d, want Get() %d", scoped.ForSite(8), scoped.Get())
+	}
+	if plain.ForSite(7) != plain.Get() {
+		t.Errorf("non-scoped ForSite(7) = %d, want Get() %d", plain.ForSite(7), plain.Get())
+	}
+
+	again := settings.ResolveSites(reg, rows)
+	if len(again) != 0 {
+		t.Errorf("identical ResolveSites changes = %+v, want none", again)
+	}
+
+	removed := settings.ResolveSites(reg, map[string]map[uint]json.RawMessage{})
+	found = false
+	for _, c := range removed {
+		if c.Key == scoped.Name() && c.SiteID == 7 {
+			found = true
+			if c.Old != int64(5) {
+				t.Errorf("removal Old = %#v, want int64(5)", c.Old)
+			}
+			if c.New != nil {
+				t.Errorf("removal New = %#v, want nil", c.New)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("removing site 7 must emit a change, got %+v", removed)
+	}
+	if scoped.ForSite(7) != scoped.Get() {
+		t.Errorf("ForSite(7) after removal = %d, want Get() %d", scoped.ForSite(7), scoped.Get())
+	}
+}

--- a/apps/api/internal/platform/settings/scope_db_test.go
+++ b/apps/api/internal/platform/settings/scope_db_test.go
@@ -247,6 +247,43 @@ func TestServiceSiteScope(t *testing.T) {
 	}
 }
 
+func TestServiceSiteWriteRefreshesForSite(t *testing.T) {
+	reset(t)
+	seedActor(t)
+	ctx := context.Background()
+
+	scoped := settings.Bool(settings.Meta{
+		Name: "sc.flag", DescEN: "e", DescZH: "z",
+		SiteScoped: true,
+	}, false)
+	reg := settings.NewRegistry(
+		settings.Domain{Name: "sc", TitleZH: "sc", Keys: []settings.Entry{scoped}},
+	)
+	dist := settings.NewDistributor(testDB, reg, nil)
+	svc := settings.NewService(reg, settings.NewStore(testDB), dist)
+	site := settings.SiteScope(3)
+
+	if _, err := svc.Set(ctx, 7, site, scoped.Name(), json.RawMessage(`true`), "site", nil); err != nil {
+		t.Fatalf("set site scoped: %v", err)
+	}
+	if scoped.ForSite(3) != true {
+		t.Errorf("ForSite(3) after Set = %v, want true without a manual Refresh", scoped.ForSite(3))
+	}
+	if scoped.Get() != false {
+		t.Errorf("Get() after site Set = %v, want platform false", scoped.Get())
+	}
+	if scoped.ForSite(4) != false {
+		t.Errorf("ForSite(4) after site 3 Set = %v, want platform false", scoped.ForSite(4))
+	}
+
+	if _, err := svc.Reset(ctx, 7, site, scoped.Name(), "undo"); err != nil {
+		t.Fatalf("reset site: %v", err)
+	}
+	if scoped.ForSite(3) != false {
+		t.Errorf("ForSite(3) after Reset = %v, want platform fallback false", scoped.ForSite(3))
+	}
+}
+
 func TestServiceEffective(t *testing.T) {
 	reset(t)
 	seedActor(t)

--- a/apps/api/internal/platform/settings/service.go
+++ b/apps/api/internal/platform/settings/service.go
@@ -133,12 +133,10 @@ func (s *Service) Set(ctx context.Context, actorID uint, scope Scope, key string
 	if _, err := s.store.Set(ctx, scope, key, raw, note, expectVersion, actorID); err != nil {
 		return nil, err
 	}
-	if scope.IsPlatform() {
-		if err := s.dist.Refresh(ctx); err != nil {
-			return nil, err
-		}
-		s.dist.Announce(ctx)
+	if err := s.dist.Refresh(ctx); err != nil {
+		return nil, err
 	}
+	s.dist.Announce(ctx)
 	return s.viewFor(ctx, e, scope)
 }
 
@@ -156,12 +154,10 @@ func (s *Service) Reset(ctx context.Context, actorID uint, scope Scope, key stri
 	if err := s.store.Reset(ctx, scope, key, note, actorID); err != nil {
 		return nil, err
 	}
-	if scope.IsPlatform() {
-		if err := s.dist.Refresh(ctx); err != nil {
-			return nil, err
-		}
-		s.dist.Announce(ctx)
+	if err := s.dist.Refresh(ctx); err != nil {
+		return nil, err
 	}
+	s.dist.Announce(ctx)
 	return s.viewFor(ctx, e, scope)
 }
 

--- a/apps/api/internal/platform/settings/store.go
+++ b/apps/api/internal/platform/settings/store.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
+	"strconv"
 
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
@@ -50,6 +52,29 @@ func (s *Store) Values(ctx context.Context, scope Scope) (map[string]json.RawMes
 	out := make(map[string]json.RawMessage, len(rows))
 	for _, r := range rows {
 		out[r.Key] = json.RawMessage(r.Value)
+	}
+	return out, nil
+}
+
+func (s *Store) SiteValues(ctx context.Context) (map[string]map[uint]json.RawMessage, error) {
+	var rows []SettingOverride
+	err := s.db.WithContext(ctx).
+		Where("scope_kind = ?", ScopeSite).
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]map[uint]json.RawMessage)
+	for _, r := range rows {
+		id, err := strconv.ParseUint(r.ScopeID, 10, 64)
+		if err != nil {
+			slog.Warn("settings: site override row has a non-numeric scope_id; ignored", "scope_id", r.ScopeID, "key", r.Key)
+			continue
+		}
+		if out[r.Key] == nil {
+			out[r.Key] = make(map[uint]json.RawMessage)
+		}
+		out[r.Key][uint(id)] = json.RawMessage(r.Value)
 	}
 	return out, nil
 }


### PR DESCRIPTION
Config-center W3-c: in-process per-site settings reads, and the two upload master switches enforced per calling site.

## What

- **`Key[T].ForSite(siteID)`** — a new atomic per-site overlay (`atomic.Pointer[map[uint]T]`) beside the platform snapshot. Overlay hit returns the site override; miss falls back to `Get()`. `Entry` gains unexported `applySites`/`siteValues`.
- **`Store.SiteValues`** — loads all `scope_kind='site'` rows keyed by setting name then numeric `scope_id` (non-numeric ids warned and skipped).
- **`ResolveSites`** — standalone resolver (does not touch `Resolve`'s signature): only `SiteScoped` keys, decode+validate with warn+skip per row, emits add/change/removal `SiteChange`s via DeepEqual against the previous overlay; an identical refresh emits nothing; applying an empty map is what clears a deleted row.
- **Distributor** — `Refresh` fetches platform and site rows **before applying either**, so a failed site query keeps the whole previous snapshot in force; site changes log as `settings: site override applied/removed`; the total-failure floor also resets overlays; `settings: loaded` gains `site_overrides=N`.
- **Service** — site-scope `Set`/`Reset` now Refresh + Announce like platform writes (W2 skipped this because nothing in-process could read site rows yet).
- **Enforcement** — `image.upload_enabled` and `artifact.upload_enabled` become `SiteScoped`. The image upload route reorders to `ClientAuth → uploadGate → Upload`, and the gate reads `ForSite(*client.SiteID)` for site-bound clients, else platform `Get()`. The three artifact upload handlers switch to an `uploadEnabled(ctx)` helper with the same rule, in place, status codes unchanged.

## Behavior change

An unauthenticated `POST /image/upload` while uploads are disabled now gets **401** (from `ClientAuth`) instead of the old gate-first **503** — identity precedes policy, and the per-site policy needs the client identity. Artifact routes already authenticated before the gate, so nothing shifts there.

Not in scope: the S2S read face (`Effective`) keeps reading site rows from the DB per request; `platform.read_only`/`platform.notice` stay contract-only with no in-process call sites.

## Verification

- gofmt clean (delta vs main baseline empty; touched∩baseline empty)
- `go build ./...` / `go vet ./...` green under `apps/api`
- New tests: `TestForSite`, `TestResolveSites` (apply / out-of-bounds skip / non-scoped skip / idempotent refresh / removal), `TestServiceSiteWriteRefreshesForSite` (console site write → `ForSite` reflects with no manual refresh; `Get()` unaffected; reset falls back) — all verified running for real against an ephemeral DB
- Full suite: 168 packages ok (`-count=1 -p 1`, ephemeral DB)
- Golden key list unchanged (86 keys, no new keys)
- Nine OpenAPI specs byte-identical to merge base 0961784b

No schema change; no migration to run.

https://claude.ai/code/session_015kefkqiURPNwLbRE7xNfq7