### PR TITLE
fix(hihyou): exempt the trailing contentless run from the no-body gate

### DIFF
--- a/apps/api/internal/jobs/hihyou/segment.go
+++ b/apps/api/internal/jobs/hihyou/segment.go
@@ -203,8 +203,24 @@ func Gate(seg Segmentation) []string {
 	// A heading whose block holds only an image is real upstream shape — it has
 	// no preview to publish, so it is dropped per item. More than a couple in one
 	// issue means the segmentation itself slipped.
+	//
+	// The trailing contentless run is exempt: 期256's closing credits span three
+	// bold lines (文案/文案审核 rosters), which quarantined a perfectly segmented
+	// issue — a contentless block at the very end cannot be a lost body, while a
+	// mid-issue empty still means exactly that. Trailing items that carry
+	// pictures still count: an image-only story is upstream shape, not a
+	// sign-off. Census 2026-09-05 over all 220 issues: the exemption flips only
+	// 期256; every other issue has a trailing run of zero.
+	items := seg.Items
+	for len(items) > 0 {
+		last := items[len(items)-1]
+		if len(last.Body) != 0 || len(last.Pictures) != 0 {
+			break
+		}
+		items = items[:len(items)-1]
+	}
 	empty := 0
-	for _, it := range seg.Items {
+	for _, it := range items {
 		if len(it.Body) == 0 {
 			empty++
 		}

--- a/apps/api/internal/jobs/hihyou/segment_test.go
+++ b/apps/api/internal/jobs/hihyou/segment_test.go
@@ -194,8 +194,12 @@ func TestGateQuarantinesRatherThanBestEfforts(t *testing.T) {
 	}{
 		{"too few items", Segmentation{Items: []Item{{Title: "a", Body: []string{"x"}}}}, "item count"},
 		{"orphan blowup", Segmentation{Items: threeItems(), Orphans: 10}, "orphan paragraphs"},
-		{"bodyless run", Segmentation{Items: append(threeItems(),
-			Item{Title: "d"}, Item{Title: "e"}, Item{Title: "f"})}, "items with no body"},
+		{"bodyless run mid-issue", Segmentation{Items: append([]Item{
+			{Title: "d"}, {Title: "e"}, {Title: "f"}}, threeItems()...)}, "items with no body"},
+		{"image-only trailing run", Segmentation{Items: append(threeItems(),
+			Item{Title: "d", Pictures: []string{"p"}},
+			Item{Title: "e", Pictures: []string{"p"}},
+			Item{Title: "f", Pictures: []string{"p"}})}, "items with no body"},
 		{"sign-off as title", Segmentation{Items: append(threeItems(),
 			Item{Title: strings.Repeat("长", 91), Body: []string{"x"}})}, "over-long titles"},
 	}
@@ -207,6 +211,13 @@ func TestGateQuarantinesRatherThanBestEfforts(t *testing.T) {
 	}
 	if fail := Gate(Segmentation{Items: threeItems()}); len(fail) != 0 {
 		t.Errorf("a healthy issue was rejected: %v", fail)
+	}
+	signoff := append(threeItems(),
+		Item{Title: "文案：Zinogre、剩斗士星星、kksk、"},
+		Item{Title: "Casillas、倉小唯、poi233、萧端凛、式轩"},
+		Item{Title: "文案审核：信光、远野、十二级重巡拿拿酱、尘归"})
+	if fail := Gate(Segmentation{Items: signoff}); len(fail) != 0 {
+		t.Errorf("期256-shaped trailing sign-off was rejected: %v", fail)
 	}
 }
 


### PR DESCRIPTION
## What

The hihyou segment gate quarantines an issue when more than 2 items have no body. Issue 256 (cv52388429) tripped it on its **closing credits**: this week's sign-off spans three bold lines (`文案：…` / continuation / `文案审核：…`), each of which segments as a bodyless item. The 21 real news items are perfectly segmented — bodies, pictures, sections all present, 0 orphans, 0 unknown headings.

This exempts the **trailing contentless run** (no body *and* no pictures) from the empty count. A contentless block at the very end cannot be a lost body; a mid-issue empty still means exactly that and still counts. Trailing items that carry pictures also still count, so an image-only tail story cannot hide behind the exemption.

## Census (all 220 corpus issues, incl. the three new ones)

- Old gate: 218 pass. New gate: 219 pass. **The only flip is issue 256.**
- Trailing contentless run distribution: 219 issues have run=0; only 256 has run=3.
- The only issue still quarantined is 163 (known orphan-paragraph layout, pre-existing).

## Why now

The 2026-09-05 refresh ingested issues 257+258 (52 pending rows) but 256 was gate-quarantined and is a hole in production. After merge, CI rebuilds `infra-tools`; a re-run of `import-hihyou-weekly -only 256 -apply` on the box fills it (idempotent; expected: created=21, dropped_no_body=3).

## Tests

- Reworked `bodyless run` case to mid-issue (what the gate actually protects).
- New case: image-only trailing run still fails.
- New assertion: 期256-shaped trailing sign-off passes.
- `go test ./internal/jobs/hihyou/ -count=1` green; `go vet` clean; `gofmt` clean.

No schema change, no migration.
