### PR TITLE
feat(dedup): never pair works across mediums

### DIFF
--- a/apps/api/cmd/work-dedup/census.go
+++ b/apps/api/cmd/work-dedup/census.go
@@ -44,7 +44,7 @@ type pairRow struct {
 func pairQuerySQL() string {
 	return `
 WITH lw AS (
-  SELECT id, site, display_name FROM catalog_work WHERE deleted_at IS NULL
+  SELECT id, site, display_name, medium_id FROM catalog_work WHERE deleted_at IS NULL
 ),
 norms AS (
   SELECT work_id, n, bool_or(official) AS official FROM (` + service.WorkDupeCorpusSQL() + `) c GROUP BY work_id, n
@@ -163,7 +163,7 @@ FROM universe p
 JOIN lane la ON la.id = p.a
 JOIN lane lb ON lb.id = p.b
 JOIN lw wa ON wa.id = p.a
-JOIN lw wb ON wb.id = p.b
+JOIN lw wb ON wb.id = p.b AND wb.medium_id = wa.medium_id
 LEFT JOIN wdate da ON da.work_id = p.a
 LEFT JOIN wdate dbb ON dbb.work_id = p.b
 LEFT JOIN bgmdate ba ON ba.work_id = p.a

--- a/apps/api/cmd/work-dedup/crossmedium.go
+++ b/apps/api/cmd/work-dedup/crossmedium.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"api/internal/platform/catalog/model"
+
+	"gorm.io/gorm"
+)
+
+const crossMediumSamples = 10
+
+type crossMediumRow struct {
+	AID     int64  `gorm:"column:a_id"`
+	BID     int64  `gorm:"column:b_id"`
+	MediumA int16  `gorm:"column:medium_a"`
+	MediumB int16  `gorm:"column:medium_b"`
+	NameA   string `gorm:"column:name_a"`
+	NameB   string `gorm:"column:name_b"`
+}
+
+func runCrossMedium(ctx context.Context, db *gorm.DB, w io.Writer, actor int64, run bool) error {
+	var rows []crossMediumRow
+	if err := db.WithContext(ctx).Raw(`
+SELECT c.a_id, c.b_id, wa.medium_id AS medium_a, wb.medium_id AS medium_b,
+  wa.display_name AS name_a, wb.display_name AS name_b
+FROM catalog_match_candidate c
+JOIN catalog_work wa ON wa.id = c.a_id
+JOIN catalog_work wb ON wb.id = c.b_id
+WHERE c.entity_type = ? AND c.status IN (?, ?, ?)
+  AND wa.medium_id <> wb.medium_id
+ORDER BY c.a_id, c.b_id`,
+		model.EntityTypeWork,
+		model.CandidateStatusPending,
+		model.CandidateStatusDeferred,
+		model.CandidateStatusNeedsManual,
+	).Scan(&rows).Error; err != nil {
+		return err
+	}
+
+	mode := "DRY-RUN (pass -run to reject cross-medium candidates)"
+	if run {
+		mode = "APPLIED"
+	}
+	fmt.Fprintf(w, "%s [crossmedium] actor=%d n=%d\n", mode, actor, len(rows))
+	for i, r := range rows {
+		if i >= crossMediumSamples {
+			fmt.Fprintf(w, "  … and %d more\n", len(rows)-crossMediumSamples)
+			break
+		}
+		fmt.Fprintf(w, "  %d<->%d medium=%d×%d a=%q b=%q\n",
+			r.AID, r.BID, r.MediumA, r.MediumB, r.NameA, r.NameB)
+	}
+	if !run {
+		return nil
+	}
+
+	res := db.WithContext(ctx).Exec(`
+UPDATE catalog_match_candidate AS c
+SET status = ?, decided_by = ?, decided_at = now()
+FROM catalog_work wa, catalog_work wb
+WHERE c.entity_type = ?
+  AND c.status IN (?, ?, ?)
+  AND wa.id = c.a_id AND wb.id = c.b_id
+  AND wa.medium_id <> wb.medium_id`,
+		model.CandidateStatusRejected, actor,
+		model.EntityTypeWork,
+		model.CandidateStatusPending,
+		model.CandidateStatusDeferred,
+		model.CandidateStatusNeedsManual,
+	)
+	if res.Error != nil {
+		return res.Error
+	}
+	fmt.Fprintf(w, "  rejected=%d\n", res.RowsAffected)
+	return nil
+}

--- a/apps/api/cmd/work-dedup/main.go
+++ b/apps/api/cmd/work-dedup/main.go
@@ -24,8 +24,8 @@ const waveTagW1 = "rule:work-dedup w1"
 const exitNewPairs = 3
 
 func main() {
-	mode := flag.String("mode", "census", "census | seed | propose | execute | watch")
-	actor := flag.Int64("actor", 0, "operator user id recorded on candidates/proposals (required for seed/propose/execute)")
+	mode := flag.String("mode", "census", "census | seed | propose | execute | watch | crossmedium")
+	actor := flag.Int64("actor", 0, "operator user id recorded on candidates/proposals (required for seed/propose/execute/crossmedium)")
 	run := flag.Bool("run", false, "write (default: dry-run preview)")
 	limit := flag.Int("limit", 0, "propose: max merge groups this run; execute: max proposals this run (0 = all)")
 	note := flag.String("note", waveTagW1, "wave note tag stamped on proposals and matched by -mode execute")
@@ -34,9 +34,9 @@ func main() {
 	failOnNew := flag.Bool("fail-on-new", false, fmt.Sprintf("watch: exit %d when undecided new pairs exist", exitNewPairs))
 	flag.Parse()
 
-	writes := *mode == "seed" || *mode == "propose" || *mode == "execute"
+	writes := *mode == "seed" || *mode == "propose" || *mode == "execute" || *mode == "crossmedium"
 	if writes && *actor <= 0 {
-		fmt.Fprintln(os.Stderr, "-actor <user-id> is required for seed/propose/execute")
+		fmt.Fprintln(os.Stderr, "-actor <user-id> is required for seed/propose/execute/crossmedium")
 		os.Exit(2)
 	}
 
@@ -65,6 +65,8 @@ func main() {
 		if err == nil && *failOnNew && fresh > 0 {
 			os.Exit(exitNewPairs)
 		}
+	case "crossmedium":
+		err = runCrossMedium(ctx, db, os.Stdout, *actor, *run)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown mode %q\n", *mode)
 		os.Exit(2)

--- a/apps/api/cmd/work-dedup/pipeline_test.go
+++ b/apps/api/cmd/work-dedup/pipeline_test.go
@@ -529,3 +529,135 @@ func TestWorkDedupCensusWidening(t *testing.T) {
 		assert.Equal(t, bucketDateClash, verdict)
 	})
 }
+
+func catalogMedium(t *testing.T, key string) int16 {
+	t.Helper()
+	var id int16
+	require.NoError(t, testDB.Raw(`SELECT id FROM catalog_medium WHERE key = ?`, key).Scan(&id).Error)
+	require.NotZero(t, id, "%s medium is not seeded", key)
+	return id
+}
+
+func mkCandidate(t *testing.T, a, b int64, status int16, decidedBy *int64) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&model.CatalogMatchCandidate{
+		EntityType: model.EntityTypeWork, AID: min(a, b), BID: max(a, b),
+		Reason: model.CandidateReasonNameNormEqual, Status: status,
+		DecidedBy: decidedBy,
+	}).Error)
+}
+
+func TestWorkDedupCensusMediumGate(t *testing.T) {
+	requireDB(t)
+	ctx := context.Background()
+
+	t.Run("title_collision", func(t *testing.T) {
+		cleanPipeline(t)
+		gal := galgameMedium(t)
+		anime := catalogMedium(t, "anime")
+
+		crossA := mkWork(t, gal, "クロスメディアエイ作品テスト", nil)
+		crossB := mkWork(t, anime, "クロスメディアビー作品テスト", nil)
+		mkTitle(t, crossA, "クロスメディア重複タイトル検証")
+		mkTitle(t, crossB, "クロスメディア重複タイトル検証")
+
+		sameA := mkWork(t, gal, "同メディアエイ作品テスト", nil)
+		sameB := mkWork(t, gal, "同メディアビー作品テスト", nil)
+		mkTitle(t, sameA, "同メディア重複タイトル検証")
+		mkTitle(t, sameB, "同メディア重複タイトル検証")
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		assert.False(t, hasPair(c, crossA, crossB), "cross-medium title collision must not pair")
+		assert.True(t, hasPair(c, sameA, sameB), "same-medium title collision must pair")
+	})
+
+	t.Run("ref_collision", func(t *testing.T) {
+		cleanPipeline(t)
+		gal := galgameMedium(t)
+		anime := catalogMedium(t, "anime")
+		const officialSite int16 = 9
+
+		crossA := mkWork(t, gal, "クロスメディア参照エイ作品", nil)
+		crossB := mkWork(t, anime, "クロスメディア参照ビー作品", nil)
+		mkRef(t, crossA, officialSite, "www.example.com/medium/gate", model.LinkKindExact, nil)
+		mkRef(t, crossB, officialSite, "www.example.com/medium/gate", model.LinkKindProbable, nil)
+
+		sameA := mkWork(t, gal, "同メディア参照エイ作品テスト", nil)
+		sameB := mkWork(t, gal, "同メディア参照ビー作品テスト", nil)
+		mkRef(t, sameA, officialSite, "www.example.com/medium/gate-same", model.LinkKindExact, nil)
+		mkRef(t, sameB, officialSite, "www.example.com/medium/gate-same", model.LinkKindProbable, nil)
+
+		c, err := buildCensus(ctx, testDB)
+		require.NoError(t, err)
+		assert.False(t, hasPair(c, crossA, crossB), "cross-medium ref collision must not pair")
+		assert.True(t, hasPair(c, sameA, sameB), "same-medium ref collision must pair")
+	})
+}
+
+func TestCrossMediumRejectsOnlyOpenCrossMediumRows(t *testing.T) {
+	requireDB(t)
+	cleanPipeline(t)
+	ctx := context.Background()
+	gal := galgameMedium(t)
+	anime := catalogMedium(t, "anime")
+	const actor = int64(4242)
+
+	pendingA := mkWork(t, gal, "クロスメディア未決エイ作品", nil)
+	pendingB := mkWork(t, anime, "クロスメディア未決ビー作品", nil)
+	mkCandidate(t, pendingA, pendingB, model.CandidateStatusPending, nil)
+
+	deferredA := mkWork(t, gal, "クロスメディア保留エイ作品", nil)
+	deferredB := mkWork(t, anime, "クロスメディア保留ビー作品", nil)
+	mkCandidate(t, deferredA, deferredB, model.CandidateStatusDeferred, nil)
+
+	manualA := mkWork(t, gal, "クロスメディア手動エイ作品", nil)
+	manualB := mkWork(t, anime, "クロスメディア手動ビー作品", nil)
+	mkCandidate(t, manualA, manualB, model.CandidateStatusNeedsManual, nil)
+
+	prior := int64(7)
+	rejectedA := mkWork(t, gal, "クロスメディア既決エイ作品", nil)
+	rejectedB := mkWork(t, anime, "クロスメディア既決ビー作品", nil)
+	mkCandidate(t, rejectedA, rejectedB, model.CandidateStatusRejected, &prior)
+
+	sameA := mkWork(t, gal, "同メディア未決エイ作品テスト", nil)
+	sameB := mkWork(t, gal, "同メディア未決ビー作品テスト", nil)
+	mkCandidate(t, sameA, sameB, model.CandidateStatusPending, nil)
+
+	goneA := mkWork(t, gal, "削除クロスメディアエイ作品", nil)
+	goneB := mkWork(t, anime, "削除クロスメディアビー作品", nil)
+	mkCandidate(t, goneA, goneB, model.CandidateStatusPending, nil)
+	require.NoError(t, testDB.Delete(&model.CatalogWork{}, goneA).Error)
+
+	var out bytes.Buffer
+	require.NoError(t, runCrossMedium(ctx, testDB, &out, actor, false))
+	assert.Contains(t, out.String(), "DRY-RUN")
+	assert.Contains(t, out.String(), "n=4")
+	assert.Equal(t, model.CandidateStatusPending, candidateStatus(t, pendingA, pendingB))
+	assert.Equal(t, model.CandidateStatusDeferred, candidateStatus(t, deferredA, deferredB))
+	assert.Equal(t, model.CandidateStatusNeedsManual, candidateStatus(t, manualA, manualB))
+	assert.Equal(t, model.CandidateStatusRejected, candidateStatus(t, rejectedA, rejectedB))
+	assert.Equal(t, model.CandidateStatusPending, candidateStatus(t, sameA, sameB))
+	assert.Equal(t, model.CandidateStatusPending, candidateStatus(t, goneA, goneB))
+
+	out.Reset()
+	require.NoError(t, runCrossMedium(ctx, testDB, &out, actor, true))
+	assert.Contains(t, out.String(), "APPLIED")
+	assert.Contains(t, out.String(), "rejected=4")
+
+	assert.Equal(t, model.CandidateStatusRejected, candidateStatus(t, pendingA, pendingB))
+	assert.Equal(t, model.CandidateStatusRejected, candidateStatus(t, deferredA, deferredB))
+	assert.Equal(t, model.CandidateStatusRejected, candidateStatus(t, manualA, manualB))
+	assert.Equal(t, model.CandidateStatusRejected, candidateStatus(t, goneA, goneB))
+	assert.Equal(t, model.CandidateStatusPending, candidateStatus(t, sameA, sameB),
+		"same-medium row must be untouched")
+	gotRej := candidateOf(t, rejectedA, rejectedB)
+	assert.Equal(t, model.CandidateStatusRejected, gotRej.Status)
+	require.NotNil(t, gotRej.DecidedBy)
+	assert.Equal(t, prior, *gotRej.DecidedBy, "already-rejected row must keep its original actor")
+
+	gotPending := candidateOf(t, pendingA, pendingB)
+	require.NotNil(t, gotPending.DecidedBy)
+	assert.Equal(t, actor, *gotPending.DecidedBy)
+	require.NotNil(t, gotPending.DecidedAt)
+}

--- a/apps/api/cmd/work-dedup/report.go
+++ b/apps/api/cmd/work-dedup/report.go
@@ -54,6 +54,27 @@ func printCensus(c *census, w io.Writer) {
 	for _, k := range names {
 		fmt.Fprintf(w, "  lane %-18s %d\n", k, lanes[k])
 	}
+	var both []pairRow
+	for i, r := range c.rows {
+		if c.verdicts[i] == bucketBothKungal {
+			both = append(both, r)
+		}
+	}
+	const bothKungalSamples = 50
+	site := func(p *string) string {
+		if p == nil {
+			return ""
+		}
+		return *p
+	}
+	for i, r := range both {
+		if i >= bothKungalSamples {
+			fmt.Fprintf(w, "  … and %d more\n", len(both)-bothKungalSamples)
+			break
+		}
+		fmt.Fprintf(w, "  both-kungal: %d %d %q %q %q %q\n",
+			r.A, r.B, r.NameA, r.NameB, site(r.SiteA), site(r.SiteB))
+	}
 	for i, g := range c.groups {
 		if i >= 5 {
 			break

--- a/apps/api/internal/platform/catalog/service/work_dupe.go
+++ b/apps/api/internal/platform/catalog/service/work_dupe.go
@@ -66,7 +66,10 @@ func WorkDupeCorpusSQL() string {
 // recordWorkDupeSuspects files a pending match candidate for every live work
 // sharing a folded identity norm with the freshly minted work. It never
 // blocks the mint — same-name distinct works are real, so the receipt goes
-// to the reconciliation queue instead of the submitter.
+// to the reconciliation queue instead of the submitter. Works of a different
+// medium never pair: the bangumi cross-media import deliberately mints an
+// adaptation under the same title, and title-only suspects had filed ~1.3k
+// cross-medium receipts before the medium predicate was added.
 func recordWorkDupeSuspects(tx *gorm.DB, workID int64) error {
 	var hits []int64
 	err := tx.Raw(`
@@ -74,6 +77,8 @@ func recordWorkDupeSuspects(tx *gorm.DB, workID int64) error {
 		SELECT DISTINCT o.work_id
 		FROM corpus mine
 		JOIN corpus o ON o.n = mine.n AND o.work_id <> mine.work_id
+		JOIN catalog_work wm ON wm.id = mine.work_id
+		JOIN catalog_work wo ON wo.id = o.work_id AND wo.medium_id = wm.medium_id
 		WHERE mine.work_id = ? AND `+WorkDupeNormEligibleSQL("mine.n")+`
 		ORDER BY o.work_id`, workID).Scan(&hits).Error
 	if err != nil || len(hits) == 0 {

--- a/apps/api/internal/platform/catalog/service/work_dupe_test.go
+++ b/apps/api/internal/platform/catalog/service/work_dupe_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const animeMediumID int16 = 4
+
 func TestSubmitWorkFilesSpacingDupeCandidate(t *testing.T) {
 	s := newLifecycle(t)
 	existing := createWorkX(t, galgameMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "既存作品の表示名")
@@ -32,6 +34,24 @@ func TestSubmitWorkFilesSpacingDupeCandidate(t *testing.T) {
 	assert.Equal(t, model.CandidateReasonNameNormEqual, got.Reason)
 	assert.Equal(t, model.CandidateStatusPending, got.Status)
 	assert.Nil(t, got.DecidedBy)
+}
+
+func TestSubmitWorkCrossMediumCollisionFilesNothing(t *testing.T) {
+	s := newLifecycle(t)
+	anime := createWorkX(t, animeMediumID, model.ContentRatingAllAges, model.WorkStatusLive, "既存作品の表示名")
+	require.NoError(t, testDB.Create(&model.CatalogWorkTitle{
+		WorkID: anime.ID, Lang: "ja", Title: "重複検出タイトル", Kind: model.WorkTitleKindOfficial,
+	}).Error)
+
+	_, err := s.SubmitWork(t.Context(), SubmitWorkParams{
+		Site: submitSite, ProductWorkID: 90505, ActorUID: 7,
+		Fields: submitFields("重複 検出 タイトル"),
+	})
+	require.NoError(t, err)
+
+	var filed int64
+	require.NoError(t, testDB.Model(&model.CatalogMatchCandidate{}).Count(&filed).Error)
+	assert.Zero(t, filed, "an anime sharing the title must not pair with a galgame mint")
 }
 
 func TestSubmitWorkWithoutCollisionFilesNothing(t *testing.T) {


### PR DESCRIPTION
## What

**Ruling applied**: two works of different medium are never the same work. The bangumi cross-media import deliberately mints an adaptation (anime/manga/novel) under the galgame's title; the title-only dup detectors treated those as duplicate suspects and piled ~1.3k cross-medium candidates into the manual queue.

- **Census gate** (`cmd/work-dedup/census.go`): the pair query joins live works with `wb.medium_id = wa.medium_id` at the outer join, so both the title-norm lane and the ref lane stop forming cross-medium pairs.
- **Mint gate** (`service/work_dupe.go`): `recordWorkDupeSuspects` gets the same medium-equality predicate, so the submit path cannot re-mint cross-medium pending candidates after the cleanup.
- **`crossmedium` cleanup mode** (`cmd/work-dedup/crossmedium.go`): machine-rejects the existing backlog — entity_type=5, status ∈ {pending, deferred, needsManual}, differing mediums; raw-table join so candidates against soft-deleted works are cleared too; dry-run by default, `-run -actor <id>` to apply. Measured 1,352 rows on prod, **zero quarantined works** among them, so the raw status flip (bypassing `releaseQuarantinedPair`) strands nothing.
- **Report**: `printCensus` now enumerates both-kungal frozen pairs (a, b, names, sites; cap 50) instead of only counting them, so ops can see which true duplicates are claims-frozen.

## Tests

- `TestWorkDedupCensusMediumGate` (title_collision / ref_collision), each with a same-medium positive control sharing the gate.
- `TestCrossMediumRejectsOnlyOpenCrossMediumRows`: statuses 0/3/4 flipped incl. one against a soft-deleted work; same-medium pending row and an already-rejected row untouched.
- `TestSubmitWorkCrossMediumCollisionFilesNothing`: anime sharing the title no longer files a candidate on galgame mint.
- Full `./cmd/work-dedup/` and `./internal/platform/catalog/service/` suites green against an ephemeral DB.

## After deploy (operator)

`work-dedup -mode crossmedium -actor 1` (dry-run, expect n≈1,352) → `-run` → re-run census to confirm cross-medium pairs are gone. No schema change, no migration.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD