### PR TITLE
feat(console): rebuild the catalog dedup review console

### DIFF
--- a/apps/api/internal/platform/catalog/handler/admin.go
+++ b/apps/api/internal/platform/catalog/handler/admin.go
@@ -47,6 +47,10 @@ func (s *AdminServer) register(api huma.API) {
 		Summary: "List match candidates (the ambiguity bucket)", Tags: tags,
 	}, s.listCandidates)
 	huma.Register(api, huma.Operation{
+		OperationID: "catalogQueueSummary", Method: http.MethodGet, Path: "/api/v1/admin/catalog/candidates/summary",
+		Summary: "Queue depth: candidates grouped by entity type × status, probable refs grouped by entity type", Tags: tags,
+	}, s.queueSummary)
+	huma.Register(api, huma.Operation{
 		OperationID: "decideCatalogCandidate", Method: http.MethodPost, Path: "/api/v1/admin/catalog/candidates/decide",
 		Summary: "Decide a match candidate: accept (credit_name → link a person; else opens a merge proposal), reject (kept forever) or defer", Tags: tags,
 	}, s.decideCandidate)
@@ -188,6 +192,19 @@ func (s *AdminServer) listCandidates(ctx context.Context, in *candidatesInput) (
 		return nil, apiErr(http.StatusInternalServerError, errors.ErrInternalServer)
 	}
 	return &candidatesOutput{Body: okEnvelope(dto.Page[service.CandidateItem]{Items: items, Total: total})}, nil
+}
+
+type queueSummaryOutput struct {
+	Body Envelope[service.QueueSummary]
+}
+
+func (s *AdminServer) queueSummary(ctx context.Context, _ *struct{}) (*queueSummaryOutput, error) {
+	summary, err := s.queues.QueueSummary(ctx)
+	if err != nil {
+		slog.Error("catalog admin queue summary", "err", err)
+		return nil, apiErr(http.StatusInternalServerError, errors.ErrInternalServer)
+	}
+	return &queueSummaryOutput{Body: okEnvelope(summary)}, nil
 }
 
 type decideCandidateInput struct {

--- a/apps/api/internal/platform/catalog/service/admin_queue.go
+++ b/apps/api/internal/platform/catalog/service/admin_queue.go
@@ -45,6 +45,14 @@ type EntitySummary struct {
 	CreditCount *int64 `json:"credit_count,omitempty"`
 	SourceID    *int16 `json:"source_id,omitempty"`
 	WorkStatus  *int16 `json:"work_status,omitempty"`
+
+	MediumID      *int16             `json:"medium_id,omitempty"`
+	OLang         string             `json:"olang,omitempty"`
+	ContentRating *int16             `json:"content_rating,omitempty"`
+	Site          string             `json:"site,omitempty"`
+	ClaimState    *int16             `json:"claim_state,omitempty"`
+	ReleaseYear   *int16             `json:"release_year,omitempty"`
+	Refs          []EntityRefSummary `json:"refs,omitempty"`
 }
 
 func entitySummary(db *gorm.DB, entityType int16, id int64) EntitySummary {
@@ -115,6 +123,7 @@ func (s *AdminQueueService) ListCandidates(ctx context.Context, f CandidateFilte
 		}
 	}
 	s.enrichCreditNameContext(ctx, items)
+	s.enrichWorkContext(ctx, items)
 	return items, total, nil
 }
 

--- a/apps/api/internal/platform/catalog/service/admin_queue_summary.go
+++ b/apps/api/internal/platform/catalog/service/admin_queue_summary.go
@@ -1,0 +1,152 @@
+package service
+
+import (
+	"context"
+
+	"api/internal/platform/catalog/model"
+)
+
+const workRefEvidenceLimit = 6
+
+type CandidateBucketCount struct {
+	EntityType int16 `gorm:"column:entity_type" json:"entity_type"`
+	Status     int16 `gorm:"column:status" json:"status"`
+	Count      int64 `gorm:"column:count" json:"count"`
+}
+
+type ProbableRefBucketCount struct {
+	EntityType int16 `gorm:"column:entity_type" json:"entity_type"`
+	Count      int64 `gorm:"column:count" json:"count"`
+}
+
+type QueueSummary struct {
+	Candidates   []CandidateBucketCount   `json:"candidates"`
+	ProbableRefs []ProbableRefBucketCount `json:"probable_refs"`
+}
+
+func (s *AdminQueueService) QueueSummary(ctx context.Context) (QueueSummary, error) {
+	db := s.db.WithContext(ctx)
+
+	var candidates []CandidateBucketCount
+	if err := db.Raw(`SELECT entity_type, status, count(*) AS count
+	                  FROM catalog_match_candidate
+	                  GROUP BY entity_type, status
+	                  ORDER BY entity_type, status`).Scan(&candidates).Error; err != nil {
+		return QueueSummary{}, err
+	}
+
+	// Scope copied from ListProbableRefs; it deliberately does not filter
+	// dead_at, so the chip totals match the queue the reviewer pages through.
+	var refs []ProbableRefBucketCount
+	if err := db.Raw(`SELECT entity_type, count(*) AS count
+	                  FROM catalog_external_ref
+	                  WHERE link_kind = ? AND verified_at IS NULL
+	                  GROUP BY entity_type
+	                  ORDER BY entity_type`, model.LinkKindProbable).Scan(&refs).Error; err != nil {
+		return QueueSummary{}, err
+	}
+
+	if candidates == nil {
+		candidates = []CandidateBucketCount{}
+	}
+	if refs == nil {
+		refs = []ProbableRefBucketCount{}
+	}
+	return QueueSummary{Candidates: candidates, ProbableRefs: refs}, nil
+}
+
+type EntityRefSummary struct {
+	SourceID   int16  `gorm:"column:source_id" json:"source_id"`
+	ExternalID string `gorm:"column:external_id" json:"external_id"`
+	LinkKind   int16  `gorm:"column:link_kind" json:"link_kind"`
+}
+
+func (s *AdminQueueService) enrichWorkContext(ctx context.Context, items []CandidateItem) {
+	var ids []int64
+	for _, it := range items {
+		if it.EntityType == model.EntityTypeWork {
+			ids = append(ids, it.AID, it.BID)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	db := s.db.WithContext(ctx)
+
+	type workRow struct {
+		ID            int64   `gorm:"column:id"`
+		MediumID      int16   `gorm:"column:medium_id"`
+		OLang         string  `gorm:"column:olang"`
+		ContentRating int16   `gorm:"column:content_rating"`
+		Site          *string `gorm:"column:site"`
+		ClaimState    *int16  `gorm:"column:claim_state"`
+	}
+	works := map[int64]workRow{}
+	var workRows []workRow
+	if err := db.Raw(`SELECT id, medium_id, olang, content_rating, site, claim_state
+		FROM catalog_work WHERE id IN ?`, ids).Scan(&workRows).Error; err == nil {
+		for _, r := range workRows {
+			works[r.ID] = r
+		}
+	}
+
+	years := map[int64]int16{}
+	var yearRows []struct {
+		WorkID int64 `gorm:"column:work_id"`
+		Year   int16 `gorm:"column:year"`
+	}
+	if err := db.Raw(`SELECT work_id, min(released_y) AS year FROM catalog_release
+		WHERE work_id IN ? AND released_y IS NOT NULL AND deleted_at IS NULL
+		GROUP BY work_id`, ids).Scan(&yearRows).Error; err == nil {
+		for _, r := range yearRows {
+			years[r.WorkID] = r.Year
+		}
+	}
+
+	refs := map[int64][]EntityRefSummary{}
+	var refRows []struct {
+		EntityID   int64  `gorm:"column:entity_id"`
+		SourceID   int16  `gorm:"column:source_id"`
+		ExternalID string `gorm:"column:external_id"`
+		LinkKind   int16  `gorm:"column:link_kind"`
+	}
+	if err := db.Raw(`SELECT entity_id, source_id, external_id, link_kind FROM (
+			SELECT entity_id, source_id, external_id, link_kind,
+			       row_number() OVER (PARTITION BY entity_id
+			                          ORDER BY link_kind, source_id, external_id) AS rn
+			FROM catalog_external_ref
+			WHERE entity_type = ? AND entity_id IN ? AND link_kind IN ? AND dead_at IS NULL
+		) ranked WHERE rn <= ?`,
+		model.EntityTypeWork, ids,
+		[]int16{model.LinkKindExact, model.LinkKindProbable},
+		workRefEvidenceLimit).Scan(&refRows).Error; err == nil {
+		for _, r := range refRows {
+			refs[r.EntityID] = append(refs[r.EntityID], EntityRefSummary{
+				SourceID: r.SourceID, ExternalID: r.ExternalID, LinkKind: r.LinkKind,
+			})
+		}
+	}
+
+	fill := func(sum *EntitySummary) {
+		if w, ok := works[sum.ID]; ok {
+			medium, rating := w.MediumID, w.ContentRating
+			sum.MediumID = &medium
+			sum.ContentRating = &rating
+			sum.OLang = w.OLang
+			sum.ClaimState = w.ClaimState
+			if w.Site != nil {
+				sum.Site = *w.Site
+			}
+		}
+		if y, ok := years[sum.ID]; ok {
+			sum.ReleaseYear = &y
+		}
+		sum.Refs = refs[sum.ID]
+	}
+	for i := range items {
+		if items[i].EntityType == model.EntityTypeWork {
+			fill(&items[i].A)
+			fill(&items[i].B)
+		}
+	}
+}

--- a/apps/web/app/components/catalog/CandidateCreditPair.vue
+++ b/apps/web/app/components/catalog/CandidateCreditPair.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import {
+  CANDIDATE_REASON_LABELS,
+  CANDIDATE_STATUS,
+  CANDIDATE_STATUS_COLORS,
+  CANDIDATE_STATUS_LABELS,
+  CATALOG_SOURCE_LABELS
+} from '~/constants/catalog'
+import type {
+  CatalogCandidateItem,
+  CatalogEntitySummary
+} from '~~/shared/types/catalog'
+
+const props = defineProps<{ item: CatalogCandidateItem; busy: boolean }>()
+
+const emit = defineEmits<{
+  accept: []
+  reject: []
+  defer: []
+  detach: []
+}>()
+
+const sides = computed(() => [
+  { tag: 'A', summary: props.item.a },
+  { tag: 'B', summary: props.item.b }
+])
+
+const isDecidable = computed(() =>
+  (
+    [
+      CANDIDATE_STATUS.pending,
+      CANDIDATE_STATUS.deferred,
+      CANDIDATE_STATUS.needsManual
+    ] as number[]
+  ).includes(props.item.status)
+)
+
+const sourceLabel = (s: CatalogEntitySummary) =>
+  s.source_id == null
+    ? ''
+    : (CATALOG_SOURCE_LABELS[s.source_id] ?? `源${s.source_id}`)
+</script>
+
+<template>
+  <KunCard content-class="space-y-2 p-3">
+    <div class="flex flex-wrap items-center gap-2">
+      <KunChip color="info" variant="flat" size="xs">名义</KunChip>
+      <KunChip color="default" variant="flat" size="xs">
+        {{ CANDIDATE_REASON_LABELS[item.reason] ?? item.reason }}
+      </KunChip>
+      <KunChip
+        v-if="item.score !== null"
+        color="default"
+        variant="flat"
+        size="xs"
+      >
+        相似度 {{ item.score?.toFixed(2) }}
+      </KunChip>
+      <KunChip
+        :color="CANDIDATE_STATUS_COLORS[item.status] ?? 'default'"
+        variant="flat"
+        size="xs"
+        class="ml-auto"
+      >
+        {{ CANDIDATE_STATUS_LABELS[item.status] ?? item.status }}
+      </KunChip>
+    </div>
+
+    <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+      <template v-for="(side, index) in sides" :key="side.tag">
+        <KunIcon
+          v-if="index > 0"
+          name="lucide:arrow-left-right"
+          class="text-default-400 size-4"
+        />
+        <span class="flex flex-wrap items-center gap-1.5">
+          <span class="text-foreground font-medium">
+            {{ side.summary.display_name || `#${side.summary.id}` }}
+          </span>
+          <span class="text-default-400 font-mono text-xs">
+            #{{ side.summary.id }}
+          </span>
+          <KunChip
+            v-if="side.summary.source_id != null"
+            color="info"
+            variant="flat"
+            size="xs"
+          >
+            {{ sourceLabel(side.summary) }}
+          </KunChip>
+          <span class="text-default-400 text-xs">
+            {{ side.summary.credit_count ?? 0 }} 条署名
+          </span>
+        </span>
+      </template>
+    </div>
+
+    <div v-if="isDecidable" class="flex flex-wrap gap-2">
+      <KunButton
+        color="success"
+        size="sm"
+        :disabled="busy"
+        @click="emit('accept')"
+      >
+        确认为同一人
+      </KunButton>
+      <KunButton
+        color="danger"
+        variant="flat"
+        size="sm"
+        :disabled="busy"
+        @click="emit('reject')"
+      >
+        不是同一人（永久保留）
+      </KunButton>
+      <KunButton
+        color="default"
+        variant="flat"
+        size="sm"
+        :disabled="busy"
+        @click="emit('defer')"
+      >
+        搁置
+      </KunButton>
+    </div>
+
+    <div v-else class="flex flex-wrap items-center gap-2">
+      <p class="text-default-400 text-sm">
+        已决策（{{ CANDIDATE_STATUS_LABELS[item.status] }}
+        <template v-if="item.decided_by !== null">
+          · 操作者 {{ item.decided_by }}</template
+        >）
+      </p>
+      <KunButton
+        v-if="item.status === CANDIDATE_STATUS.accepted"
+        color="default"
+        variant="flat"
+        size="sm"
+        :disabled="busy"
+        @click="emit('detach')"
+      >
+        撤销关联（摘离双方名义）
+      </KunButton>
+    </div>
+  </KunCard>
+</template>

--- a/apps/web/app/components/catalog/CandidatePair.vue
+++ b/apps/web/app/components/catalog/CandidatePair.vue
@@ -1,0 +1,290 @@
+<script setup lang="ts">
+import {
+  CANDIDATE_REASON_LABELS,
+  CANDIDATE_STATUS,
+  CANDIDATE_STATUS_COLORS,
+  CANDIDATE_STATUS_LABELS,
+  CATALOG_ENTITY_TYPE,
+  CATALOG_ENTITY_TYPES,
+  CATALOG_MEDIUM_LABELS,
+  WORK_STATUS
+} from '~/constants/catalog'
+import type {
+  CatalogCandidateItem,
+  CatalogEntityRef,
+  CatalogEntitySummary,
+  CatalogMergeDirection
+} from '~~/shared/types/catalog'
+
+const props = defineProps<{ item: CatalogCandidateItem; busy: boolean }>()
+
+const emit = defineEmits<{
+  merge: [direction: CatalogMergeDirection]
+  reject: []
+  defer: []
+  release: [workId: number]
+}>()
+
+const refKey = (r: CatalogEntityRef) => `${r.source_id}:${r.external_id}`
+
+const sharedKeys = computed(() => {
+  const left = new Set((props.item.a.refs ?? []).map(refKey))
+  return (props.item.b.refs ?? []).map(refKey).filter((k) => left.has(k))
+})
+
+const refCount = (s: CatalogEntitySummary) => s.refs?.length ?? 0
+
+const survivor = computed<'a' | 'b'>(() => {
+  const { a, b } = props.item
+  if (a.site && !b.site) return 'a'
+  if (b.site && !a.site) return 'b'
+  if (refCount(a) !== refCount(b)) return refCount(a) > refCount(b) ? 'a' : 'b'
+  return a.id <= b.id ? 'a' : 'b'
+})
+
+const recommended = computed<CatalogMergeDirection>(() =>
+  survivor.value === 'a' ? 'ba' : 'ab'
+)
+
+const nameOf = (s: CatalogEntitySummary) => s.display_name || `#${s.id}`
+
+const recommendReason = computed(() => {
+  const { a, b } = props.item
+  const keep = survivor.value === 'a' ? a : b
+  const tag = survivor.value.toUpperCase()
+  if (keep.site) return `${tag}「${nameOf(keep)}」已被 ${keep.site} 认领`
+  if (refCount(a) !== refCount(b)) {
+    return `${tag}「${nameOf(keep)}」外部锚点更多（${refCount(a)} vs ${refCount(b)}）`
+  }
+  return `${tag}「${nameOf(keep)}」id 更小，铸造更早`
+})
+
+const direction = ref<CatalogMergeDirection>(recommended.value)
+watch(recommended, (value) => {
+  direction.value = value
+})
+
+const keepSide = computed(() => (direction.value === 'ab' ? 'b' : 'a'))
+
+const isWork = computed(
+  () => props.item.entity_type === CATALOG_ENTITY_TYPE.work
+)
+
+const entityNoun = computed(
+  () => CATALOG_ENTITY_TYPES[props.item.entity_type] ?? '实体'
+)
+
+const isDecidable = computed(() =>
+  (
+    [
+      CANDIDATE_STATUS.pending,
+      CANDIDATE_STATUS.deferred,
+      CANDIDATE_STATUS.needsManual
+    ] as number[]
+  ).includes(props.item.status)
+)
+
+const nameMismatch = computed(
+  () => props.item.a.display_name !== props.item.b.display_name
+)
+
+const mediumMismatch = computed(() => {
+  const { a, b } = props.item
+  return (
+    a.medium_id != null && b.medium_id != null && a.medium_id !== b.medium_id
+  )
+})
+
+const mediumPair = computed(() => {
+  const { a, b } = props.item
+  const label = (id?: number) =>
+    id == null ? '未知' : (CATALOG_MEDIUM_LABELS[id] ?? `媒介${id}`)
+  return `${label(a.medium_id)} vs ${label(b.medium_id)}`
+})
+
+const bothClaimed = computed(() => !!props.item.a.site && !!props.item.b.site)
+
+const quarantinedIds = computed(() =>
+  [props.item.a, props.item.b]
+    .filter((s) => s.work_status === WORK_STATUS.QUARANTINE)
+    .map((s) => s.id)
+)
+
+const sharedRefs = computed(() =>
+  (props.item.a.refs ?? []).filter((r) => sharedKeys.value.includes(refKey(r)))
+)
+</script>
+
+<template>
+  <KunCard content-class="space-y-3 p-4">
+    <div class="flex flex-wrap items-center gap-2">
+      <KunChip color="info" variant="flat" size="xs">
+        {{ entityNoun }}
+      </KunChip>
+      <KunChip color="default" variant="flat" size="xs">
+        {{ CANDIDATE_REASON_LABELS[item.reason] ?? item.reason }}
+      </KunChip>
+      <KunChip
+        v-if="item.score !== null"
+        color="default"
+        variant="flat"
+        size="xs"
+      >
+        相似度 {{ item.score?.toFixed(2) }}
+      </KunChip>
+      <span class="text-default-400 text-xs">
+        {{ formatDate(item.created_at, { isShowYear: true }) }} 入队
+      </span>
+      <KunChip
+        :color="CANDIDATE_STATUS_COLORS[item.status] ?? 'default'"
+        variant="flat"
+        size="xs"
+        class="ml-auto"
+      >
+        {{ CANDIDATE_STATUS_LABELS[item.status] ?? item.status }}
+      </KunChip>
+    </div>
+
+    <div
+      v-if="sharedKeys.length"
+      class="border-success-200 bg-success-50 flex flex-wrap items-center gap-2 rounded-lg border px-3 py-2"
+    >
+      <KunIcon name="lucide:anchor" class="text-success-600 size-4" />
+      <span class="text-success-700 text-sm font-medium">
+        {{ sharedKeys.length }} 个共同外部锚点，几乎可以断定是同一{{
+          entityNoun
+        }}
+      </span>
+      <CatalogRefChip
+        v-for="r in sharedRefs"
+        :key="refKey(r)"
+        :source-id="r.source_id"
+        :external-id="r.external_id"
+        :link-kind="r.link_kind"
+        :entity-type="item.entity_type"
+        shared
+      />
+    </div>
+
+    <div
+      v-if="mediumMismatch"
+      class="border-danger-200 bg-danger-50 flex items-center gap-2 rounded-lg border px-3 py-2"
+    >
+      <KunIcon
+        name="lucide:triangle-alert"
+        class="text-danger size-4 shrink-0"
+      />
+      <span class="text-danger-700 text-sm">
+        两侧媒介不同（{{
+          mediumPair
+        }}）。跨媒介同名件是有意分别铸造的，通常不该合并。
+      </span>
+    </div>
+
+    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <CatalogCandidateSide
+        tag="A"
+        :entity-type="item.entity_type"
+        :summary="item.a"
+        :shared-keys="sharedKeys"
+        :role="keepSide === 'a' ? 'keep' : 'absorb'"
+        :name-mismatch="nameMismatch"
+      />
+      <CatalogCandidateSide
+        tag="B"
+        :entity-type="item.entity_type"
+        :summary="item.b"
+        :shared-keys="sharedKeys"
+        :role="keepSide === 'b' ? 'keep' : 'absorb'"
+        :name-mismatch="nameMismatch"
+      />
+    </div>
+
+    <template v-if="isDecidable">
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-default-500 text-sm">保留哪一侧：</span>
+        <KunButton
+          :color="direction === 'ba' ? 'primary' : 'default'"
+          :variant="direction === 'ba' ? 'solid' : 'flat'"
+          size="sm"
+          @click="direction = 'ba'"
+        >
+          保留 A（B → A）
+        </KunButton>
+        <KunButton
+          :color="direction === 'ab' ? 'primary' : 'default'"
+          :variant="direction === 'ab' ? 'solid' : 'flat'"
+          size="sm"
+          @click="direction = 'ab'"
+        >
+          保留 B（A → B）
+        </KunButton>
+        <span class="text-default-400 text-xs">
+          推荐保留：{{ recommendReason }}
+        </span>
+      </div>
+
+      <div
+        v-if="bothClaimed"
+        class="border-danger-200 bg-danger-50 flex items-center gap-2 rounded-lg border px-3 py-2"
+      >
+        <KunIcon
+          name="lucide:shield-alert"
+          class="text-danger size-4 shrink-0"
+        />
+        <span class="text-danger-700 text-sm">
+          两侧都已被站点认领（{{ item.a.site }} /
+          {{ item.b.site }}）。合并会释放被并入一侧的认领关系。
+        </span>
+      </div>
+
+      <div class="flex flex-wrap gap-2">
+        <KunButton
+          color="success"
+          :disabled="busy"
+          @click="emit('merge', direction)"
+        >
+          <KunIcon name="lucide:git-merge" class="mr-1 size-4" />
+          合并（保留 {{ keepSide === 'a' ? 'A' : 'B' }}）
+        </KunButton>
+        <KunButton
+          color="danger"
+          variant="flat"
+          :disabled="busy"
+          @click="emit('reject')"
+        >
+          不是同一{{ entityNoun
+          }}{{ isWork && quarantinedIds.length ? '（并放行隔离件）' : '' }}
+        </KunButton>
+        <KunButton
+          color="default"
+          variant="flat"
+          :disabled="busy"
+          @click="emit('defer')"
+        >
+          搁置
+        </KunButton>
+      </div>
+    </template>
+
+    <div v-else class="flex flex-wrap items-center gap-2">
+      <p class="text-default-400 text-sm">
+        该候选已决策（{{ CANDIDATE_STATUS_LABELS[item.status] }}
+        <template v-if="item.decided_by !== null">
+          · 操作者 {{ item.decided_by }}</template
+        >）
+      </p>
+      <KunButton
+        v-for="id in quarantinedIds"
+        :key="id"
+        color="warning"
+        variant="flat"
+        size="sm"
+        :disabled="busy"
+        @click="emit('release', id)"
+      >
+        放行 #{{ id }}
+      </KunButton>
+    </div>
+  </KunCard>
+</template>

--- a/apps/web/app/components/catalog/CandidateSide.vue
+++ b/apps/web/app/components/catalog/CandidateSide.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import {
+  CATALOG_MEDIUM_COLORS,
+  CATALOG_MEDIUM_LABELS,
+  CLAIM_STATE_LABELS,
+  CONTENT_RATING_COLORS,
+  CONTENT_RATING_LABELS,
+  WORK_STATUS,
+  WORK_STATUS_LABELS
+} from '~/constants/catalog'
+import type { CatalogEntitySummary } from '~~/shared/types/catalog'
+
+const props = defineProps<{
+  tag: 'A' | 'B'
+  entityType: number
+  summary: CatalogEntitySummary
+  sharedKeys: string[]
+  role: 'keep' | 'absorb'
+  nameMismatch: boolean
+}>()
+
+const refs = computed(() => props.summary.refs ?? [])
+
+const isShared = (sourceId: number, externalId: string) =>
+  props.sharedKeys.includes(`${sourceId}:${externalId}`)
+
+const isQuarantined = computed(
+  () => props.summary.work_status === WORK_STATUS.QUARANTINE
+)
+
+const abnormalStatus = computed(() =>
+  props.summary.work_status != null &&
+  props.summary.work_status !== WORK_STATUS.LIVE
+    ? props.summary.work_status
+    : null
+)
+</script>
+
+<template>
+  <div
+    class="rounded-lg border p-3"
+    :class="
+      role === 'keep'
+        ? 'border-success-300 bg-success-50'
+        : 'border-default-200'
+    "
+  >
+    <div class="mb-1 flex items-center gap-2">
+      <KunChip
+        :color="role === 'keep' ? 'success' : 'default'"
+        :variant="role === 'keep' ? 'solid' : 'flat'"
+        size="xs"
+      >
+        {{ tag }} · {{ role === 'keep' ? '保留' : '并入' }}
+      </KunChip>
+      <span class="text-default-400 font-mono text-xs">#{{ summary.id }}</span>
+      <KunCopy :text="String(summary.id)" />
+    </div>
+
+    <div class="flex flex-wrap items-center gap-1.5">
+      <p
+        class="text-lg leading-tight font-medium"
+        :class="nameMismatch ? 'text-warning-700' : 'text-foreground'"
+      >
+        {{ summary.display_name || '（无显示名）' }}
+      </p>
+      <KunChip
+        v-if="abnormalStatus !== null"
+        :color="isQuarantined ? 'warning' : 'default'"
+        variant="flat"
+        size="xs"
+      >
+        {{ WORK_STATUS_LABELS[abnormalStatus] ?? abnormalStatus }}
+      </KunChip>
+    </div>
+
+    <div class="mt-2 flex flex-wrap items-center gap-1.5">
+      <KunChip
+        v-if="summary.medium_id != null"
+        :color="CATALOG_MEDIUM_COLORS[summary.medium_id] ?? 'default'"
+        variant="flat"
+        size="xs"
+      >
+        {{
+          CATALOG_MEDIUM_LABELS[summary.medium_id] ?? `媒介${summary.medium_id}`
+        }}
+      </KunChip>
+      <KunChip
+        v-if="summary.content_rating != null"
+        :color="CONTENT_RATING_COLORS[summary.content_rating] ?? 'default'"
+        variant="flat"
+        size="xs"
+      >
+        {{
+          CONTENT_RATING_LABELS[summary.content_rating] ??
+          summary.content_rating
+        }}
+      </KunChip>
+      <span v-if="summary.olang" class="text-default-500 text-xs">
+        原语 <span class="font-mono">{{ summary.olang }}</span>
+      </span>
+      <span
+        v-if="summary.release_year != null"
+        class="text-default-500 text-xs"
+      >
+        {{ summary.release_year }} 年发行
+      </span>
+      <span
+        v-if="summary.credit_count != null"
+        class="text-default-500 text-xs"
+      >
+        {{ summary.credit_count }} 条署名
+      </span>
+    </div>
+
+    <div v-if="summary.site" class="mt-2">
+      <KunChip color="warning" variant="flat" size="sm">
+        <template #start>
+          <KunIcon name="lucide:shield-check" class="mr-1 size-3.5" />
+        </template>
+        已被 {{ summary.site }} 认领<template
+          v-if="summary.claim_state != null"
+        >
+          · {{ CLAIM_STATE_LABELS[summary.claim_state] ?? summary.claim_state }}
+        </template>
+      </KunChip>
+    </div>
+
+    <div class="mt-2">
+      <p class="text-default-400 mb-1 text-xs">外部锚点</p>
+      <div v-if="refs.length" class="flex flex-wrap gap-1.5">
+        <CatalogRefChip
+          v-for="r in refs"
+          :key="`${r.source_id}:${r.external_id}`"
+          :source-id="r.source_id"
+          :external-id="r.external_id"
+          :link-kind="r.link_kind"
+          :entity-type="entityType"
+          :shared="isShared(r.source_id, r.external_id)"
+        />
+      </div>
+      <p v-else class="text-default-300 text-xs">无（无法用外部身份佐证）</p>
+    </div>
+  </div>
+</template>

--- a/apps/web/app/components/catalog/Candidates.vue
+++ b/apps/web/app/components/catalog/Candidates.vue
@@ -3,72 +3,56 @@ import {
   CATALOG_FILTER_ALL,
   CATALOG_ENTITY_TYPES,
   CATALOG_ENTITY_TYPE,
-  CATALOG_SOURCE_LABELS,
+  CATALOG_QUEUE_SUMMARY_KEY,
   CANDIDATE_STATUS,
   CANDIDATE_STATUS_LABELS,
-  CANDIDATE_STATUS_COLORS,
-  CANDIDATE_REASON_LABELS,
-  WORK_STATUS,
-  WORK_STATUS_LABELS
+  CANDIDATE_REASON_LABELS
 } from '~/constants/catalog'
 import type {
   CatalogCandidateItem,
   CatalogCandidatePage,
   CatalogDecideCandidateData,
-  CatalogDetachNameData
+  CatalogDetachNameData,
+  CatalogMergeDirection,
+  CatalogQueueSummary
 } from '~~/shared/types/catalog'
-
-const isPersonLink = (c: CatalogCandidateItem) =>
-  c.entity_type === CATALOG_ENTITY_TYPE.creditName
-
-const isDecidable = (c: CatalogCandidateItem) =>
-  (
-    [
-      CANDIDATE_STATUS.pending,
-      CANDIDATE_STATUS.deferred,
-      CANDIDATE_STATUS.needsManual
-    ] as number[]
-  ).includes(c.status)
-
-const quarantinedIds = (c: CatalogCandidateItem) =>
-  [
-    { id: c.a_id, s: c.a },
-    { id: c.b_id, s: c.b }
-  ]
-    .filter(({ s }) => s.work_status === WORK_STATUS.QUARANTINE)
-    .map(({ id }) => id)
-
-const quarantinedSide = (c: CatalogCandidateItem) => {
-  if (c.a.work_status === WORK_STATUS.QUARANTINE) return 'a' as const
-  if (c.b.work_status === WORK_STATUS.QUARANTINE) return 'b' as const
-  return null
-}
 
 const api = useApi('catalog')
 
 const page = ref(1)
-const limit = 50
-const status = ref(CANDIDATE_STATUS.pending as number)
-const entityType = ref(CATALOG_FILTER_ALL)
+const limit = 20
+const status = ref(CANDIDATE_STATUS.needsManual as number)
+const entityType = ref(CATALOG_ENTITY_TYPE.work as number)
 const reason = ref(CATALOG_FILTER_ALL)
 watch([status, entityType, reason], () => {
   page.value = 1
 })
 
-const { data, status: fetchStatus, refresh, error } =
-  await useApiFetch<CatalogCandidatePage>(
-    '/admin/catalog/candidates',
-    {
-      query: computed(() => ({
-        page: page.value,
-        limit,
-        status: status.value,
-        entity_type: entityType.value,
-        reason: reason.value
-      }))
-    },
+const { data: summary, refresh: refreshSummary } =
+  await useApiFetch<CatalogQueueSummary>(
+    '/admin/catalog/candidates/summary',
+    { key: CATALOG_QUEUE_SUMMARY_KEY },
     'catalog'
   )
+
+const {
+  data,
+  status: fetchStatus,
+  refresh,
+  error
+} = await useApiFetch<CatalogCandidatePage>(
+  '/admin/catalog/candidates',
+  {
+    query: computed(() => ({
+      page: page.value,
+      limit,
+      status: status.value,
+      entity_type: entityType.value,
+      reason: reason.value
+    }))
+  },
+  'catalog'
+)
 const items = computed(() => data.value?.items ?? [])
 const total = computed(() => data.value?.total ?? 0)
 const totalPages = computed(() => Math.max(1, Math.ceil(total.value / limit)))
@@ -97,30 +81,28 @@ const reasonFilterOptions = computed(() => [
   }))
 ])
 
-const expandedKey = ref('')
-const direction = ref<'ab' | 'ba' | ''>('')
-const note = ref('')
-const deciding = ref(false)
+const applyBucket = (nextEntityType: number, nextStatus: number) => {
+  entityType.value = nextEntityType
+  status.value = nextStatus
+}
+
+const isPersonLink = (c: CatalogCandidateItem) =>
+  c.entity_type === CATALOG_ENTITY_TYPE.creditName
 
 const keyOf = (c: CatalogCandidateItem) =>
   `${c.entity_type}:${c.a_id}:${c.b_id}`
 
-const toggleExpand = (c: CatalogCandidateItem) => {
-  const key = keyOf(c)
-  expandedKey.value = expandedKey.value === key ? '' : key
-  const side = quarantinedSide(c)
-  direction.value = side === 'a' ? 'ab' : side === 'b' ? 'ba' : ''
-  note.value = ''
+const deciding = ref(false)
+
+const afterWrite = async () => {
+  await Promise.all([refresh(), refreshSummary()])
 }
 
 const decide = async (
   c: CatalogCandidateItem,
-  action: 'accept' | 'reject' | 'defer'
+  action: 'accept' | 'reject' | 'defer',
+  merge?: { direction: CatalogMergeDirection; note: string }
 ) => {
-  if (action === 'accept' && !isPersonLink(c) && !direction.value) {
-    useKunMessage('请先显式选择合并方向', 'warn')
-    return
-  }
   deciding.value = true
   try {
     const body: Record<string, unknown> = {
@@ -128,49 +110,75 @@ const decide = async (
       a_id: c.a_id,
       b_id: c.b_id,
       action,
-      note: note.value || undefined
+      note: merge?.note || undefined
     }
-    if (action === 'accept' && !isPersonLink(c)) {
-      body.source_id = direction.value === 'ab' ? c.a_id : c.b_id
-      body.target_id = direction.value === 'ab' ? c.b_id : c.a_id
+    if (merge) {
+      body.source_id = merge.direction === 'ab' ? c.a_id : c.b_id
+      body.target_id = merge.direction === 'ab' ? c.b_id : c.a_id
     }
     const res = await api.post<CatalogDecideCandidateData>(
       '/admin/catalog/candidates/decide',
       body
     )
-    if (res.code === 0) {
-      if (action === 'accept' && isPersonLink(c)) {
-        if (res.data?.needs_manual) {
-          useKunMessage('双方已属不同 person，已标记待人工处理', 'warn')
-        } else {
-          useKunMessage(
-            res.data?.person_created
-              ? `已新建 person #${res.data?.person_id ?? ''}`
-              : `已并入 person #${res.data?.person_id ?? ''}`,
-            'success'
-          )
-        }
-      } else if (action === 'accept') {
-        useKunMessage(
-          `已建合并提案 #${res.data?.proposal_id ?? ''}，请到提案桶审批`,
-          'success'
-        )
-      } else if (res.data?.released?.length) {
-        useKunMessage(
-          res.data.released.map((id) => `已放行 #${id}`).join('、'),
-          'success'
-        )
-      } else {
-        useKunMessage(action === 'reject' ? '已拒绝（永久保留）' : '已搁置', 'success')
-      }
-      expandedKey.value = ''
-      await refresh()
-    } else {
+    if (res.code !== 0) {
       useKunMessage(res.message || '操作失败', 'error')
+      return false
     }
+    if (action === 'accept' && isPersonLink(c)) {
+      if (res.data?.needs_manual) {
+        useKunMessage('双方已属不同 person，已标记待人工处理', 'warn')
+      } else {
+        useKunMessage(
+          res.data?.person_created
+            ? `已新建 person #${res.data?.person_id ?? ''}`
+            : `已并入 person #${res.data?.person_id ?? ''}`,
+          'success'
+        )
+      }
+    } else if (action === 'accept') {
+      useKunMessage(
+        `已建合并提案 #${res.data?.proposal_id ?? ''}，约 48 小时冷静期后执行`,
+        'success'
+      )
+    } else if (res.data?.released?.length) {
+      useKunMessage(
+        res.data.released.map((id) => `已放行 #${id}`).join('、'),
+        'success'
+      )
+    } else {
+      useKunMessage(
+        action === 'reject' ? '已拒绝（永久保留为负知识）' : '已搁置',
+        'success'
+      )
+    }
+    await afterWrite()
+    return true
   } finally {
     deciding.value = false
   }
+}
+
+const mergeOpen = ref(false)
+const mergeTarget = ref<CatalogCandidateItem | null>(null)
+const mergeDirection = ref<CatalogMergeDirection>('ab')
+
+const askMerge = (
+  c: CatalogCandidateItem,
+  direction: CatalogMergeDirection
+) => {
+  mergeTarget.value = c
+  mergeDirection.value = direction
+  mergeOpen.value = true
+}
+
+const confirmMerge = async (note: string) => {
+  const c = mergeTarget.value
+  if (!c || deciding.value) return
+  const ok = await decide(c, 'accept', {
+    direction: mergeDirection.value,
+    note
+  })
+  if (ok) mergeOpen.value = false
 }
 
 const releaseWork = async (workId: number) => {
@@ -182,8 +190,7 @@ const releaseWork = async (workId: number) => {
     )
     if (res.code === 0) {
       useKunMessage(`已放行 #${workId}`, 'success')
-      expandedKey.value = ''
-      await refresh()
+      await afterWrite()
     } else {
       useKunMessage(res.message || '操作失败', 'error')
     }
@@ -206,21 +213,24 @@ const detachLink = async (c: CatalogCandidateItem) => {
       }
     }
     useKunMessage('已撤销关联（双方名义已摘离）', 'success')
-    expandedKey.value = ''
-    await refresh()
+    await afterWrite()
   } finally {
     deciding.value = false
   }
 }
-
-const sourceLabel = (id: number | null | undefined) =>
-  id == null ? '' : (CATALOG_SOURCE_LABELS[id] ?? `源${id}`)
 </script>
 
 <template>
   <div class="space-y-4">
     <h1 class="text-foreground text-2xl font-bold">目录人审队列</h1>
     <CatalogSubNav />
+
+    <CatalogCandidatesOverview
+      :summary="summary ?? null"
+      :entity-type="entityType"
+      :status="status"
+      @select="applyBucket"
+    />
 
     <div class="flex flex-wrap items-center gap-2">
       <KunButton
@@ -246,216 +256,38 @@ const sourceLabel = (id: number | null | undefined) =>
         class="w-40"
       />
     </div>
-    <p class="text-default-500 text-sm">共 {{ total }} 条候选</p>
+    <p class="text-default-500 text-sm">
+      当前筛选共 {{ total }} 条候选
+      <span v-if="isLoading" class="text-default-400">· 加载中…</span>
+    </p>
 
     <CommonFetchError v-if="error" @retry="refresh" />
 
-    <div class="space-y-2">
-      <KunCard
-        v-for="c in items"
-        :key="keyOf(c)"
-        content-class="space-y-3 p-4"
-      >
-        <button
-          class="flex w-full flex-wrap items-center gap-2 text-left"
-          @click="toggleExpand(c)"
-        >
-          <KunChip color="info" variant="flat" size="xs">
-            {{ CATALOG_ENTITY_TYPES[c.entity_type] ?? c.entity_type }}
-          </KunChip>
-          <span class="text-foreground font-medium">
-            {{ c.a.display_name || `#${c.a_id}` }}
-          </span>
-          <KunIcon name="lucide:arrow-left-right" class="text-default-400 size-4" />
-          <span class="text-foreground font-medium">
-            {{ c.b.display_name || `#${c.b_id}` }}
-          </span>
-          <KunChip color="default" variant="flat" size="xs">
-            {{ CANDIDATE_REASON_LABELS[c.reason] ?? c.reason }}
-          </KunChip>
-          <KunChip v-if="c.score !== null" color="default" variant="flat" size="xs">
-            score {{ c.score?.toFixed(2) }}
-          </KunChip>
-          <KunChip
-            :color="CANDIDATE_STATUS_COLORS[c.status] ?? 'default'"
-            variant="flat"
-            size="xs"
-            class="ml-auto"
-          >
-            {{ CANDIDATE_STATUS_LABELS[c.status] ?? c.status }}
-          </KunChip>
-        </button>
-
-        <div v-if="expandedKey === keyOf(c)" class="space-y-3">
-          <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <div
-              v-for="side in [
-                { tag: 'A', s: c.a },
-                { tag: 'B', s: c.b }
-              ]"
-              :key="side.tag"
-              class="border-default-200 rounded-lg border p-3"
-            >
-              <p class="text-default-400 text-xs">{{ side.tag }} · #{{ side.s.id }}</p>
-              <div class="flex flex-wrap items-center gap-1.5">
-                <p
-                  class="text-lg font-medium"
-                  :class="
-                    c.a.display_name !== c.b.display_name
-                      ? 'text-warning-600'
-                      : 'text-foreground'
-                  "
-                >
-                  {{ side.s.display_name || '（无显示名）' }}
-                </p>
-                <KunChip
-                  v-if="side.s.work_status === WORK_STATUS.QUARANTINE"
-                  color="warning"
-                  variant="flat"
-                  size="sm"
-                >
-                  {{ WORK_STATUS_LABELS[WORK_STATUS.QUARANTINE] }}
-                </KunChip>
-              </div>
-              <div
-                v-if="isPersonLink(c)"
-                class="mt-1 flex flex-wrap items-center gap-1.5"
-              >
-                <KunChip
-                  v-if="side.s.source_id != null"
-                  color="info"
-                  variant="flat"
-                  size="xs"
-                >
-                  {{ sourceLabel(side.s.source_id) }}
-                </KunChip>
-                <span class="text-default-400 text-xs">
-                  {{ side.s.credit_count ?? 0 }} 条署名
-                </span>
-              </div>
-            </div>
-          </div>
-
-          <template v-if="isPersonLink(c) && isDecidable(c)">
-            <div class="flex flex-wrap gap-2">
-              <KunButton
-                color="success"
-                :disabled="deciding"
-                @click="decide(c, 'accept')"
-              >
-                <KunIcon
-                  v-if="deciding"
-                  name="lucide:loader-circle"
-                  class="mr-1 size-4 animate-spin"
-                />
-                确认为同一人
-              </KunButton>
-              <KunButton
-                color="danger"
-                variant="flat"
-                :disabled="deciding"
-                @click="decide(c, 'reject')"
-              >
-                拒绝（永久保留）
-              </KunButton>
-              <KunButton
-                color="default"
-                variant="flat"
-                :disabled="deciding"
-                @click="decide(c, 'defer')"
-              >
-                搁置
-              </KunButton>
-            </div>
-          </template>
-
-          <template v-else-if="isDecidable(c)">
-            <div class="flex flex-wrap items-center gap-2">
-              <span class="text-default-500 text-sm">合并方向：</span>
-              <KunButton
-                :color="direction === 'ab' ? 'primary' : 'default'"
-                :variant="direction === 'ab' ? 'solid' : 'flat'"
-                size="sm"
-                @click="direction = 'ab'"
-              >
-                A → B（保留 {{ c.b.display_name || `#${c.b_id}` }}）
-              </KunButton>
-              <KunButton
-                :color="direction === 'ba' ? 'primary' : 'default'"
-                :variant="direction === 'ba' ? 'solid' : 'flat'"
-                size="sm"
-                @click="direction = 'ba'"
-              >
-                B → A（保留 {{ c.a.display_name || `#${c.a_id}` }}）
-              </KunButton>
-            </div>
-            <KunInput v-model="note" placeholder="备注（可选，随提案携带）" />
-            <div class="flex flex-wrap gap-2">
-              <KunButton
-                color="success"
-                :disabled="deciding || !direction"
-                @click="decide(c, 'accept')"
-              >
-                <KunIcon
-                  v-if="deciding"
-                  name="lucide:loader-circle"
-                  class="mr-1 size-4 animate-spin"
-                />
-                接受并建提案
-              </KunButton>
-              <KunButton
-                color="danger"
-                variant="flat"
-                :disabled="deciding"
-                @click="decide(c, 'reject')"
-              >
-                {{ quarantinedSide(c) ? '拒绝并放行' : '拒绝（永久保留）' }}
-              </KunButton>
-              <KunButton
-                color="default"
-                variant="flat"
-                :disabled="deciding"
-                @click="decide(c, 'defer')"
-              >
-                搁置
-              </KunButton>
-            </div>
-          </template>
-
-          <div v-else class="flex flex-wrap items-center gap-2">
-            <p class="text-default-400 text-sm">
-              该候选已决策（{{ CANDIDATE_STATUS_LABELS[c.status] }}
-              <template v-if="c.decided_by !== null">
-                · 操作者 {{ c.decided_by }}</template
-              >）
-            </p>
-            <KunButton
-              v-if="isPersonLink(c) && c.status === CANDIDATE_STATUS.accepted"
-              color="default"
-              variant="flat"
-              size="sm"
-              :disabled="deciding"
-              @click="detachLink(c)"
-            >
-              撤销关联（摘离双方名义）
-            </KunButton>
-            <KunButton
-              v-for="id in quarantinedIds(c)"
-              :key="id"
-              color="warning"
-              variant="flat"
-              :disabled="deciding"
-              @click="releaseWork(id)"
-            >
-              放行 #{{ id }}
-            </KunButton>
-          </div>
-        </div>
-      </KunCard>
+    <div class="space-y-3">
+      <template v-for="c in items" :key="keyOf(c)">
+        <CatalogCandidateCreditPair
+          v-if="isPersonLink(c)"
+          :item="c"
+          :busy="deciding"
+          @accept="decide(c, 'accept')"
+          @reject="decide(c, 'reject')"
+          @defer="decide(c, 'defer')"
+          @detach="detachLink(c)"
+        />
+        <CatalogCandidatePair
+          v-else
+          :item="c"
+          :busy="deciding"
+          @merge="askMerge(c, $event)"
+          @reject="decide(c, 'reject')"
+          @defer="decide(c, 'defer')"
+          @release="releaseWork"
+        />
+      </template>
 
       <KunCard v-if="!items.length && !error" content-class="p-10">
         <p class="text-default-400 text-center">
-          {{ isLoading ? '加载中…' : '没有匹配的候选' }}
+          {{ isLoading ? '加载中…' : '这一队是空的，换个格子看看' }}
         </p>
       </KunCard>
     </div>
@@ -464,6 +296,14 @@ const sourceLabel = (id: number | null | undefined) =>
       v-model:current-page="page"
       :total-page="totalPages"
       :is-loading="isLoading"
+    />
+
+    <CatalogMergeConfirm
+      v-model="mergeOpen"
+      :item="mergeTarget"
+      :direction="mergeDirection"
+      :busy="deciding"
+      @confirm="confirmMerge"
     />
   </div>
 </template>

--- a/apps/web/app/components/catalog/CandidatesOverview.vue
+++ b/apps/web/app/components/catalog/CandidatesOverview.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import {
+  CANDIDATE_STATUS,
+  CANDIDATE_STATUS_COLORS,
+  CANDIDATE_STATUS_LABELS,
+  CATALOG_ENTITY_TYPE,
+  CATALOG_ENTITY_TYPES
+} from '~/constants/catalog'
+import type { CatalogQueueSummary } from '~~/shared/types/catalog'
+
+const props = defineProps<{
+  summary: CatalogQueueSummary | null
+  entityType: number
+  status: number
+}>()
+
+const emit = defineEmits<{ select: [entityType: number, status: number] }>()
+
+const STATUS_ORDER = [
+  CANDIDATE_STATUS.needsManual,
+  CANDIDATE_STATUS.pending,
+  CANDIDATE_STATUS.deferred,
+  CANDIDATE_STATUS.accepted,
+  CANDIDATE_STATUS.rejected
+] as number[]
+
+const buckets = computed(() => props.summary?.candidates ?? [])
+
+const countOf = (entityType: number, status: number) =>
+  buckets.value.find((b) => b.entity_type === entityType && b.status === status)
+    ?.count ?? 0
+
+const rows = computed(() => {
+  const present = [...new Set(buckets.value.map((b) => b.entity_type))]
+  const weight = (id: number) =>
+    id === CATALOG_ENTITY_TYPE.work
+      ? -2
+      : id === CATALOG_ENTITY_TYPE.creditName
+        ? -1
+        : id
+  return present
+    .sort((a, b) => weight(a) - weight(b))
+    .map((id) => ({
+      entityType: id,
+      label: CATALOG_ENTITY_TYPES[id] ?? `类型${id}`,
+      cells: STATUS_ORDER.map((s) => ({ status: s, count: countOf(id, s) })),
+      total: buckets.value
+        .filter((b) => b.entity_type === id)
+        .reduce((sum, b) => sum + b.count, 0)
+    }))
+})
+
+const workBacklog = computed(() =>
+  countOf(CATALOG_ENTITY_TYPE.work, CANDIDATE_STATUS.needsManual)
+)
+
+const probableRefTotal = computed(() =>
+  (props.summary?.probable_refs ?? []).reduce((sum, b) => sum + b.count, 0)
+)
+
+const isActive = (entityType: number, status: number) =>
+  props.entityType === entityType && props.status === status
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div
+      v-if="workBacklog > 0"
+      class="border-warning-200 bg-warning-50 flex flex-wrap items-center gap-4 rounded-xl border p-4"
+    >
+      <div>
+        <p class="text-warning-700 text-sm">作品重复 · 待人工</p>
+        <p class="text-warning-800 text-3xl leading-tight font-bold">
+          {{ workBacklog }}
+        </p>
+      </div>
+      <p class="text-default-500 min-w-60 flex-1 text-sm">
+        机器判不了的作品重复对全部堆在这一格：两侧证据摆在一起，人来裁「合并 /
+        不是同一作品 / 搁置」。
+      </p>
+      <KunButton
+        color="warning"
+        @click="
+          emit('select', CATALOG_ENTITY_TYPE.work, CANDIDATE_STATUS.needsManual)
+        "
+      >
+        <KunIcon name="lucide:list-checks" class="mr-1 size-4" />
+        审这一队
+      </KunButton>
+    </div>
+
+    <KunCard content-class="p-4 space-y-3">
+      <div class="flex flex-wrap items-center gap-2">
+        <h2 class="text-foreground text-base font-bold">队列全景</h2>
+        <span class="text-default-400 text-xs">点任意格子即可筛到那一队</span>
+      </div>
+
+      <div class="overflow-x-auto">
+        <table class="w-full min-w-[42rem] text-sm">
+          <thead class="text-default-500">
+            <tr>
+              <th class="px-2 py-1 text-left font-medium">实体类型</th>
+              <th
+                v-for="s in STATUS_ORDER"
+                :key="s"
+                class="px-2 py-1 text-center font-medium"
+              >
+                {{ CANDIDATE_STATUS_LABELS[s] }}
+              </th>
+              <th class="px-2 py-1 text-right font-medium">合计</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="row in rows"
+              :key="row.entityType"
+              class="border-default-200 border-t"
+            >
+              <td class="text-foreground px-2 py-1.5 font-medium">
+                {{ row.label }}
+              </td>
+              <td
+                v-for="cell in row.cells"
+                :key="cell.status"
+                class="px-2 py-1.5 text-center"
+              >
+                <KunButton
+                  v-if="cell.count > 0"
+                  :color="
+                    isActive(row.entityType, cell.status)
+                      ? 'primary'
+                      : (CANDIDATE_STATUS_COLORS[cell.status] ?? 'default')
+                  "
+                  :variant="
+                    isActive(row.entityType, cell.status) ? 'solid' : 'flat'
+                  "
+                  size="xs"
+                  @click="emit('select', row.entityType, cell.status)"
+                >
+                  {{ cell.count }}
+                </KunButton>
+                <span v-else class="text-default-300">—</span>
+              </td>
+              <td class="text-default-500 px-2 py-1.5 text-right">
+                {{ row.total }}
+              </td>
+            </tr>
+            <tr v-if="!rows.length">
+              <td
+                :colspan="STATUS_ORDER.length + 2"
+                class="text-default-400 px-2 py-6 text-center"
+              >
+                队列是空的
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div
+        v-if="probableRefTotal > 0"
+        class="border-default-200 flex flex-wrap items-center gap-2 border-t pt-3"
+      >
+        <KunIcon name="lucide:link" class="text-default-400 size-4" />
+        <span class="text-default-500 text-sm">
+          另有 {{ probableRefTotal }} 条待确认的外部链接
+        </span>
+        <KunButton
+          color="default"
+          variant="flat"
+          size="xs"
+          @click="navigateTo('/catalog/refs')"
+        >
+          去确认
+        </KunButton>
+      </div>
+    </KunCard>
+  </div>
+</template>

--- a/apps/web/app/components/catalog/MergeConfirm.vue
+++ b/apps/web/app/components/catalog/MergeConfirm.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { CATALOG_ENTITY_TYPES } from '~/constants/catalog'
+import type {
+  CatalogCandidateItem,
+  CatalogEntitySummary,
+  CatalogMergeDirection
+} from '~~/shared/types/catalog'
+
+const props = defineProps<{
+  item: CatalogCandidateItem | null
+  direction: CatalogMergeDirection
+  busy: boolean
+}>()
+
+const open = defineModel<boolean>({ required: true })
+
+const emit = defineEmits<{ confirm: [note: string] }>()
+
+const note = ref('')
+watch(open, (value) => {
+  if (value) note.value = ''
+})
+
+const source = computed<CatalogEntitySummary | null>(() =>
+  props.item ? (props.direction === 'ab' ? props.item.a : props.item.b) : null
+)
+const target = computed<CatalogEntitySummary | null>(() =>
+  props.item ? (props.direction === 'ab' ? props.item.b : props.item.a) : null
+)
+
+const entityNoun = computed(() =>
+  props.item ? (CATALOG_ENTITY_TYPES[props.item.entity_type] ?? '实体') : '实体'
+)
+
+const nameOf = (s: CatalogEntitySummary | null) =>
+  s ? s.display_name || `#${s.id}` : ''
+
+const releasesClaim = computed(
+  () => !!props.item?.a.site && !!props.item?.b.site
+)
+</script>
+
+<template>
+  <KunModal v-model="open" title="确认合并" size="md">
+    <div class="space-y-4">
+      <div class="border-default-200 space-y-2 rounded-lg border p-3">
+        <p class="text-default-500 text-sm">这次合并会：</p>
+        <div class="flex flex-wrap items-center gap-2">
+          <KunChip color="danger" variant="flat" size="sm">
+            并入 {{ nameOf(source) }} · #{{ source?.id }}
+          </KunChip>
+          <KunIcon name="lucide:arrow-right" class="text-default-400 size-4" />
+          <KunChip color="success" variant="solid" size="sm">
+            保留 {{ nameOf(target) }} · #{{ target?.id }}
+          </KunChip>
+        </div>
+        <p class="text-default-400 text-xs">
+          被并入的{{
+            entityNoun
+          }}会退出身份索引，其外部锚点与关系将改挂到保留侧。
+        </p>
+      </div>
+
+      <div
+        class="border-info-200 bg-info-50 flex items-start gap-2 rounded-lg border px-3 py-2"
+      >
+        <KunIcon
+          name="lucide:clock"
+          class="text-info-600 mt-0.5 size-4 shrink-0"
+        />
+        <p class="text-info-700 text-sm">
+          确认后只会开出一条合并提案，约 48
+          小时冷静期后才会真正执行；期间可以在「合并提案」里撤回。
+        </p>
+      </div>
+
+      <div
+        v-if="releasesClaim"
+        class="border-danger-200 bg-danger-50 flex items-start gap-2 rounded-lg border px-3 py-2"
+      >
+        <KunIcon
+          name="lucide:shield-alert"
+          class="text-danger mt-0.5 size-4 shrink-0"
+        />
+        <p class="text-danger-700 text-sm">
+          两侧都被站点认领：合并会<span class="font-bold">释放</span
+          >被并入一侧（{{ source?.site }}）的认领关系，该站点将失去这条{{
+            entityNoun
+          }}的所有权。执行后不可自动恢复。
+        </p>
+      </div>
+
+      <KunInput v-model="note" placeholder="备注（可选，随提案携带）" />
+
+      <div class="flex justify-end gap-3">
+        <KunButton color="default" variant="flat" @click="open = false">
+          取消
+        </KunButton>
+        <KunButton
+          :color="releasesClaim ? 'danger' : 'success'"
+          :disabled="busy"
+          @click="emit('confirm', note)"
+        >
+          <KunIcon
+            v-if="busy"
+            name="lucide:loader-circle"
+            class="mr-1 size-4 animate-spin"
+          />
+          确认合并并开提案
+        </KunButton>
+      </div>
+    </div>
+  </KunModal>
+</template>

--- a/apps/web/app/components/catalog/RefChip.vue
+++ b/apps/web/app/components/catalog/RefChip.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import {
+  CATALOG_LINK_KIND,
+  CATALOG_SOURCE_LABELS,
+  catalogExternalUrl
+} from '~/constants/catalog'
+
+const props = defineProps<{
+  sourceId: number
+  externalId: string
+  linkKind: number
+  entityType?: number
+  shared?: boolean
+}>()
+
+const label = computed(
+  () => CATALOG_SOURCE_LABELS[props.sourceId] ?? `源${props.sourceId}`
+)
+
+const url = computed(() =>
+  catalogExternalUrl(props.sourceId, props.externalId, props.entityType)
+)
+
+const isProbable = computed(() => props.linkKind === CATALOG_LINK_KIND.probable)
+
+const hint = computed(() => {
+  const kind = isProbable.value ? '推测链接（未确认）' : '精确链接'
+  return props.shared ? `${kind} · 双方共有的身份锚点` : kind
+})
+</script>
+
+<template>
+  <KunChip
+    :color="shared ? 'success' : 'default'"
+    :variant="isProbable ? 'bordered' : 'flat'"
+    size="xs"
+    :class="shared ? 'ring-success-400 ring-1' : ''"
+    :title="hint"
+  >
+    <template #start>
+      <KunIcon
+        v-if="shared"
+        name="lucide:anchor"
+        class="text-success-600 mr-1 size-3"
+      />
+    </template>
+    <span :class="shared ? 'text-success-700' : 'text-default-500'">
+      {{ label }}
+    </span>
+    <KunLink
+      v-if="url"
+      :href="url"
+      target="_blank"
+      underline="hover"
+      color="primary"
+      class-name="ml-1 font-mono"
+    >
+      {{ externalId }}
+    </KunLink>
+    <span v-else class="text-foreground ml-1 font-mono">{{ externalId }}</span>
+    <template #end>
+      <KunIcon
+        v-if="isProbable"
+        name="lucide:circle-help"
+        class="text-default-400 ml-1 size-3"
+      />
+    </template>
+  </KunChip>
+</template>

--- a/apps/web/app/components/catalog/Refs.vue
+++ b/apps/web/app/components/catalog/Refs.vue
@@ -2,12 +2,15 @@
 import {
   CATALOG_FILTER_ALL,
   CATALOG_ENTITY_TYPES,
+  CATALOG_QUEUE_SUMMARY_KEY,
   CATALOG_SOURCE_LABELS,
-  MATCHED_BY_KINDS
+  MATCHED_BY_KINDS,
+  catalogExternalUrl
 } from '~/constants/catalog'
 import type {
   CatalogProbableRefItem,
   CatalogProbableRefPage,
+  CatalogQueueSummary,
   CatalogRefActionData
 } from '~~/shared/types/catalog'
 
@@ -21,19 +24,34 @@ watch([sourceID, entityType], () => {
   page.value = 1
 })
 
-const { data, status: fetchStatus, refresh, error } =
-  await useApiFetch<CatalogProbableRefPage>(
-    '/admin/catalog/refs/probable',
-    {
-      query: computed(() => ({
-        page: page.value,
-        limit,
-        source_id: sourceID.value,
-        entity_type: entityType.value
-      }))
-    },
+const { data: summary, refresh: refreshSummary } =
+  await useApiFetch<CatalogQueueSummary>(
+    '/admin/catalog/candidates/summary',
+    { key: CATALOG_QUEUE_SUMMARY_KEY },
     'catalog'
   )
+
+const entityBuckets = computed(() =>
+  [...(summary.value?.probable_refs ?? [])].sort((a, b) => b.count - a.count)
+)
+
+const {
+  data,
+  status: fetchStatus,
+  refresh,
+  error
+} = await useApiFetch<CatalogProbableRefPage>(
+  '/admin/catalog/refs/probable',
+  {
+    query: computed(() => ({
+      page: page.value,
+      limit,
+      source_id: sourceID.value,
+      entity_type: entityType.value
+    }))
+  },
+  'catalog'
+)
 const items = computed(() => data.value?.items ?? [])
 const total = computed(() => data.value?.total ?? 0)
 const totalPages = computed(() => Math.max(1, Math.ceil(total.value / limit)))
@@ -57,6 +75,9 @@ const entityTypeOptions = computed(() => [
 const matchedByKind = (matchedBy: string) =>
   MATCHED_BY_KINDS.find((k) => matchedBy.startsWith(k.prefix))
 
+const externalUrl = (r: CatalogProbableRefItem) =>
+  catalogExternalUrl(r.source_id, r.external_id, r.entity_type)
+
 const keyBody = (r: CatalogProbableRefItem) => ({
   entity_type: r.entity_type,
   entity_id: r.entity_id,
@@ -70,6 +91,10 @@ const refKey = (r: CatalogProbableRefItem) =>
 const acting = ref('')
 const conflictHint = ref('')
 
+const afterWrite = async () => {
+  await Promise.all([refresh(), refreshSummary()])
+}
+
 const confirmRef = async (r: CatalogProbableRefItem) => {
   acting.value = refKey(r)
   conflictHint.value = ''
@@ -80,7 +105,7 @@ const confirmRef = async (r: CatalogProbableRefItem) => {
     )
     if (res.code === 0) {
       useKunMessage('已确认为 exact', 'success')
-      await refresh()
+      await afterWrite()
     } else {
       useKunMessage(res.message || '确认失败', 'error')
       conflictHint.value = `${res.message}。若两者可能是同一实体，请到候选桶为它们建立候选后走合并流程。`
@@ -109,14 +134,17 @@ const confirmReject = async () => {
   }
   acting.value = refKey(r)
   try {
-    const res = await api.post<CatalogRefActionData>('/admin/catalog/refs/reject', {
-      ...keyBody(r),
-      reason: rejectReason.value.trim()
-    })
+    const res = await api.post<CatalogRefActionData>(
+      '/admin/catalog/refs/reject',
+      {
+        ...keyBody(r),
+        reason: rejectReason.value.trim()
+      }
+    )
     if (res.code === 0) {
       useKunMessage('已拒绝并记录负知识', 'success')
       rejectOpen.value = false
-      await refresh()
+      await afterWrite()
     } else {
       useKunMessage(res.message || '拒绝失败', 'error')
     }
@@ -130,6 +158,29 @@ const confirmReject = async () => {
   <div class="space-y-4">
     <h1 class="text-foreground text-2xl font-bold">目录人审队列</h1>
     <CatalogSubNav />
+
+    <div v-if="entityBuckets.length" class="flex flex-wrap items-center gap-2">
+      <span class="text-default-500 text-sm">待确认分布：</span>
+      <KunButton
+        :color="entityType === CATALOG_FILTER_ALL ? 'primary' : 'default'"
+        :variant="entityType === CATALOG_FILTER_ALL ? 'solid' : 'flat'"
+        size="xs"
+        @click="entityType = CATALOG_FILTER_ALL"
+      >
+        全部
+      </KunButton>
+      <KunButton
+        v-for="bucket in entityBuckets"
+        :key="bucket.entity_type"
+        :color="entityType === bucket.entity_type ? 'primary' : 'default'"
+        :variant="entityType === bucket.entity_type ? 'solid' : 'flat'"
+        size="xs"
+        @click="entityType = bucket.entity_type"
+      >
+        {{ CATALOG_ENTITY_TYPES[bucket.entity_type] ?? bucket.entity_type }}
+        <span class="ml-1 font-mono">{{ bucket.count }}</span>
+      </KunButton>
+    </div>
 
     <div class="flex flex-wrap items-center gap-2">
       <KunSelect
@@ -166,7 +217,7 @@ const confirmReject = async () => {
         <tbody>
           <tr
             v-for="r in items"
-            :key="`${r.entity_type}:${r.entity_id}:${r.source_id}:${r.external_id}`"
+            :key="refKey(r)"
             class="border-default-200 border-t align-top"
           >
             <td class="px-3 py-2">
@@ -176,12 +227,26 @@ const confirmReject = async () => {
               <span class="text-foreground">
                 {{ r.entity.display_name || `#${r.entity_id}` }}
               </span>
+              <span class="text-default-400 ml-1 font-mono text-xs">
+                #{{ r.entity_id }}
+              </span>
             </td>
             <td class="px-3 py-2">
               {{ CATALOG_SOURCE_LABELS[r.source_id] ?? r.source_id }}
             </td>
             <td class="px-3 py-2">
-              <span class="font-mono">{{ r.external_id }}</span>
+              <KunLink
+                v-if="externalUrl(r)"
+                :href="externalUrl(r) || ''"
+                target="_blank"
+                underline="hover"
+                color="primary"
+                class-name="font-mono"
+                is-show-anchor-icon
+              >
+                {{ r.external_id }}
+              </KunLink>
+              <span v-else class="font-mono">{{ r.external_id }}</span>
               <KunCopy :text="r.external_id" />
             </td>
             <td class="px-3 py-2">
@@ -239,7 +304,9 @@ const confirmReject = async () => {
         <p class="text-default-500 text-sm">
           将删除
           <span class="text-foreground font-medium">
-            {{ rejectTarget?.entity.display_name || `#${rejectTarget?.entity_id}` }}
+            {{
+              rejectTarget?.entity.display_name || `#${rejectTarget?.entity_id}`
+            }}
           </span>
           ↔
           <span class="font-mono">{{ rejectTarget?.external_id }}</span>

--- a/apps/web/app/components/catalog/SubNav.vue
+++ b/apps/web/app/components/catalog/SubNav.vue
@@ -1,16 +1,27 @@
 <script setup lang="ts">
-import { CANDIDATE_STATUS, PROPOSAL_STATUS } from '~/constants/catalog'
+import {
+  CANDIDATE_STATUS,
+  CATALOG_QUEUE_SUMMARY_KEY,
+  PROPOSAL_STATUS
+} from '~/constants/catalog'
 import type {
-  CatalogCandidatePage,
   CatalogProposalPage,
-  CatalogProbableRefPage
+  CatalogQueueSummary
 } from '~~/shared/types/catalog'
 
 const route = useRoute()
 
-const { data: pendingCandidates } = await useApiFetch<CatalogCandidatePage>(
-  '/admin/catalog/candidates',
-  { query: { status: CANDIDATE_STATUS.pending, limit: 1 } },
+// The badge used to count status=pending only, which reported 67 while ~6.4k
+// work pairs sat in needsManual — the queue the console exists to drain was
+// invisible from the nav.
+const OPEN_CANDIDATE_STATUSES = [
+  CANDIDATE_STATUS.pending,
+  CANDIDATE_STATUS.needsManual
+] as number[]
+
+const { data: summary } = await useApiFetch<CatalogQueueSummary>(
+  '/admin/catalog/candidates/summary',
+  { key: CATALOG_QUEUE_SUMMARY_KEY },
   'catalog'
 )
 const { data: openProposals } = await useApiFetch<CatalogProposalPage>(
@@ -18,10 +29,14 @@ const { data: openProposals } = await useApiFetch<CatalogProposalPage>(
   { query: { status: PROPOSAL_STATUS.open, limit: 1 } },
   'catalog'
 )
-const { data: probableRefs } = await useApiFetch<CatalogProbableRefPage>(
-  '/admin/catalog/refs/probable',
-  { query: { limit: 1 } },
-  'catalog'
+
+const openCandidates = computed(() =>
+  (summary.value?.candidates ?? [])
+    .filter((b) => OPEN_CANDIDATE_STATUSES.includes(b.status))
+    .reduce((sum, b) => sum + b.count, 0)
+)
+const probableRefs = computed(() =>
+  (summary.value?.probable_refs ?? []).reduce((sum, b) => sum + b.count, 0)
 )
 
 const tabs = computed(() => [
@@ -29,7 +44,7 @@ const tabs = computed(() => [
     to: '/catalog/candidates',
     label: '候选',
     icon: 'lucide:git-compare',
-    count: pendingCandidates.value?.total ?? 0
+    count: openCandidates.value
   },
   {
     to: '/catalog/proposals',
@@ -41,7 +56,7 @@ const tabs = computed(() => [
     to: '/catalog/refs',
     label: '外链确认',
     icon: 'lucide:link',
-    count: probableRefs.value?.total ?? 0
+    count: probableRefs.value
   }
 ])
 </script>

--- a/apps/web/app/constants/catalog.ts
+++ b/apps/web/app/constants/catalog.ts
@@ -1,5 +1,6 @@
-
 export const CATALOG_FILTER_ALL = -1
+
+export const CATALOG_QUEUE_SUMMARY_KEY = 'catalog-queue-summary'
 
 export const CATALOG_ENTITY_TYPES: Record<number, string> = {
   0: '人物',
@@ -12,7 +13,13 @@ export const CATALOG_ENTITY_TYPES: Record<number, string> = {
 }
 
 export const CATALOG_ENTITY_TYPE = {
-  creditName: 1
+  person: 0,
+  creditName: 1,
+  organization: 2,
+  label: 3,
+  character: 4,
+  work: 5,
+  release: 6
 } as const
 
 export const CANDIDATE_STATUS = {
@@ -116,7 +123,107 @@ export const CATALOG_SOURCE_LABELS: Record<number, string> = {
   8: 'Steam',
   9: '官网',
   10: 'Twitter',
-  11: 'Pixiv'
+  11: 'Pixiv',
+  12: '策展',
+  13: '超分',
+  14: 'Ci-en',
+  15: 'DMM',
+  16: '网页',
+  17: 'Getchu',
+  18: '派生',
+  19: 'NextMoe',
+  20: 'HowLongToBeat'
+}
+
+export const CATALOG_SOURCE = {
+  user: 1,
+  vndb: 2,
+  bangumi: 3,
+  dlsite: 4,
+  erogamescape: 5,
+  anilist: 6,
+  mal: 7,
+  steam: 8,
+  officialSite: 9,
+  twitter: 10,
+  pixiv: 11,
+  curated: 12,
+  upscale: 13,
+  cien: 14,
+  dmm: 15,
+  web: 16,
+  getchu: 17,
+  derived: 18,
+  nextmoe: 19,
+  howlongtobeat: 20
+} as const
+
+export const CATALOG_LINK_KIND = {
+  exact: 0,
+  probable: 1,
+  related: 2
+} as const
+
+export const CATALOG_MEDIUM_LABELS: Record<number, string> = {
+  1: 'Galgame',
+  2: '漫画',
+  3: '小说',
+  4: '动画',
+  5: 'ASMR'
+}
+
+export const CATALOG_MEDIUM_COLORS: Record<number, CatalogChipColor> = {
+  1: 'primary',
+  2: 'warning',
+  3: 'info',
+  4: 'secondary',
+  5: 'default'
+}
+
+export const CONTENT_RATING_LABELS: Record<number, string> = {
+  0: '全年龄',
+  1: '敏感',
+  2: 'R18'
+}
+
+export const CONTENT_RATING_COLORS: Record<number, CatalogChipColor> = {
+  0: 'success',
+  1: 'warning',
+  2: 'danger'
+}
+
+export const CLAIM_STATE_LABELS: Record<number, string> = {
+  0: '已上线',
+  1: '草稿',
+  2: '隐藏',
+  3: '待审核',
+  4: '已拒绝'
+}
+
+const startsWithLetter = (externalId: string) => /^[A-Za-z]/.test(externalId)
+
+export const catalogExternalUrl = (
+  sourceId: number,
+  externalId: string,
+  entityType?: number
+): string | null => {
+  const id = externalId.trim()
+  if (!id) return null
+  switch (sourceId) {
+    case CATALOG_SOURCE.vndb: {
+      if (startsWithLetter(id)) return `https://vndb.org/${id}`
+      const prefix = entityType === CATALOG_ENTITY_TYPE.release ? 'r' : 'v'
+      return `https://vndb.org/${prefix}${id}`
+    }
+    case CATALOG_SOURCE.bangumi:
+      return `https://bangumi.tv/subject/${id}`
+    case CATALOG_SOURCE.steam:
+      return `https://store.steampowered.com/app/${id}`
+    case CATALOG_SOURCE.howlongtobeat:
+      return `https://howlongtobeat.com/game/${id}`
+    default:
+      return null
+  }
 }
 
 export const CATALOG_IMAGE_REF_KIND_LABELS: Record<string, string> = {

--- a/apps/web/shared/types/catalog.ts
+++ b/apps/web/shared/types/catalog.ts
@@ -2,11 +2,18 @@ import type { components } from './generated/catalog-admin-api'
 
 type Schemas = components['schemas']
 
+export type CatalogEntityRef = Schemas['EntityRefSummary']
 export type CatalogEntitySummary = Schemas['EntitySummary']
 export type CatalogCandidateItem = Schemas['CandidateItem']
+export type CatalogCandidatePage = Schemas['PageCandidateItem']
+export type CatalogCandidateBucket = Schemas['CandidateBucketCount']
+export type CatalogProbableRefBucket = Schemas['ProbableRefBucketCount']
+export type CatalogQueueSummary = Schemas['QueueSummary']
+
+export type CatalogMergeDirection = 'ab' | 'ba'
+
 export type CatalogProposalItem = Schemas['ProposalItem']
 export type CatalogProbableRefItem = Schemas['ProbableRefItem']
-export type CatalogCandidatePage = Schemas['PageCandidateItem']
 export type CatalogProposalPage = Schemas['PageProposalItem']
 export type CatalogProbableRefPage = Schemas['PageProbableRefItem']
 export type CatalogDecideCandidateData = Schemas['DecideCandidateData']

--- a/apps/web/shared/types/generated/catalog-admin-api.ts
+++ b/apps/web/shared/types/generated/catalog-admin-api.ts
@@ -38,6 +38,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/catalog/candidates/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Queue depth: candidates grouped by entity type × status, probable refs grouped by entity type */
+        get: operations["catalogQueueSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/catalog/claims/pending": {
         parameters: {
             query?: never;
@@ -229,6 +246,14 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        CandidateBucketCount: {
+            /** Format: int64 */
+            count: number;
+            /** Format: int32 */
+            entity_type: number;
+            /** Format: int32 */
+            status: number;
+        };
         CandidateItem: {
             a: components["schemas"]["EntitySummary"];
             /** Format: int64 */
@@ -344,12 +369,30 @@ export interface components {
              */
             credit_name_id: number;
         };
+        EntityRefSummary: {
+            external_id: string;
+            /** Format: int32 */
+            link_kind: number;
+            /** Format: int32 */
+            source_id: number;
+        };
         EntitySummary: {
+            /** Format: int32 */
+            claim_state?: number;
+            /** Format: int32 */
+            content_rating?: number;
             /** Format: int64 */
             credit_count?: number;
             display_name: string;
             /** Format: int64 */
             id: number;
+            /** Format: int32 */
+            medium_id?: number;
+            olang?: string;
+            refs?: components["schemas"]["EntityRefSummary"][] | null;
+            /** Format: int32 */
+            release_year?: number;
+            site?: string;
             /** Format: int32 */
             source_id?: number;
             /** Format: int32 */
@@ -475,6 +518,18 @@ export interface components {
             data?: components["schemas"]["ProposalActionData"];
             message: string;
         };
+        EnvelopeQueueSummary: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/EnvelopeQueueSummary.json
+             */
+            readonly $schema?: string;
+            /** Format: int64 */
+            code: number;
+            data?: components["schemas"]["QueueSummary"];
+            message: string;
+        };
         EnvelopeRefActionData: {
             /**
              * Format: uri
@@ -557,6 +612,12 @@ export interface components {
             /** Format: int64 */
             work_id: number;
         };
+        ProbableRefBucketCount: {
+            /** Format: int64 */
+            count: number;
+            /** Format: int32 */
+            entity_type: number;
+        };
         ProbableRefItem: {
             /** Format: date-time */
             created_at: string;
@@ -619,6 +680,10 @@ export interface components {
             target: components["schemas"]["EntitySummary"];
             /** Format: int64 */
             target_entity_id: number;
+        };
+        QueueSummary: {
+            candidates: components["schemas"]["CandidateBucketCount"][] | null;
+            probable_refs: components["schemas"]["ProbableRefBucketCount"][] | null;
         };
         RefActionData: {
             done: boolean;
@@ -754,6 +819,35 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["EnvelopeDecideCandidateData"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HouseError"];
+                };
+            };
+        };
+    };
+    catalogQueueSummary: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnvelopeQueueSummary"];
                 };
             };
             /** @description Error */

--- a/docs/catalog/admin-openapi.yaml
+++ b/docs/catalog/admin-openapi.yaml
@@ -1,5 +1,22 @@
 components:
   schemas:
+    CandidateBucketCount:
+      additionalProperties: false
+      properties:
+        count:
+          format: int64
+          type: integer
+        entity_type:
+          format: int32
+          type: integer
+        status:
+          format: int32
+          type: integer
+      required:
+        - entity_type
+        - status
+        - count
+      type: object
     CandidateItem:
       additionalProperties: false
       properties:
@@ -227,9 +244,31 @@ components:
       required:
         - credit_name_id
       type: object
+    EntityRefSummary:
+      additionalProperties: false
+      properties:
+        external_id:
+          type: string
+        link_kind:
+          format: int32
+          type: integer
+        source_id:
+          format: int32
+          type: integer
+      required:
+        - source_id
+        - external_id
+        - link_kind
+      type: object
     EntitySummary:
       additionalProperties: false
       properties:
+        claim_state:
+          format: int32
+          type: integer
+        content_rating:
+          format: int32
+          type: integer
         credit_count:
           format: int64
           type: integer
@@ -238,6 +277,22 @@ components:
         id:
           format: int64
           type: integer
+        medium_id:
+          format: int32
+          type: integer
+        olang:
+          type: string
+        refs:
+          items:
+            $ref: "#/components/schemas/EntityRefSummary"
+          type:
+            - array
+            - "null"
+        release_year:
+          format: int32
+          type: integer
+        site:
+          type: string
         source_id:
           format: int32
           type: integer
@@ -458,6 +513,27 @@ components:
         - code
         - message
       type: object
+    EnvelopeQueueSummary:
+      additionalProperties: false
+      properties:
+        $schema:
+          description: A URL to the JSON Schema for this object.
+          examples:
+            - https://example.com/EnvelopeQueueSummary.json
+          format: uri
+          readOnly: true
+          type: string
+        code:
+          format: int64
+          type: integer
+        data:
+          $ref: "#/components/schemas/QueueSummary"
+        message:
+          type: string
+      required:
+        - code
+        - message
+      type: object
     EnvelopeRefActionData:
       additionalProperties: false
       properties:
@@ -647,6 +723,19 @@ components:
         - product_work_id
         - submitted_event_id
       type: object
+    ProbableRefBucketCount:
+      additionalProperties: false
+      properties:
+        count:
+          format: int64
+          type: integer
+        entity_type:
+          format: int32
+          type: integer
+      required:
+        - entity_type
+        - count
+      type: object
     ProbableRefItem:
       additionalProperties: false
       properties:
@@ -787,6 +876,25 @@ components:
         - execute_after
         - executed_at
         - note
+      type: object
+    QueueSummary:
+      additionalProperties: false
+      properties:
+        candidates:
+          items:
+            $ref: "#/components/schemas/CandidateBucketCount"
+          type:
+            - array
+            - "null"
+        probable_refs:
+          items:
+            $ref: "#/components/schemas/ProbableRefBucketCount"
+          type:
+            - array
+            - "null"
+      required:
+        - candidates
+        - probable_refs
       type: object
     RefActionData:
       additionalProperties: false
@@ -995,6 +1103,25 @@ paths:
                 $ref: "#/components/schemas/HouseError"
           description: Error
       summary: "Decide a match candidate: accept (credit_name → link a person; else opens a merge proposal), reject (kept forever) or defer"
+      tags:
+        - catalog-admin
+  /api/v1/admin/catalog/candidates/summary:
+    get:
+      operationId: catalogQueueSummary
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EnvelopeQueueSummary"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HouseError"
+          description: Error
+      summary: "Queue depth: candidates grouped by entity type × status, probable refs grouped by entity type"
       tags:
         - catalog-admin
   /api/v1/admin/catalog/claims/pending:


### PR DESCRIPTION
## Why

The dedup review queue was effectively invisible: the console defaulted to pending-only (67 credit-name rows) while **6.4k work pairs sat in needsManual with no entry point**, and deciding a work pair meant expanding a bare row that carried no evidence.

## What

**Backend** (read-only; no schema change, no migration):
- `GET /api/v1/admin/catalog/candidates/summary` — candidate counts by entity_type × status + probable-ref counts by entity_type (scope copied verbatim from `ListProbableRefs`, `dead_at` deliberately unfiltered so chip totals match the pageable queue).
- `EntitySummary` gains optional work-evidence fields (medium, olang, content_rating, site, claim_state, min release year, ≤6 live refs, exact before probable) via a best-effort `enrichWorkContext` mirroring the credit-name enrichment precedent. `required` unchanged (`id`/`display_name`) — backward compatible.
- `docs/catalog/admin-openapi.yaml` regenerated from code in this PR; generated TS types rebuilt; the temporary type overlay dropped.

**Frontend** (KunUI only, project palette, no gradients):
- Queue overview matrix (entity type × status) with a highlighted works/needsManual banner; default filter lands on 作品 × 待人工.
- Work pairs are side-by-side evidence cards: medium/rating/olang/year chips, claim badges, linkable source anchors (vndb/bangumi/steam/hltb), shared anchors highlighted and summarised as near-conclusive; a red cross-medium warning (deliberately minted adaptations must not merge) and a danger warning when both sides are claimed.
- Merge direction is an explicit per-card toggle preset to a recommended survivor (claimed side > more anchors > lower id) with a one-line reason; a single shared confirm modal states the ~48h cooling-off.
- SubNav badges count pending + needsManual (previous pending-only badge said 67 while 6.4k were invisible — same bug).
- Refs page gains entity-type count chips and outbound links; confirm/reject + mandatory reason flow untouched.

## Gates

`go build ./...` / `go vet ./internal/platform/catalog/...` / route-registration test green; `pnpm -C apps/web typecheck` (proven live via injected TS2322), `lint`, `build` all green after the overlay drop.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD