### PR TITLE
docs: config-center pages for the 86-key registry and per-site reads

### DIFF
--- a/docs/deploy/18-config-center.md
+++ b/docs/deploy/18-config-center.md
@@ -16,16 +16,34 @@
 | 3. 数据库覆盖值 | 主库 `kun_galgame_infra` 的 `setting_overrides` | 写入后 30 秒内所有服务生效(oauth / image / artifact 经 Redis 推送为毫秒级) | 控制台 `/settings`,需 `settings.write` |
 
 第 3 层有两种行:**平台行**(所有服务读的那一份)和**站点行**(`scope=site:<sites.id>`,只对声明了
-「可按站点覆盖」的键存在,只被 S2S 读面与控制台读,进程内 `keys.X.Get()` 不看它)。
+「可按站点覆盖」的键存在)。自 W3-c 起站点行也进程内生效:`keys.X.Get()` 仍只看平台行,
+`keys.X.ForSite(siteID)` 有站点行时返回站点值、否则退回平台生效值。
 
-读取是进程内原子指针,请求路径零网络;每个服务每 30 秒向主库拉一次平台行(几十行)。
+读取是进程内原子指针,请求路径零网络;每个服务每 30 秒向主库拉一次平台行与站点行(各几十行),
+两批都取到才一起应用——站点查询失败时整份沿用上一份快照。
 刷新失败沿用上一份;启动时连续失败则只带 1+2 两层运行并打 `settings: initial load failed` 的
 ERROR 日志。数据库里的一行若类型不符、越界或枚举外,会被忽略并退回 2/1 层,日志有 WARN。
 
 **边界**:配置中心只收运行期可调项(开关、阈值、TTL、配额)。密钥、host/port/dsn/bucket、S3
 path style、PG 连接池、OIDC 签名算法、aff URL 模板等启动期接线永远留在环境变量里。
 
-## 18.1 现有键(44 个:platform 2 + W1 18 + jobs 24)
+## 18.1 现有键(86 个)
+
+| 域 | 键数 | 来源 |
+|---|---|---|
+| `platform` | 2 | W2,站点契约 |
+| `auth` | 7 | W1 1 + W3-a 6 |
+| `image` | 5 | W1 1 + W3-b 4(GC) |
+| `artifact` | 9 | W1 8 + W3-b 1(GC) |
+| `trust` | 11 | W1 4 + W3-a 7 |
+| `ai` | 6 | W1 3 + W3-a 1 + W3-b 2(模型名) |
+| `store` | 7 | W1 1 + W3-b 6(价格面) |
+| `apiv2` / `catalog` / `community` / `developer` | 4 / 2 / 7 / 2 | W3-a 新域 |
+| `jobs` | 24 | W2,12 任务 × 2 |
+
+全目录以控制台 `/settings` 为准——**注册表即界面**,每个键的类型、范围与中英文说明都在
+`internal/platform/settings/keys` 的声明里(`keys.go` = platform + W1,`policy.go` = W3-a,
+`boot.go` = W3-b,`jobs.go` = 任务表)。下面只展开 platform 与 W1 的详表,W3 两批列到键名。
 
 ### 平台策略(`platform`,W2)
 
@@ -39,7 +57,9 @@ path style、PG 连接池、OIDC 签名算法、aff URL 模板等启动期接线
 ### 运行期可调项(W1,18 个)
 
 `image.upload_enabled` 与 `artifact.upload_enabled` 同时是**公开键**(随读面下发,站点据此隐藏上传入口),
-但不可按站点覆盖:执法是平台级的,站点行只会撒谎。
+自 W3-c 起也**可按站点覆盖**并按调用站执法:image 上传门与 artifact 三个上传入口按 client 绑定的
+站点读 `ForSite`,未绑定站点的 client 用平台值。image 的上传门排在鉴权之后——未认证请求在上传
+关闭时回的是 401,不再是 503(认证过的仍是 503)。
 
 | 键 | 类型 | 默认 | 环境变量地板 | 生效位置 |
 |---|---|---|---|---|
@@ -63,6 +83,32 @@ path style、PG 连接池、OIDC 签名算法、aff URL 模板等启动期接线
 | `store.link_quota_per_client` | int | 5000 | `KUN_STORE_LINK_QUOTA_PER_CLIENT` | 每个调用站可铸链的商品数上限 |
 
 单位写在键名里,环境变量的写法与迁入前完全一致。
+
+### 请求路径策略(W3-a,29 个)
+
+原代码常量收编,无环境变量地板、无公开/站点覆盖;改了 30 秒内在请求路径生效:
+
+- `apiv2.*`:`default_rate_per_minute` / `default_quota_per_day` / `auth_fail_per_minute` / `auth_fail_block_seconds`
+- `auth.*`:`ip_rate_per_minute` / `token_endpoint_rate_per_minute` / `strict_rate_per_minute` / `allowed_email_domains` / `verification_resend_cooldown_seconds` / `register_gift_points`
+- `trust.*`:`report_rate_window_minutes` / `report_rate_max_per_window` / `aggregate_threshold` / `new_account_age_days` / `new_account_reporter_weight` / `policy_cache_ttl_seconds` / `term_cache_ttl_seconds`
+- `ai.moderate_max_tokens`
+- `community.*`:`sandbox_max_links` / `sandbox_max_images` / `sandbox_max_mentions` / `sandbox_max_topics_per_day` / `sandbox_max_replies_per_day` / `sandbox_window_hours` / `flag_hide_threshold`
+- `catalog.*`:`totals_cache_ttl_seconds` / `merge_cooling_off_hours`
+- `developer.*`:`credential_cache_ttl_seconds` / `credential_cache_negative_ttl_seconds`
+
+### 启动期旋钮收编(W3-b,13 个)
+
+原 `pkg/config` 字段迁入,六个键保留原环境变量作地板
+(`KUN_STORE_PRICE_ENABLED` / `_USER_AGENT` / `_STEAM_REGIONS` / `_DLSITE_CURRENCIES`、
+`KUN_AI_UPSTREAM_MODEL` / `KUN_AI_OMNI_MODEL`),其余无地板:
+
+- `image.gc_*`:`cold_after_days` / `softdelete_after_days` / `harddelete_after_days` / `max_per_run`(image-gc 任务开跑时读)
+- `artifact.gc_max_per_run`(artifact-gc 任务开跑时读)
+- `store.price_*`:`enabled`(总开关,关闭时报价请求 503、后台刷新跳过)/ `user_agent` / `steam_regions` / `dlsite_currencies` / `wait_on_miss_ms` / `fresh_for_hours`
+- `ai.upstream_model` / `ai.omni_model`
+
+**例外:`store.price_steam_regions` 与 `store.price_dlsite_currencies` 在 catalog 启动时读一次**,
+改了要重启 catalog 才生效(fetcher 构造期定型);其余 84 个键都是使用时读。
 
 ### 后台任务(`jobs`,W2,12 × 2)
 
@@ -94,7 +140,8 @@ oauth 上的调度器(`internal/jobs`)每个任务两把键,没有环境变量�
 (旧值 → 新值 + 备注),页面底部可见。
 
 页面顶部的「作用域」默认是「平台(全局)」;选中某个站点后只列出可按站点覆盖的键,来源多一种
-`站点覆盖`,没有站点行的键显示它继承的平台生效值。站点行只影响 18.7 的读面,不影响任何服务进程。
+`站点覆盖`,没有站点行的键显示它继承的平台生效值。站点行自 W3-c 起与平台行同样进程内生效
+(上传两开关按调用站执法)并同样触发推送/轮询刷新,也继续喂 18.7 的读面。
 
 页面显示的「来源」不含环境变量:oauth 进程看不见其他容器的环境。所以当某键显示「默认」而所属
 服务的 compose 里仍设着同名变量时,该服务实际用的是变量值。真值看 18.3。
@@ -112,8 +159,9 @@ DELETE /api/v1/admin/settings/{key}?note=[&site=]   撤销覆盖
 
 ## 18.3 怎么验证真的生效了
 
-每个服务启动时打一行 `settings: loaded keys=18 overrides=N env_floor=M`,之后每当某键的值或来源变化
-打一行 `settings: applied key=... value=... source=db|env|default`。改完值后 30 秒内在目标服务的
+每个服务启动时打一行 `settings: loaded keys=86 overrides=N env_floor=M site_overrides=K`,之后每当
+某键的值或来源变化打一行 `settings: applied key=... value=... source=db|env|default`;站点行的增删改
+打 `settings: site override applied|removed key=... site=...`。改完值后 30 秒内在目标服务的
 容器日志里应看到对应的 `applied` 行;没看到 = 该服务没连上主库或没启动分发器,先查它的启动日志。
 
 ```bash
@@ -132,12 +180,13 @@ docker logs --since 2m <container> 2>&1 | rg 'settings: (loaded|applied|initial 
 
 ## 18.5 怎么新增一个键
 
-1. 在 `internal/platform/settings/keys/keys.go` 对应域声明(`settings.Bool/Int/Float/String/Enum/StringList`),
+1. 在 `internal/platform/settings/keys` 里对应域的文件声明(`settings.Bool/Int/Float/String/Enum/StringList`),
    给默认值、范围/枚举、中英说明;要保留环境变量地板就填 `EnvVar`;要随读面下发给站点就标 `Public`,
    允许站点单独覆盖就标 `SiteScoped`(两者都是契约,加了就不能撤)。新的定时任务不在这里声明,
    而是在 `keys/jobs.go` 的表里加一行(见 18.6)。
 2. 把它加进该域的 `Keys` 列表;`TestLiveRegistryIsWellFormed` 的 golden 表补一行。
-3. 消费处在**使用时**读 `keys.X.Get()`,不要在构造时读进结构体字段(那正是迁走的东西)。
+3. 消费处在**使用时**读 `keys.X.Get()`(可按站点覆盖的键在知道调用站时读
+   `keys.X.ForSite(siteID)`),不要在构造时读进结构体字段(那正是迁走的东西)。
 4. 测试里用 `settings.Override(t, keys.X, v)` 注入,cleanup 自动还原。
 5. 不需要迁移、不需要改控制台:注册表即界面。
 

--- a/docs/integration/oauth/14-settings.md
+++ b/docs/integration/oauth/14-settings.md
@@ -2,7 +2,7 @@
 
 返回 [README](./README.md)
 
-> **状态:已实现**(配置中心 W2,2026-09-02)。端点 `GET /settings`;实现在
+> **状态:已实现**(配置中心 W2,2026-09-02;W3-c 起上传两开关可按站点覆盖并按站执法)。端点 `GET /settings`;实现在
 > `internal/platform/settings/handler.go`(`Effective`),路由注册在 `cmd/oauth/main.go`。
 > 管理端是 OAuth 控制台的 `/settings` 页;内部模型(三层解析、审计、传播)见 infra
 > `docs/deploy/18-config-center.md`。
@@ -72,11 +72,13 @@
 |------|------|------|------|------|
 | `platform.read_only` | bool | `false` | 是 | `true` 时拒绝一切写操作(发帖、评论、编辑、上传、点赞、后台修改),回一句可读提示;读不受影响。用于数据库迁移等全平台维护窗口 |
 | `platform.notice` | string | `""` | 是 | 非空时在页面顶部展示这一行公告(≤ 500 字,单行);空不展示 |
-| `image.upload_enabled` | bool | `false` | 否 | `false` 时隐藏或禁用图片上传入口(图床本身此时对上传回 503) |
-| `artifact.upload_enabled` | bool | `false` | 否 | `false` 时隐藏或禁用文件上传入口(artifact 服务此时对上传回 503) |
+| `image.upload_enabled` | bool | `false` | 是 | `false` 时隐藏或禁用图片上传入口(图床对该站的上传此时回 503) |
+| `artifact.upload_enabled` | bool | `false` | 是 | `false` 时隐藏或禁用文件上传入口(artifact 服务对该站的上传此时回 503) |
 
 「可按站点覆盖」= 管理员可以在控制台选中某个站点后单独设置(例如只让 letmoe 进入只读)。
-不可按站点覆盖的键,每个站点拿到的都是平台值。
+不可按站点覆盖的键,每个站点拿到的都是平台值。上传两个开关不只随读面下发:图床与 artifact
+服务自己也按调用方 client 绑定的站点执法(W3-c 起),所以站点从读面看到的值与实际被放行/拒绝
+的行为一致。
 
 > 读面报告的是 OAuth 进程看到的值:数据库覆盖值,否则代码默认。上传两个开关在各自服务的
 > compose 里可能还设着同名环境变量地板,那个地板 OAuth 看不见——这正是 infra 侧「先在控制台建行、


### PR DESCRIPTION
Config-center W3-d: documentation catch-up after #123 (W3-a), #124 (W3-b) and #125 (W3-c). Docs only, no code.

- **`docs/deploy/18-config-center.md`** — was still describing the 44-key W2 registry and asserting that site rows are invisible to service processes. Now: per-domain census table (86 keys), the W3-a request-path batch (29) and W3-b boot-knob batch (13) listed by key name with the six surviving env floors and the two restart-to-change catalog fetcher keys, the `ForSite` read model (`Get()` stays platform-only), per-site enforcement of the two upload switches including the 401-before-503 order for unauthenticated image uploads, both-batches-then-apply refresh semantics, and the `site_overrides` field in the `settings: loaded` line.
- **`docs/integration/oauth/14-settings.md`** (Tier A contract) — the two upload switches flip to 可按站点覆盖 = 是, with a note that image/artifact now enforce them per calling site, so the read-face value and the actual accept/reject behavior agree.

Mirror sync to forum/patch (`docs:sync --write` + `docs:audit` in kungal-docs) follows after merge.

https://claude.ai/code/session_015kefkqiURPNwLbRE7xNfq7