### PR TITLE
fix(store-price): schedule the retry after a failed fetch

### DIFF
--- a/apps/api/internal/platform/store/model/price.go
+++ b/apps/api/internal/platform/store/model/price.go
@@ -23,7 +23,15 @@ type PriceQuote struct {
 	FetchedAt       time.Time      `gorm:"not null"`
 	ExpiresAt       time.Time      `gorm:"not null;index"`
 	LastRequestedAt time.Time      `gorm:"not null;index"`
-	CreatedAt       time.Time
+	// A failed fetch must not overwrite the cached row (a stale price beats
+	// none), so expires_at stayed in the past and dueForRefresh, which orders by
+	// it, handed the same failing rows back every tick forever: the DLsite lane
+	// retried two rows every 60s for 23h in 2026-09, and once a failing set
+	// reaches the tick budget it also starves every healthy lane behind it.
+	// next_attempt_at is the retry schedule; expires_at stays the content's
+	// freshness, which is what `stale` on the face reports.
+	NextAttemptAt *time.Time `gorm:"index"`
+	CreatedAt     time.Time
 }
 
 func (PriceQuote) TableName() string { return "store_price_quotes" }

--- a/apps/api/internal/platform/store/price/batcher.go
+++ b/apps/api/internal/platform/store/price/batcher.go
@@ -215,9 +215,11 @@ func (b *batcher) writeErrors(ctx context.Context, ids []string, now time.Time) 
 		return
 	}
 	var rows []model.PriceQuote
+	var kept []Key
 	for _, id := range ids {
 		k := Key{Source: b.fetch.Source(), ExternalID: id, Region: b.region}
 		if _, ok := have[k]; ok {
+			kept = append(kept, k)
 			continue
 		}
 		rows = append(rows, model.PriceQuote{
@@ -231,6 +233,10 @@ func (b *batcher) writeErrors(ctx context.Context, ids []string, now time.Time) 
 			ExpiresAt:       now.Add(b.svc.opts.ErrorFor),
 			LastRequestedAt: now,
 		})
+	}
+	if err := b.svc.deferRetry(ctx, kept, now.Add(b.svc.opts.ErrorFor)); err != nil {
+		slog.Warn("store price: defer retry after fetch error failed",
+			"source", b.fetch.Source(), "region", b.region, "count", len(kept), "error", err)
 	}
 	if err := b.svc.upsert(ctx, rows); err != nil {
 		slog.Warn("store price: upsert failed",

--- a/apps/api/internal/platform/store/price/service.go
+++ b/apps/api/internal/platform/store/price/service.go
@@ -141,7 +141,7 @@ func (s *Service) Quotes(ctx context.Context, anchors []Anchor, wait time.Durati
 		if row, ok := rows[k]; ok {
 			r := row
 			sl.row = &r
-			if !now.Before(row.ExpiresAt) {
+			if !now.Before(row.ExpiresAt) && dueForAttempt(row, now) {
 				if b := s.batcherFor(k); b != nil {
 					b.enqueue(k.ExternalID)
 				}
@@ -209,6 +209,10 @@ func (s *Service) expand(anchors []Anchor) []Key {
 		}
 	}
 	return keys
+}
+
+func dueForAttempt(row model.PriceQuote, now time.Time) bool {
+	return row.NextAttemptAt == nil || !now.Before(*row.NextAttemptAt)
 }
 
 func (s *Service) batcherFor(k Key) *batcher {

--- a/apps/api/internal/platform/store/price/service_backoff_test.go
+++ b/apps/api/internal/platform/store/price/service_backoff_test.go
@@ -1,0 +1,97 @@
+package price
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"api/internal/platform/store/model"
+	"api/internal/platform/store/storetest"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+func (f *fakeFetcher) setFail(v bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.fail = v
+}
+
+func seedExpired(t *testing.T, id string, fetched time.Time) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&model.PriceQuote{
+		Source: "dlsite", ExternalID: id, Region: "jp",
+		QuoteState: "priced", URL: "https://example.test/" + id, Currency: "JPY",
+		ListMinor: 10000, CurrentMinor: 8000, Converted: datatypes.JSON([]byte("{}")),
+		FetchedAt: fetched, ExpiresAt: fetched, LastRequestedAt: time.Now(),
+	}).Error)
+}
+
+func takeQuote(t *testing.T, id string) model.PriceQuote {
+	t.Helper()
+	var row model.PriceQuote
+	require.NoError(t, testDB.Where("source = ? AND external_id = ? AND region = ?", "dlsite", id, "jp").Take(&row).Error)
+	return row
+}
+
+func TestFailedRefreshSchedulesTheRetryInsteadOfEveryTick(t *testing.T) {
+	fake := &fakeFetcher{fail: true}
+	svc := newTestService(t, []Fetcher{fake}, Options{ErrorFor: 15 * time.Minute, RefreshEvery: 50 * time.Millisecond})
+	past := time.Now().Add(-time.Hour)
+	seedExpired(t, "RJ300001", past)
+
+	_, err := svc.Quotes(context.Background(), []Anchor{{Source: "dlsite", ExternalID: "RJ300001"}}, 0)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return fake.callCount() >= 1 }, 3*time.Second, 20*time.Millisecond)
+
+	require.Never(t, func() bool { return fake.callCount() > 1 }, 600*time.Millisecond, 25*time.Millisecond)
+
+	row := takeQuote(t, "RJ300001")
+	require.Equal(t, "priced", row.QuoteState)
+	require.WithinDuration(t, past, row.FetchedAt, 2*time.Second)
+	require.NotNil(t, row.NextAttemptAt)
+	require.InDelta(t, (15 * time.Minute).Seconds(), time.Until(*row.NextAttemptAt).Seconds(), 5)
+
+	_, err = svc.Quotes(context.Background(), []Anchor{{Source: "dlsite", ExternalID: "RJ300001"}}, 0)
+	require.NoError(t, err)
+	require.Never(t, func() bool { return fake.callCount() > 1 }, 300*time.Millisecond, 25*time.Millisecond)
+}
+
+func TestScheduledRetryRunsWhenDueAndSuccessClearsIt(t *testing.T) {
+	fake := &fakeFetcher{fail: true}
+	svc := newTestService(t, []Fetcher{fake}, Options{ErrorFor: 15 * time.Minute, RefreshEvery: 50 * time.Millisecond})
+	past := time.Now().Add(-time.Hour)
+	seedExpired(t, "RJ300002", past)
+
+	_, err := svc.Quotes(context.Background(), []Anchor{{Source: "dlsite", ExternalID: "RJ300002"}}, 0)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return fake.callCount() >= 1 }, 3*time.Second, 20*time.Millisecond)
+
+	fake.setFail(false)
+	require.NoError(t, testDB.Model(&model.PriceQuote{}).
+		Where("external_id = ?", "RJ300002").
+		Update("next_attempt_at", time.Now().Add(-time.Minute)).Error)
+
+	require.Eventually(t, func() bool {
+		row := takeQuote(t, "RJ300002")
+		return row.NextAttemptAt == nil && row.FetchedAt.After(past.Add(time.Minute))
+	}, 3*time.Second, 25*time.Millisecond)
+}
+
+func TestDueForRefreshSkipsScheduledRows(t *testing.T) {
+	require.NoError(t, storetest.Truncate(testDB))
+	svc := New(testDB, nil, Options{})
+	past := time.Now().Add(-time.Hour)
+	seedExpired(t, "RJ300003", past)
+	seedExpired(t, "RJ300004", past)
+	later := time.Now().Add(10 * time.Minute)
+	require.NoError(t, testDB.Model(&model.PriceQuote{}).
+		Where("external_id = ?", "RJ300004").
+		Update("next_attempt_at", later).Error)
+
+	keys, err := svc.dueForRefresh(context.Background(), time.Now(), 7*24*time.Hour, 500)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, "RJ300003", keys[0].ExternalID)
+}

--- a/apps/api/internal/platform/store/price/store.go
+++ b/apps/api/internal/platform/store/price/store.go
@@ -41,6 +41,7 @@ func (s *Service) upsert(ctx context.Context, rows []model.PriceQuote) error {
 		DoUpdates: clause.AssignmentColumns([]string{
 			"quote_state", "url", "currency", "list_minor", "current_minor",
 			"discount_percent", "sale_ends_at", "converted", "fetched_at", "expires_at",
+			"next_attempt_at",
 		}),
 	}).Create(&rows).Error
 }
@@ -54,11 +55,25 @@ func (s *Service) touchRequested(ctx context.Context, ids []int64, now time.Time
 		Update("last_requested_at", now).Error
 }
 
+func (s *Service) deferRetry(ctx context.Context, keys []Key, until time.Time) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	tuples := make([][]any, len(keys))
+	for i, k := range keys {
+		tuples[i] = []any{k.Source, k.ExternalID, k.Region}
+	}
+	return s.db.WithContext(ctx).Model(&model.PriceQuote{}).
+		Where("(source, external_id, region) IN ?", tuples).
+		Update("next_attempt_at", until).Error
+}
+
 func (s *Service) dueForRefresh(ctx context.Context, now time.Time, hot time.Duration, limit int) ([]Key, error) {
 	var rows []model.PriceQuote
 	q := s.db.WithContext(ctx).Model(&model.PriceQuote{}).
 		Select("source", "external_id", "region").
-		Where("expires_at < ? AND last_requested_at > ?", now, now.Add(-hot)).
+		Where("expires_at < ? AND last_requested_at > ? AND (next_attempt_at IS NULL OR next_attempt_at <= ?)",
+			now, now.Add(-hot), now).
 		Order("expires_at")
 	if limit > 0 {
 		q = q.Limit(limit)


### PR DESCRIPTION
## What

A failed upstream fetch leaves the cached quote row alone on purpose (a stale price beats no price), but it also left `expires_at` in the past — and `dueForRefresh` picks rows **ordered by `expires_at`**. Failing rows therefore park at the head of the queue and are handed back on every 60s tick, forever.

Live in production right now: the DLsite lane (dead since the German egress gets `302 → google.com`) has re-fetched the same **two** rows every 60 seconds since 2026-09-02 08:19Z — 23 hours, ~1,400 requests, one WARN per minute — and the read path re-queues them on every request too.

The log noise is the small half. Once a failing set reaches the 500-row tick budget, it **starves every healthy row behind it**: one dead storefront silently freezes the refresh loop for all lanes. The catalog currently carries 166,229 fetchable DLsite ids and 10,183 Steam appids on live galgame works, so a DLsite outage hits that budget immediately.

## How

Split the retry schedule from the content's freshness:

- `next_attempt_at` (new, nullable, indexed) = when we may try again.
- `expires_at` keeps meaning "how fresh this price is", which is what `stale` reports on `/v2/store/prices`.

A failed fetch pushes `next_attempt_at` to `now + ErrorFor` on the rows it kept — content, `fetched_at` and `quote_state` untouched. `dueForRefresh` and the read path both skip a row that is not due. A successful write clears the column.

## Verification

- 21 PASS in `internal/platform/store/price` against a real DSN (2.05s), 3 of them new.
- Positive control: remove the one `deferRetry` call and `TestFailedRefreshSchedulesTheRetryInsteadOfEveryTick` reports "Condition satisfied" within 600ms (the storm reproduces); put it back and it passes.

## Migration

`store_price_quotes.next_attempt_at` on **kun_galgame_infra** — `go run ./cmd/migrate`. Production runs it from the compose `migrate` dependency on deploy, so no manual step, provided the migrate image is actually pulled fresh.

https://claude.ai/code/session_01HLzRxMZfQ46zdNUhsA6RWa