### PR TITLE
fix(apiv2): field-keyed proposal errors and effective suppression caps

### DIFF
--- a/apps/api/internal/platform/apiv2/handler/catalog_schema_test.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog_schema_test.go
@@ -51,7 +51,9 @@ func TestGetSchemaWorkAndRelease(t *testing.T) {
 		t.Fatalf("include/full_set %+v %+v", s.Include, s.FullSet)
 	}
 	foundTitles, foundKind := false, false
+	capByKey := map[string]int{}
 	for _, f := range s.Fields {
+		capByKey[f.Key] = f.MaxSuppressed
 		if f.Key == editspec.FieldWorkTitles {
 			foundTitles = true
 			if f.FieldType != string(editing.KindList) {
@@ -67,6 +69,23 @@ func TestGetSchemaWorkAndRelease(t *testing.T) {
 	}
 	if !foundTitles {
 		t.Fatal("missing catalog.work.titles")
+	}
+	// titles declares no cap of its own, so a raw read published 0 here while
+	// the companion enforced the 200 default — max_suppressed must always be
+	// the effective limit, equal on parent and companion.
+	suppressed := 0
+	for key, parentCap := range capByKey {
+		companionCap, ok := capByKey[key+editing.SuppressedFieldSuffix]
+		if !ok {
+			continue
+		}
+		suppressed++
+		if parentCap != companionCap || parentCap <= 0 {
+			t.Fatalf("%s max_suppressed %d != companion %d", key, parentCap, companionCap)
+		}
+	}
+	if suppressed < 3 {
+		t.Fatalf("expected titles, credits and roster companions, saw %d", suppressed)
 	}
 	if foundKind {
 		t.Fatal("kind must not appear as a field key or field_type")

--- a/apps/api/internal/platform/apiv2/handler/me_proposals.go
+++ b/apps/api/internal/platform/apiv2/handler/me_proposals.go
@@ -568,12 +568,14 @@ func proposalErr(err error) error {
 	}
 	var perm *editing.PermissionError
 	if errors.As(err, &perm) {
-		return problem.New(problem.CodePermissionRequired, "", "", perm.Error())
+		p := problem.New(problem.CodePermissionRequired, "", "", perm.Error())
+		p.Errors = []problem.FieldError{{Pointer: "/patch/" + perm.Key, Reason: problem.ReasonNotPermitted, Detail: perm.Error()}}
+		return p
 	}
 	var val *editing.ValidationError
 	if errors.As(err, &val) {
 		p := problem.New(problem.CodeValidationFailed, "", "", val.Error())
-		p.Errors = []problem.FieldError{{Pointer: "/" + val.Key, Reason: problem.ReasonUnknownValue, Detail: val.Error()}}
+		p.Errors = []problem.FieldError{{Pointer: "/patch/" + val.Key, Reason: problem.ReasonUnknownValue, Detail: val.Error()}}
 		return p
 	}
 	return err

--- a/apps/api/internal/platform/apiv2/handler/me_proposals_err_test.go
+++ b/apps/api/internal/platform/apiv2/handler/me_proposals_err_test.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"testing"
+
+	"api/internal/platform/apiv2/problem"
+	"api/internal/platform/editing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Every keyed lane points into the proposal's patch document, decide-time
+// errors included — the ValidationError lane alone used "/"+key until the
+// edit UI reported the inconsistency.
+func TestProposalErrPointersSharePatchPrefix(t *testing.T) {
+	cases := []struct {
+		err     error
+		code    string
+		pointer string
+		reason  string
+	}{
+		{
+			&editing.ValidationError{Key: "catalog.work.titles", Reason: "must be an array"},
+			problem.CodeValidationFailed, "/patch/catalog.work.titles", problem.ReasonUnknownValue,
+		},
+		{
+			&editing.PermissionError{Key: "catalog.work.credits", Action: "propose"},
+			problem.CodePermissionRequired, "/patch/catalog.work.credits", problem.ReasonNotPermitted,
+		},
+		{
+			&editing.UnknownFieldError{Key: "catalog.work.nope"},
+			problem.CodeValidationFailed, "/patch/catalog.work.nope", problem.ReasonUnknownValue,
+		},
+		{
+			&editing.LockedFieldError{Key: "catalog.work.olang"},
+			problem.CodeValidationFailed, "/patch/catalog.work.olang", problem.ReasonImmutable,
+		},
+		{
+			&editing.ConflictError{Keys: []string{"catalog.work.titles"}},
+			problem.CodeValidationFailed, "/patch/catalog.work.titles", problem.ReasonInconsistentWith,
+		},
+	}
+	for _, c := range cases {
+		p, ok := proposalErr(c.err).(*problem.Problem)
+		require.True(t, ok, "%T", c.err)
+		require.Equal(t, c.code, p.Code, "%T", c.err)
+		require.Len(t, p.Errors, 1, "%T", c.err)
+		require.Equal(t, c.pointer, p.Errors[0].Pointer, "%T", c.err)
+		require.Equal(t, c.reason, p.Errors[0].Reason, "%T", c.err)
+		require.NotEmpty(t, p.Errors[0].Detail, "%T", c.err)
+	}
+}

--- a/apps/api/internal/platform/apiv2/problem/registry.go
+++ b/apps/api/internal/platform/apiv2/problem/registry.go
@@ -94,6 +94,7 @@ const (
 	ReasonUnknownReference = "UNKNOWN_REFERENCE"
 	ReasonImmutable        = "IMMUTABLE"
 	ReasonInconsistentWith = "INCONSISTENT_WITH"
+	ReasonNotPermitted     = "NOT_PERMITTED"
 )
 
 var Codes = []Def{
@@ -153,6 +154,7 @@ var Reasons = []ReasonDef{
 	{ReasonUnknownReference, "Unknown reference", "The value refers to an entity that is not visible. Absence, merge, and visibility filtering are not distinguished."},
 	{ReasonImmutable, "Immutable", "This field cannot be changed in the current state."},
 	{ReasonInconsistentWith, "Inconsistent with", "The value contradicts another field. detail names that field's pointer."},
+	{ReasonNotPermitted, "Not permitted", "The caller is not allowed to act on this position. Unlike IMMUTABLE this is about the actor, not the field's state."},
 }
 
 var (

--- a/apps/api/internal/platform/editing/registry.go
+++ b/apps/api/internal/platform/editing/registry.go
@@ -277,6 +277,14 @@ func (r *Registry) Register(spec EntityTypeSpec) error {
 		if parent.Identity == nil {
 			return fmt.Errorf("editing: field %q suppresses %q, which declares no Identity", f.Key, parent.Key)
 		}
+		// SuppressedFieldSpec resolved the effective cap (parent's declaration or
+		// the 200 default) into the companion before registration. A parent that
+		// declared nothing kept 0, and both schema faces published that 0 as "no
+		// suppression set" while the companion enforced 200 — copy the resolved
+		// cap back so MaxSuppressed reads as the effective limit everywhere.
+		if parent.MaxSuppressed <= 0 {
+			parent.MaxSuppressed = f.MaxSuppressed
+		}
 	}
 	for site, overlay := range spec.SiteOverlays {
 		for key, p := range overlay {

--- a/apps/api/internal/platform/editing/registry_caps_test.go
+++ b/apps/api/internal/platform/editing/registry_caps_test.go
@@ -1,0 +1,65 @@
+package editing_test
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/platform/editing"
+
+	"gorm.io/gorm"
+)
+
+func TestRegisterBackfillsEffectiveMaxSuppressed(t *testing.T) {
+	noopValidate := func(any) error { return nil }
+	noopApply := func(context.Context, *gorm.DB, int64, any) error { return nil }
+	defaulted := editing.FieldSpec{
+		Key: "test.caps.rows", Kind: editing.KindList, DiffHint: editing.DiffHintItems,
+		Identity: &editing.IdentitySpec{Segments: 2, KeyCheck: numericKeyCheck("row", 2)},
+		Validate: noopValidate, Apply: noopApply,
+	}
+	declared := editing.FieldSpec{
+		Key: "test.caps.cols", Kind: editing.KindList, DiffHint: editing.DiffHintItems,
+		Identity:      &editing.IdentitySpec{Segments: 2, KeyCheck: numericKeyCheck("col", 2)},
+		MaxSuppressed: 500,
+		Validate:      noopValidate, Apply: noopApply,
+	}
+	bare := editing.FieldSpec{
+		Key: "test.caps.tags", Kind: editing.KindList, DiffHint: editing.DiffHintItems,
+		Validate: noopValidate, Apply: noopApply,
+	}
+	spec := editing.EntityTypeSpec{
+		Family: "test", Type: "test.caps",
+		LoadSnapshot: func(context.Context, int64) (map[string]any, error) { return map[string]any{}, nil },
+		Txn:          func(ctx context.Context, fn func(tx *gorm.DB) error) error { return fn(nil) },
+		DefaultPolicy: editing.Policy{
+			Propose: editing.ProposePerm(permPropose), Review: editing.ReviewPerm(permReview),
+			Automerge: editing.AutomergeNever,
+		},
+		Fields: []editing.FieldSpec{
+			defaulted, editing.SuppressedFieldSpec("test.caps", defaulted),
+			declared, editing.SuppressedFieldSpec("test.caps", declared),
+			bare,
+		},
+	}
+	reg := editing.NewRegistry()
+	if err := reg.Register(spec); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := reg.Type("test.caps")
+	if !ok {
+		t.Fatal("type not registered")
+	}
+	byKey := map[string]int{}
+	for i := range got.Fields {
+		byKey[got.Fields[i].Key] = got.Fields[i].MaxSuppressed
+	}
+	if byKey["test.caps.rows"] != byKey["test.caps.rows"+editing.SuppressedFieldSuffix] || byKey["test.caps.rows"] <= 0 {
+		t.Fatalf("defaulted parent must publish the companion's cap: %v", byKey)
+	}
+	if byKey["test.caps.cols"] != 500 || byKey["test.caps.cols"+editing.SuppressedFieldSuffix] != 500 {
+		t.Fatalf("declared cap must survive: %v", byKey)
+	}
+	if byKey["test.caps.tags"] != 0 {
+		t.Fatalf("a list with no suppression companion has no suppression set: %v", byKey)
+	}
+}


### PR DESCRIPTION
Three defects reported by the nextmoe-edit-ui team, adjudicated against refs/api-v2 (10 §4, D37 recorded):

1. **ValidationError pointer prefix** — `proposalErr` emitted `"/"+key` on the ValidationError lane while UnknownField/Locked/Conflict all emit `"/patch/"+key`. All six keyed lanes now share the `/patch/` prefix; `TestProposalErrPointersSharePatchPrefix` pins every lane.
2. **PermissionError had an empty `errors[]`** — the field key lived only in the detail prose. The lane now emits one entry at `/patch/<key>` with the new field-level reason `NOT_PERMITTED` (closed registry 12 → 13). Not `IMMUTABLE`: that names the field's state, this names the actor — same field, different permission holder, different outcome. Published immediately on `/v2/problems/reasons`; G13 disjointness holds.
3. **`max_suppressed` published the stored declaration, not the effective cap** — `work.titles` read 0 while its `.suppressed` companion enforced the 200 default, contradicting the face's own doc ("0 when the field has none"). `Register` now copies the companion's resolved cap back onto the parent, fixing the v2 schema face and the admin `SchemaProjection` in one place. Declared caps (credits/roster) are untouched; lists with no companion still read 0.

Zero regen diff across all 12 spec exports + portal artifacts (reason is a pattern string, not a schema enum) → no spec version bump. Editing + editspec suites ran against an ephemeral DB (not skip-green), apiv2 suites green.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD