### PR TITLE
feat(news): standing release flag for hihyou importer

### DIFF
--- a/apps/api/cmd/import-hihyou-weekly/main.go
+++ b/apps/api/cmd/import-hihyou-weekly/main.go
@@ -1,5 +1,8 @@
 // import-hihyou-weekly segments the harvested Gal周报 corpus into individual
 // news items and, with --apply, writes them into kun_news as status=pending.
+// -publish-actor releases the source's pending rows at the end of the run,
+// per the 2026-09-05 standing adjudication (bilibili already moderates the
+// column); run it as the uid making that call.
 package main
 
 import (
@@ -27,6 +30,7 @@ func main() {
 	dsn := flag.String("dsn", "", "kun_news DSN override (default: KUN_NEWS_PG_*)")
 	imageBase := flag.String("image-base", "", "image_service base URL override (local dev)")
 	concurrency := flag.Int("concurrency", 8, "parallel picture fetch/upload (database writes stay serial)")
+	publishActor := flag.Int64("publish-actor", 0, "uid recorded on release decisions; publishes the source's pending rows after an -apply run (0 = leave pending)")
 	flag.Parse()
 
 	_ = godotenv.Load("apps/api/.env")
@@ -51,14 +55,15 @@ func main() {
 	}
 
 	sum, err := hihyou.Import(context.Background(), cfg, hihyou.Opts{
-		Dir:         *dir,
-		Apply:       *apply,
-		SegmentOnly: *segmentOnly,
-		NoImages:    *noImages,
-		Only:        issues,
-		DSN:         *dsn,
-		ImageBase:   *imageBase,
-		Concurrency: *concurrency,
+		Dir:          *dir,
+		Apply:        *apply,
+		SegmentOnly:  *segmentOnly,
+		NoImages:     *noImages,
+		Only:         issues,
+		DSN:          *dsn,
+		ImageBase:    *imageBase,
+		Concurrency:  *concurrency,
+		PublishActor: *publishActor,
 	})
 	if sum != nil {
 		b, _ := json.MarshalIndent(sum, "", "  ")

--- a/apps/api/internal/jobs/hihyou/ingest.go
+++ b/apps/api/internal/jobs/hihyou/ingest.go
@@ -14,14 +14,15 @@ import (
 )
 
 type Opts struct {
-	Dir         string
-	Apply       bool
-	NoImages    bool
-	SegmentOnly bool // report the segmentation without touching the database
-	Only        []int
-	DSN         string
-	ImageBase   string
-	Concurrency int // parallel picture fetch/upload; the database writes stay serial
+	Dir          string
+	Apply        bool
+	NoImages     bool
+	SegmentOnly  bool // report the segmentation without touching the database
+	Only         []int
+	DSN          string
+	ImageBase    string
+	Concurrency  int   // parallel picture fetch/upload; the database writes stay serial
+	PublishActor int64 // uid on the release decisions; 0 leaves rows pending
 }
 
 type stats struct {
@@ -70,13 +71,16 @@ type Summary struct {
 	DroppedNoBody int            `json:"dropped_no_body,omitempty"`
 	ImagesUp      int            `json:"images_uploaded,omitempty"`
 	ImagesFailed  int            `json:"images_failed,omitempty"`
+	Released      int            `json:"released,omitempty"`
 	Apply         bool           `json:"apply"`
 }
 
 // Import segments the corpus and, with Apply, writes the items into kun_news as
-// status=pending. The backfill does not bypass the moderation gate: the risk on
-// this partner's content is not upstream spam but OUR extraction errors, which
-// is the case a human most needs to see.
+// status=pending. With PublishActor set, the run ends by releasing every
+// pending row of this source: on 2026-09-05 the user ruled the column is
+// wholesale-released because bilibili already moderates it, accepting the
+// remaining risk (our own extraction errors) on the 08-12 precedent. Without
+// the actor, rows wait for the console as before.
 func Import(ctx context.Context, cfg *config.Config, opts Opts) (*Summary, error) {
 	if opts.Dir == "" {
 		return nil, fmt.Errorf("import: --dir is required")
@@ -153,6 +157,14 @@ func Import(ctx context.Context, cfg *config.Config, opts Opts) (*Summary, error
 				return nil, fmt.Errorf("issue %d item %d: %w", seg.IssueNo, it.Ordinal, err)
 			}
 		}
+	}
+
+	if w != nil && opts.Apply && opts.PublishActor != 0 {
+		n, err := w.releasePending(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("standing release: %w", err)
+		}
+		sum.Released = n
 	}
 
 	sum.Items, sum.Pictures = st.items, st.pictures

--- a/apps/api/internal/jobs/hihyou/ingest_test.go
+++ b/apps/api/internal/jobs/hihyou/ingest_test.go
@@ -150,6 +150,56 @@ func TestImportWritesPendingItemsAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestPublishActorReleasesPendingRowsAndSparesYmgal(t *testing.T) {
+	db, dsn := openTestDB(t)
+	// The ymgal source row is seeded by the migration and survives Truncate, so
+	// only the guard item is created here.
+	guard := model.NewsItem{SourceKey: model.SourceKeyYmgal, Lane: model.LaneNews,
+		ExternalID: "t1", Title: "t", Preview: "p", SourceURL: "https://www.ymgal.games/t1",
+		PublishedAt: time.Unix(1786257779, 0).UTC(), Status: model.StatusPending}
+	if err := db.Create(&guard).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	writeCorpus(t, dir, healthy(1005))
+	sum, err := Import(context.Background(), &config.Config{},
+		Opts{Dir: dir, NoImages: true, Apply: true, DSN: dsn, PublishActor: 30})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sum.Created != 3 || sum.Released != 3 {
+		t.Fatalf("created=%d released=%d, want 3/3", sum.Created, sum.Released)
+	}
+
+	var n int64
+	db.Model(&model.NewsItem{}).
+		Where("source_key = ? AND status = ?", model.SourceKeyHihyou, model.StatusPublished).Count(&n)
+	if n != 3 {
+		t.Errorf("published hihyou rows = %d, want 3", n)
+	}
+	var decisions []model.NewsModerationDecision
+	if err := db.Find(&decisions).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 3 {
+		t.Fatalf("decision rows = %d, want one per released item", len(decisions))
+	}
+	for _, d := range decisions {
+		if d.ActorUID != 30 || d.FromStatus != model.StatusPending || d.ToStatus != model.StatusPublished || d.Reason == "" {
+			t.Errorf("decision = %+v", d)
+		}
+	}
+	// The release is scoped to this source: ymgal's queue answers a different
+	// promise and a wholesale sweep here would silently bypass it.
+	if err := db.Take(&guard, guard.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if guard.Status != model.StatusPending {
+		t.Errorf("ymgal row status = %d — the standing release swept another source", guard.Status)
+	}
+}
+
 // A row that already exists with the right text is the case 04c actually meets:
 // the whole 04b backfill ran with --no-images. If pictures only ever arrive on
 // create or on a text change, that run leaves 4,425 rows without a banner

--- a/apps/api/internal/jobs/hihyou/write.go
+++ b/apps/api/internal/jobs/hihyou/write.go
@@ -300,6 +300,30 @@ func (w *writer) upload(ctx context.Context, src string) (string, error) {
 	return res.Hash, nil
 }
 
+const releaseReason = "hihyou standing release: column already moderated by bilibili (user adjudication 2026-09-05)"
+
+// releasePending publishes every still-pending 批评 row and writes the audit
+// line from the rows the UPDATE actually moved — one decision per item, the
+// same shape the console's Decide writes. Source-scoped on purpose: ymgal rows
+// answer a different promise (苍麟's 广告哥 warning) and must never ride along.
+func (w *writer) releasePending(ctx context.Context) (int, error) {
+	const stmt = `
+		WITH moved AS (
+			UPDATE news_item SET status = ?, updated_at = now()
+			WHERE source_key = ? AND status = ?
+			RETURNING id
+		)
+		INSERT INTO news_moderation_decision (item_id, actor_uid, from_status, to_status, reason)
+		SELECT id, ?, ?, ?, ? FROM moved`
+	res := w.db.WithContext(ctx).Exec(stmt,
+		model.StatusPublished, model.SourceKeyHihyou, model.StatusPending,
+		w.opts.PublishActor, model.StatusPending, model.StatusPublished, releaseReason)
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	return int(res.RowsAffected), nil
+}
+
 // seedSource writes 批评's news_source row. 01 波 deliberately left it out: the
 // column URL it must carry was not known until this backfill, and a placeholder
 // homepage_url would put a wrong link under the one condition she set.


### PR DESCRIPTION
## What

Adds `-publish-actor <uid>` to `import-hihyou-weekly`. When set on an `-apply` run, the run ends with an atomic `UPDATE … RETURNING → INSERT` that publishes every still-pending row of the 批评 source and writes one `news_moderation_decision` per moved row (actor = the flag, reason cites the standing adjudication) — the same audit shape the console's `Decide` writes.

## Why

2026-09-05 user adjudication: 批评 (Gal周报) rows are released wholesale from now on, because the column is already moderated by bilibili before we ever see it. The remaining risk (our own segmentation errors) was accepted on the 08-12 precedent. Without this flag every refresh leaves a pending backlog that has to be swept by hand — today's refresh left 148 rows, released manually with this exact statement shape.

## Scope guard

The sweep is scoped to `source_key = 'galgame_hihyou'`. ymgal's pending queue answers a different partner promise (苍麟's 广告哥 warning) and must keep its manual gate; `TestPublishActorReleasesPendingRowsAndSparesYmgal` pins a ymgal pending row staying pending through a released run.

## Notes

- Default behavior unchanged: without the flag, rows stay `status=0` for the console.
- Re-segmented published rows still flip to pending in `applyItem`, then get re-released at the tail with an audit line — the decision log keeps the re-segmentation event visible.
- No schema change, no migration. `infra-tools` picks the new flag up on the next image build.

Claude-Session: https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
