### PR TITLE
fix(ci): shape the Dokploy webhook call as a GitHub push event and assert 200

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,9 +167,23 @@ jobs:
       - name: Trigger Dokploy redeploy
         env:
           WEBHOOK: ${{ secrets.DOKPLOY_WEBHOOK_INFRA }}
+          TITLE: ${{ github.event.head_commit.message || github.sha }}
         run: |
           if [ -z "$WEBHOOK" ]; then
             echo "DOKPLOY_WEBHOOK_INFRA not set — images pushed to GHCR, skipping redeploy trigger."
             exit 0
           fi
-          curl -fsS -X POST "$WEBHOOK"
+          # Dokploy's compose webhook is not a bare trigger: the compose is
+          # sourceType=github, so the handler branch-matches the request as if it
+          # were a GitHub push event. A bodyless `curl -X POST` gets 301 "Branch
+          # Not Match" — which `curl -f` treats as success, silently skipping the
+          # deploy (and 400 here means the compose's Auto Deploy toggle is off,
+          # not a bad token — a bad token would be 404). Masquerade as a push and
+          # require an actual 200.
+          body=$(jq -n --arg ref "$GITHUB_REF" --arg sha "$GITHUB_SHA" --arg title "$TITLE" \
+            '{ref: $ref, head_commit: {id: $sha, message: $title}}')
+          code=$(curl -sS -o response.json -w '%{http_code}' -X POST "$WEBHOOK" \
+            -H 'content-type: application/json' -H 'x-github-event: push' \
+            --data-raw "$body")
+          cat response.json; echo
+          [ "$code" = "200" ]


### PR DESCRIPTION
Every main build's deploy step has been failing with a bare `curl: (22) ... 400`. Root-caused against Dokploy v0.30.0 source and the panel DB:

- **The 400 is the compose's Auto Deploy toggle being off** (`autoDeploy=false` → `"Automatic deployments are disabled for this compose"`). A wrong token would be 404, branch/watch-path mismatch is 301. Flipping the toggle is a panel action (see below), not a CI change.
- **Behind it hides a worse failure mode**: the compose is `sourceType=github`, so once Auto Deploy is on, a bodyless `curl -X POST` gets **301 "Branch Not Match"** — which `curl -f` treats as success. The deploy would be silently skipped with a green step.

This PR fixes the CI side: send a minimal GitHub-push-shaped payload (`ref` + `head_commit`, commit title passed via env per the workflow-injection guidance) and assert an actual HTTP 200, printing Dokploy's response body on every run so the next failure names its cause.

**Panel prerequisites (operator action, once):** on the `infra` compose set **Auto Deploy = ON** and **Trigger Type = Tag**. The compose is bound to the Dokploy GitHub App, and with Trigger Type = Push every git push would deploy immediately via the App webhook — before images are built — then again from CI. The token webhook this PR uses does not check trigger type, so Tag keeps the App path dormant while CI drives deploys.

Verification: `jq`-built payload matches what `extractBranchName`/`shouldDeploy` expect at v0.30.0 (`watchPaths` is empty → always passes); YAML lint clean. The real end-to-end proof is the first main build after the panel toggles are set.

https://claude.ai/code/session_01VfxKvHRwA5Vj28pdvoE4bY