### PR TITLE
chore(deploy): pull the seven DB-managed settings env lines from prod compose (W3-e)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -379,7 +379,6 @@ services:
       <<: *infra-env
       KUN_IMAGE_SERVICE_HOST: 0.0.0.0
       KUN_IMAGE_SERVICE_PORT: "9278"
-      KUN_IMAGE_UPLOAD_ENABLED: "true"
     expose: ["9278"]
     depends_on:
       postgres: { condition: service_healthy }
@@ -408,7 +407,6 @@ services:
       # come from *infra-env — shared with the oauth process (artifact-gc/reclaim).
       KUN_ARTIFACT_HOST: 0.0.0.0
       KUN_ARTIFACT_PORT: "9279"
-      KUN_ARTIFACT_UPLOAD_ENABLED: "true"
     # Internal only — moyu/forum backends reach it at http://artifact:9279 over
     # dokploy-network (browsers PUT straight to B2; no public domain needed).
     expose: ["9279"]
@@ -467,7 +465,6 @@ services:
       # two the first fix happened to need.
       KUN_STORE_DLSITE_AFF_URL_TMPL_MANIAX: ${KUN_STORE_DLSITE_AFF_URL_TMPL_MANIAX:-}
       KUN_STORE_DLSITE_AFF_URL_TMPL_PRO: ${KUN_STORE_DLSITE_AFF_URL_TMPL_PRO:-}
-      KUN_STORE_LINK_QUOTA_PER_CLIENT: ${KUN_STORE_LINK_QUOTA_PER_CLIENT:-5000}
       KUN_STORE_PRICE_ENABLED: ${KUN_STORE_PRICE_ENABLED:-true}
       KUN_STORE_PRICE_USER_AGENT: "${KUN_STORE_PRICE_USER_AGENT:-NextMoe-PriceBot/1.0 (+https://www.kungal.com)}"
       KUN_STORE_PRICE_STEAM_REGIONS: ${KUN_STORE_PRICE_STEAM_REGIONS:-jp,cn,us}
@@ -621,19 +618,6 @@ services:
       KUN_TRUST_CLIENT_ID: "ac2b8856594baed9c9ee6792eec082e3"
       KUN_TRUST_CLIENT_SECRET: ${KUN_TRUST_CLIENT_SECRET:-}
       KUN_TRUST_CALLBACK_SECRET: ${KUN_TRUST_CALLBACK_SECRET:-}
-      # Shadow-scan sink (step 04) — INDEPENDENT switch. ON since 2026-07-16
-      # (Tier0 power-on): every post create/edit feeds /trust/scan; rows drain to
-      # degraded while the AI gateway is unprovisioned, with tier0_matched still
-      # recorded (calibration corpus). Prereqs in place: kungal/community_post
-      # registered + the client id above in KUN_TRUST_FORWARDER_CLIENT_IDS.
-      KUN_TRUST_SCAN_ENABLED: "true"
-      # Synchronous pre-write word-list gate (step 06) — INDEPENDENT switch. ON
-      # since 2026-07-16 (Tier0 power-on): deny (banned term) blocks the write
-      # with 422, hold (suspect term) publishes + enqueues a review item; any
-      # check error/timeout fails OPEN (a down trust never blocks posting). With
-      # an empty banned list this gate allows everything — risk is carried by the
-      # term list, which is curated in the /trust/terms admin UI.
-      KUN_TRUST_CHECK_ENABLED: "true"
     # Internal only — product backends (letmoe/...) reach it at
     # http://community:9282 over dokploy-network.
     expose: ["9282"]
@@ -678,20 +662,15 @@ services:
       KUN_AI_CLIENT_BASE_URL: http://ai:9284
       KUN_AI_CLIENT_ID: "ba21dfba94274c134e01ede5eaa7c391"
       KUN_AI_CLIENT_SECRET: ${KUN_AI_CLIENT_SECRET:-}
-      # Wave 07: what the scan worker DOES with a flagged verdict. "shadow" (the
-      # default, and what any unrecognised value degrades to) only records it;
-      # "live" also opens a trust review item and queues the hide callback.
-      # It has to be named HERE — compose forwards only the variables it lists,
-      # so setting this in the Dokploy panel alone never reaches the container
-      # (2026-08-06: a panel-only KUN_TRUST_SCAN_MODE=live was a silent no-op).
-      KUN_TRUST_SCAN_MODE: ${KUN_TRUST_SCAN_MODE:-shadow}
       # Share of CLEAN verdicts drawn into the human queue as calibration items
       # (source=6). This is the ONLY instrument that measures false negatives —
       # what the pipeline misses is otherwise invisible, since a subject nobody
       # flags produces no evidence of its own. Default 0 (off): it spends human
       # review capacity, so turning it on is a deliberate act. Capped at 0.05 in
-      # code; anything higher or negative degrades to off. Same reason as
-      # SCAN_MODE above: it must be named here to reach the container at all.
+      # code; anything higher or negative degrades to off. It must be named here
+      # to reach the container at all — compose forwards only the variables it
+      # lists (2026-08-06: a panel-only KUN_TRUST_SCAN_MODE=live was a silent
+      # no-op).
       KUN_TRUST_SCAN_SAMPLE_RATE: ${KUN_TRUST_SCAN_SAMPLE_RATE:-0}
     # Internal only — product backends reach it at http://trust:9283 over
     # dokploy-network.
@@ -740,11 +719,6 @@ services:
       # negative rate for shadow calibration (only when the LLM tier is configured).
       KUN_AI_ESCALATE_THRESHOLD: ${KUN_AI_ESCALATE_THRESHOLD:-0.4}
       KUN_AI_NEGATIVE_SAMPLE_RATE: ${KUN_AI_NEGATIVE_SAMPLE_RATE:-0.05}
-      # Per-face forced escalation: comma-separated site:kind pairs (e.g.
-      # "kungal:forum_topic,kungal:forum_reply") whose texts always get Tier2
-      # final adjudication — omni has no spam category, so classified-ad spam
-      # scores ~0 and the threshold can never catch it.
-      KUN_AI_FORCE_ESCALATE: ${KUN_AI_FORCE_ESCALATE:-}
     # Internal only — product/platform backends reach it at http://ai:9284 over
     # dokploy-network.
     expose: ["9284"]

--- a/docs/deploy/18-config-center.md
+++ b/docs/deploy/18-config-center.md
@@ -178,6 +178,10 @@ docker logs --since 2m <container> 2>&1 | rg 'settings: (loaded|applied|initial 
 4. 确认各服务日志出现 `applied ... source=db` 后,再从 compose 拔掉这些环境变量行。**先建行再拔
    env**,反过来会有一段上传被关闭的窗口。
 
+生产已于 2026-09-03 走完这四步(W3-e):控制台建了 7 行(上传两开关 / trust 三键 /
+`ai.force_escalate` / `store.link_quota_per_client`),`docker-compose.prod.yml` 里这 7 键的
+env 行已拔。此后删掉某行 DB 值,回落的是**代码默认**(不再有 env 地板)。
+
 ## 18.5 怎么新增一个键
 
 1. 在 `internal/platform/settings/keys` 里对应域的文件声明(`settings.Bool/Int/Float/String/Enum/StringList`),


### PR DESCRIPTION
Final step of the config-center W3 wave. The seven keys that received console DB rows on 2026-09-02 — `image.upload_enabled`, `artifact.upload_enabled`, `trust.scan_enabled`, `trust.check_enabled`, `trust.scan_mode`, `ai.force_escalate`, `store.link_quota_per_client` — are enforced from `setting_overrides` in every service. Verified in prod on 2026-09-03 after the 86-key deploy:

- all seven services log `settings: loaded keys=86 overrides=7 env_floor=… site_overrides=0`;
- a transient site-scope row propagated to all seven services as `settings: site override applied` / `removed` within one 30s poll cycle, then was removed.

With the DB rows in force the compose env floors for these keys are dead weight (the DB row always wins), so this pulls the seven env lines from `docker-compose.prod.yml`:

- `image`: `KUN_IMAGE_UPLOAD_ENABLED`
- `artifact`: `KUN_ARTIFACT_UPLOAD_ENABLED`
- `catalog`: `KUN_STORE_LINK_QUOTA_PER_CLIENT`
- `community`: `KUN_TRUST_SCAN_ENABLED`, `KUN_TRUST_CHECK_ENABLED`
- `trust`: `KUN_TRUST_SCAN_MODE` (the 2026-08-06 panel-only-var incident note moves onto `KUN_TRUST_SCAN_SAMPLE_RATE`, which stays env-floored)
- `ai`: `KUN_AI_FORCE_ESCALATE`

`docs/deploy/18` §18.4 records the completion and the new fallback semantics: deleting one of these DB rows now falls back to the **code default**, with no env floor behind it. Dev compose is untouched (local stacks rely on the env floors instead of console rows).

No schema change; no migration. Takes effect on the next Dokploy redeploy — no urgency, since removed floors were already overridden by DB rows. The now-inert panel variables (`KUN_TRUST_SCAN_MODE`, `KUN_STORE_LINK_QUOTA_PER_CLIENT`, `KUN_AI_FORCE_ESCALATE`) can be cleaned from the Dokploy environment at leisure.

https://claude.ai/code/session_015kefkqiURPNwLbRE7xNfq7