### PR TITLE
feat(catalog): cover-slot picker v3 — pkg veto, sharpness ranking, screenshot banner fallback (spec 2.9.0)

### DIFF
--- a/apps/api/internal/jobs/repincovers/ladder.go
+++ b/apps/api/internal/jobs/repincovers/ladder.go
@@ -16,10 +16,8 @@ func tier(kind string) int {
 	switch kind {
 	case "dig", "main":
 		return 0
-	case "pkgfront":
-		return 1
 	case "":
-		return 2
+		return 1
 	default:
 		return tierIneligible
 	}

--- a/apps/api/internal/jobs/repincovers/ladder_test.go
+++ b/apps/api/internal/jobs/repincovers/ladder_test.go
@@ -13,9 +13,8 @@ func cover(id int64, kind string, w, h int) Cover {
 
 func TestTierOrder(t *testing.T) {
 	assert.Equal(t, tier("dig"), tier("main"), "dig and main share one tier - the ruling of 2026-08-08 compares them on resolution, not on which word they use")
-	assert.Less(t, tier("dig"), tier("pkgfront"), "clean art beats a scan of a physical case")
-	assert.Less(t, tier("pkgfront"), tier(""), "a named front beats an unlabelled upload")
-	for _, k := range []string{"pkgback", "pkgmed", "pkgcontent", "pkgside"} {
+	assert.Less(t, tier("dig"), tier(""), "clean art beats an unlabelled upload")
+	for _, k := range []string{"pkgfront", "pkgback", "pkgmed", "pkgcontent", "pkgside"} {
 		assert.Equal(t, tierIneligible, tier(k), "%s is never a cover", k)
 	}
 }
@@ -42,10 +41,16 @@ func TestLargestWinsWithinTier(t *testing.T) {
 func TestLandscapeIsNeverEligible(t *testing.T) {
 	best := selectWinner([]Cover{
 		cover(1, "dig", 1600, 900),
-		cover(2, "pkgfront", 800, 1200),
+		cover(2, "", 800, 1200),
 	})
 	require.NotNil(t, best)
-	assert.Equal(t, "pkgfront", best.Kind)
+	assert.Equal(t, "", best.Kind)
+}
+
+func TestPackageArtIsNeverPinned(t *testing.T) {
+	assert.Nil(t, selectWinner([]Cover{cover(1, "pkgfront", 2000, 3000)}),
+		"the whole pkg family left the ladder: the read face vetoes it, so pinning one "+
+			"only writes a pin nothing can elect")
 }
 
 func TestUnknownDimsAreNeverEligible(t *testing.T) {

--- a/apps/api/internal/platform/apiv2/handler/map_work.go
+++ b/apps/api/internal/platform/apiv2/handler/map_work.go
@@ -10,13 +10,13 @@ import (
 )
 
 func workFromListItem(it dto.PublicWorkListItem, include []string, logoURL func(string) string) repr.Work {
-	var cover, banner *repr.Image
+	var cover, banner *repr.CoverSlot
 	if it.Covers != nil {
 		cover = imageFromSlot(it.Covers.Portrait)
 		banner = imageFromSlot(it.Covers.Banner)
 	}
 	if cover == nil {
-		cover = imageFromURL(it.Cover, "")
+		cover = slotFromImage(imageFromURL(it.Cover, ""), "cover")
 	}
 	created := it.Created
 	if created == "" {
@@ -59,7 +59,7 @@ func workFromListItem(it dto.PublicWorkListItem, include []string, logoURL func(
 }
 
 func workFromDetail(rec dto.PublicCatalogWork, include []string, logoURL func(string) string) repr.Work {
-	var cover, banner *repr.Image
+	var cover, banner *repr.CoverSlot
 	if rec.CoverSlots != nil {
 		cover = imageFromSlot(rec.CoverSlots.Portrait)
 		banner = imageFromSlot(rec.CoverSlots.Banner)
@@ -228,11 +228,25 @@ func partialDateLen(date *string) int {
 	return 0
 }
 
-func imageFromSlot(slot *dto.PublicCoverSlot) *repr.Image {
+func imageFromSlot(slot *dto.PublicCoverSlot) *repr.CoverSlot {
 	if slot == nil {
 		return nil
 	}
-	return imageFromURLMeta(slot.URL, slot.Source, slot.Width, slot.Height, slot.Thumbhash, slot.Sexual)
+	return slotFromImage(
+		imageFromURLMeta(slot.URL, slot.Source, slot.Width, slot.Height, slot.Thumbhash, slot.Sexual),
+		slot.Origin,
+	)
+}
+
+func slotFromImage(img *repr.Image, origin string) *repr.CoverSlot {
+	if img == nil {
+		return nil
+	}
+	return &repr.CoverSlot{
+		URL: img.URL, Hash: img.Hash, Width: img.Width, Height: img.Height,
+		Thumbhash: img.Thumbhash, Sexual: img.Sexual, Violence: img.Violence,
+		Source: img.Source, Origin: origin,
+	}
 }
 
 func imageFromURL(url, source string) *repr.Image {

--- a/apps/api/internal/platform/apiv2/handler/setup.go
+++ b/apps/api/internal/platform/apiv2/handler/setup.go
@@ -57,7 +57,7 @@ func SetupWith(app *fiber.App, opt Options) huma.API {
 	app.Use(protocol.RateLimit(opt.Store, credentialLimitIdentity))
 	app.Use(protocol.Idempotency(opt.Store, credentialLimitIdentity))
 
-	cfg := huma.DefaultConfig("NextMoe Public API v2", "2.8.0")
+	cfg := huma.DefaultConfig("NextMoe Public API v2", "2.9.0")
 	cfg.OpenAPIPath = ""
 	cfg.DocsPath = ""
 	cfg.SchemasPath = ""

--- a/apps/api/internal/platform/apiv2/repr/image.go
+++ b/apps/api/internal/platform/apiv2/repr/image.go
@@ -14,6 +14,19 @@ type Image struct {
 	Source    string   `json:"source" maxLength:"64" doc:"Open vocabulary sources. Must not be used as a discriminant."`
 }
 
+type CoverSlot struct {
+	_         struct{} `json:"-" additionalProperties:"true"`
+	URL       string   `json:"url" format:"uri" maxLength:"512" doc:"Absolute image URL. Never a bare hash."`
+	Hash      string   `json:"hash" minLength:"64" maxLength:"64" pattern:"^[0-9a-f]{64}$" doc:"Image-service content hash."`
+	Width     *int     `json:"width" minimum:"0" maximum:"65535" doc:"Pixel width. null if unknown."`
+	Height    *int     `json:"height" minimum:"0" maximum:"65535" doc:"Pixel height. null if unknown."`
+	Thumbhash *string  `json:"thumbhash" maxLength:"128" pattern:"^[A-Za-z0-9+/=_-]+$" doc:"Thumbhash. null if unknown."`
+	Sexual    *string  `json:"sexual" enum:"safe,suggestive,explicit" doc:"Sexual depiction. null means not assessed."`
+	Violence  *string  `json:"violence" enum:"tame,violent,brutal" doc:"Violent depiction. null means not assessed. Currently no catalog row has an assessment; the value is always null."`
+	Source    string   `json:"source" maxLength:"64" doc:"Open vocabulary sources. Must not be used as a discriminant."`
+	Origin    string   `json:"origin" enum:"cover,screenshot" doc:"Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover."`
+}
+
 type Cover struct {
 	_              struct{} `json:"-" additionalProperties:"true"`
 	ID             string   `json:"id" pattern:"^[0-9]+$" minLength:"1" maxLength:"20" doc:"catalog_work_cover row id, not the image hash."`

--- a/apps/api/internal/platform/apiv2/repr/resource.go
+++ b/apps/api/internal/platform/apiv2/repr/resource.go
@@ -51,8 +51,8 @@ type Work struct {
 	ReleaseDate          *string                  `json:"release_date" format:"date" maxLength:"10" doc:"Calendar date. null when release_status is announced, cancelled, or unknown."`
 	ReleaseDatePrecision *string                  `json:"release_date_precision" enum:"day,month,year" doc:"null when release_date is null. month dates sit on the 1st; year dates sit on January 1."`
 	ReleaseStatus        string                   `json:"release_status" enum:"released,dated,announced,cancelled,unknown" doc:"World state of the release, distinct from our knowledge gap."`
-	Cover                *Image                   `json:"cover" doc:"Selected portrait image. null if none."`
-	Banner               *Image                   `json:"banner" doc:"Selected landscape image. null if none."`
+	Cover                *CoverSlot               `json:"cover" doc:"Selected portrait image. null if none."`
+	Banner               *CoverSlot               `json:"banner" doc:"Selected landscape image. null if none. origin=screenshot marks the fallback for a work with no landscape cover."`
 	Claim                *Claim                   `json:"claim" doc:"null if unclaimed. Never omitted on view=basic."`
 	CreatedAt            string                   `json:"created_at" format:"date-time" maxLength:"32" doc:"RFC 3339 UTC."`
 	UpdatedAt            string                   `json:"updated_at" format:"date-time" maxLength:"32" doc:"RFC 3339 UTC."`
@@ -85,7 +85,7 @@ type ViaCompany struct {
 	Localized   map[string]LocalizedText `json:"localized" doc:"BCP-47 keys. Empty object if none. Must not be used as a discriminant."`
 }
 
-func NewWork(id int64, medium, display, olang, rating, releaseStatus, created, updated string, latin *string, localized map[string]LocalizedText, releaseDate, releasePrecision *string, cover, banner *Image, claim *Claim) (Work, bool) {
+func NewWork(id int64, medium, display, olang, rating, releaseStatus, created, updated string, latin *string, localized map[string]LocalizedText, releaseDate, releasePrecision *string, cover, banner *CoverSlot, claim *Claim) (Work, bool) {
 	if _, ok := MediumFromKey(medium); !ok {
 		return Work{}, false
 	}

--- a/apps/api/internal/platform/catalog/dto/public_dto.go
+++ b/apps/api/internal/platform/catalog/dto/public_dto.go
@@ -501,6 +501,7 @@ type PublicCoverSlot struct {
 	Sexual    int16  `json:"sexual"`
 	Violence  int16  `json:"violence"`
 	Source    string `json:"source"`
+	Origin    string `json:"origin" enum:"cover,screenshot" doc:"Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover"`
 }
 
 type PublicWorkCoverSlots struct {

--- a/apps/api/internal/platform/catalog/service/public_cover_slots.go
+++ b/apps/api/internal/platform/catalog/service/public_cover_slots.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"api/internal/platform/catalog/dto"
+	"api/internal/platform/catalog/model"
+)
+
+func isPortraitDims(w, h int) bool { return int64(h)*20 > int64(w)*21 }
+
+func isBannerDims(w, h int) bool { return int64(w)*3 >= int64(h)*4 }
+
+const (
+	bannerMinWidth   = 800
+	portraitMinWidth = 500
+)
+
+func isCoverArt(kind string) bool {
+	switch kind {
+	case "pkgfront", "pkgback", "pkgmed", "pkgcontent", "pkgside":
+		return false
+	default:
+		return true
+	}
+}
+
+func (s *PublicService) pickCoverSlots(rows []WorkCoverRow, meta map[string]ImageMeta, allowSexual bool) *dto.PublicWorkCoverSlots {
+	cand := s.scanCovers(rows, meta, false)
+	if allowSexual && !cand.complete() {
+		cand.fillFrom(s.scanCovers(rows, meta, true))
+	}
+	portrait, banner := s.coverSlot(cand.portrait(), meta), s.coverSlot(cand.banner(), meta)
+	if portrait == nil && banner == nil {
+		return nil
+	}
+	return &dto.PublicWorkCoverSlots{Portrait: portrait, Banner: banner}
+}
+
+type coverCandidates struct {
+	pinned                    *WorkCoverRow
+	portraitWide, portraitAny *WorkCoverRow
+	bannerWide, bannerAny     *WorkCoverRow
+	first                     *WorkCoverRow
+}
+
+func (c coverCandidates) portrait() *WorkCoverRow {
+	switch {
+	case c.pinned != nil:
+		return c.pinned
+	case c.portraitWide != nil:
+		return c.portraitWide
+	case c.portraitAny != nil:
+		return c.portraitAny
+	default:
+		return c.first
+	}
+}
+
+func (c coverCandidates) banner() *WorkCoverRow {
+	if c.bannerWide != nil {
+		return c.bannerWide
+	}
+	return c.bannerAny
+}
+
+func (c coverCandidates) complete() bool {
+	return c.pinned != nil && c.portraitWide != nil && c.portraitAny != nil &&
+		c.bannerWide != nil && c.bannerAny != nil && c.first != nil
+}
+
+func (c *coverCandidates) fillFrom(other coverCandidates) {
+	for _, pair := range []struct{ dst, src **WorkCoverRow }{
+		{&c.pinned, &other.pinned}, {&c.portraitWide, &other.portraitWide},
+		{&c.portraitAny, &other.portraitAny}, {&c.bannerWide, &other.bannerWide},
+		{&c.bannerAny, &other.bannerAny}, {&c.first, &other.first},
+	} {
+		if *pair.dst == nil {
+			*pair.dst = *pair.src
+		}
+	}
+}
+
+func (s *PublicService) scanCovers(rows []WorkCoverRow, meta map[string]ImageMeta, allowSexual bool) coverCandidates {
+	var out coverCandidates
+	for i := range rows {
+		c := &rows[i]
+		if !isCoverArt(c.Kind) {
+			continue
+		}
+		if !allowSexual && c.Sexual >= model.SexualExplicit {
+			continue
+		}
+		if s.imageURL(c.ImageHash) == "" {
+			continue
+		}
+		if out.first == nil {
+			out.first = c
+		}
+		m, ok := meta[c.ImageHash]
+		dimsKnown := ok && m.Width > 0 && m.Height > 0
+		// The forum-side pin write path has no shape gate, so production carries
+		// landscape rows flagged portrait_pinned — a 1920x1080 promo banner pinned
+		// as the card face. An unmeasured pin is still honoured; a measured one
+		// must be portrait to take the slot.
+		if c.PortraitPinned && out.pinned == nil && (!dimsKnown || isPortraitDims(m.Width, m.Height)) {
+			out.pinned = c
+		}
+		if !dimsKnown {
+			continue
+		}
+		switch {
+		case isPortraitDims(m.Width, m.Height):
+			out.portraitAny = sharperCover(out.portraitAny, c, meta)
+			if m.Width >= portraitMinWidth {
+				out.portraitWide = sharperCover(out.portraitWide, c, meta)
+			}
+		case isBannerDims(m.Width, m.Height):
+			out.bannerAny = sharperCover(out.bannerAny, c, meta)
+			if m.Width >= bannerMinWidth {
+				out.bannerWide = sharperCover(out.bannerWide, c, meta)
+			}
+		}
+	}
+	return out
+}
+
+func sharperCover(cur, next *WorkCoverRow, meta map[string]ImageMeta) *WorkCoverRow {
+	if cur == nil {
+		return next
+	}
+	a, b := pixelArea(meta[cur.ImageHash]), pixelArea(meta[next.ImageHash])
+	if a != b {
+		if b > a {
+			return next
+		}
+		return cur
+	}
+	if next.ImageHash < cur.ImageHash {
+		return next
+	}
+	return cur
+}
+
+func pixelArea(m ImageMeta) int64 { return int64(m.Width) * int64(m.Height) }
+
+func (s *PublicService) coverSlot(c *WorkCoverRow, meta map[string]ImageMeta) *dto.PublicCoverSlot {
+	if c == nil {
+		return nil
+	}
+	slot := &dto.PublicCoverSlot{
+		URL: s.imageURL(c.ImageHash), Sexual: c.Sexual, Violence: c.Violence,
+		Source: s.sourceKey(c.SourceID), Origin: "cover",
+	}
+	if m, ok := meta[c.ImageHash]; ok {
+		slot.Width, slot.Height, slot.Thumbhash = m.Width, m.Height, m.Thumbhash
+	}
+	return slot
+}
+
+func bannerMissing(slots *dto.PublicWorkCoverSlots) bool {
+	return slots == nil || slots.Banner == nil
+}
+
+func (s *PublicService) fillBannerFromScreenshots(
+	slots *dto.PublicWorkCoverSlots, shots []WorkScreenshotRow, meta map[string]ImageMeta, allowSexual bool,
+) *dto.PublicWorkCoverSlots {
+	best := s.pickBannerScreenshot(shots, meta, false)
+	if best == nil && allowSexual {
+		best = s.pickBannerScreenshot(shots, meta, true)
+	}
+	if best == nil {
+		return slots
+	}
+	if slots == nil {
+		slots = &dto.PublicWorkCoverSlots{}
+	}
+	slots.Banner = s.screenshotSlot(best, meta)
+	return slots
+}
+
+func (s *PublicService) pickBannerScreenshot(rows []WorkScreenshotRow, meta map[string]ImageMeta, allowSexual bool) *WorkScreenshotRow {
+	var best *WorkScreenshotRow
+	var bestMeta ImageMeta
+	for i := range rows {
+		sc := &rows[i]
+		if !allowSexual && sc.Sexual >= model.SexualExplicit {
+			continue
+		}
+		if s.imageURL(sc.ImageHash) == "" {
+			continue
+		}
+		m, ok := meta[sc.ImageHash]
+		if !ok || m.Width <= 0 || m.Height <= 0 || !isBannerDims(m.Width, m.Height) {
+			continue
+		}
+		if best == nil || betterBannerShot(*sc, m, *best, bestMeta) {
+			best, bestMeta = sc, m
+		}
+	}
+	return best
+}
+
+func betterBannerShot(a WorkScreenshotRow, am ImageMeta, b WorkScreenshotRow, bm ImageMeta) bool {
+	if a.Sexual != b.Sexual {
+		return a.Sexual < b.Sexual
+	}
+	if aWide, bWide := am.Width >= bannerMinWidth, bm.Width >= bannerMinWidth; aWide != bWide {
+		return aWide
+	}
+	if aArea, bArea := pixelArea(am), pixelArea(bm); aArea != bArea {
+		return aArea > bArea
+	}
+	return a.ImageHash < b.ImageHash
+}
+
+func (s *PublicService) screenshotSlot(sc *WorkScreenshotRow, meta map[string]ImageMeta) *dto.PublicCoverSlot {
+	slot := &dto.PublicCoverSlot{
+		URL: s.imageURL(sc.ImageHash), Sexual: sc.Sexual, Violence: sc.Violence,
+		Source: s.sourceKey(sc.SourceID), Origin: "screenshot",
+	}
+	if m, ok := meta[sc.ImageHash]; ok {
+		slot.Width, slot.Height, slot.Thumbhash = m.Width, m.Height, m.Thumbhash
+	}
+	return slot
+}

--- a/apps/api/internal/platform/catalog/service/public_cover_slots_test.go
+++ b/apps/api/internal/platform/catalog/service/public_cover_slots_test.go
@@ -1,11 +1,44 @@
 package service
 
-import "testing"
+import (
+	"testing"
+
+	"api/internal/platform/catalog/dto"
+)
 
 func slotSvc() *PublicService { return &PublicService{cdnBase: testCDNBase} }
 
 func slotRow(seed, kind string, pinned bool) WorkCoverRow {
 	return WorkCoverRow{ImageHash: hash64(seed), Kind: kind, PortraitPinned: pinned}
+}
+
+func shotRow(seed string, sexual int16) WorkScreenshotRow {
+	return WorkScreenshotRow{ImageHash: hash64(seed), Sexual: sexual}
+}
+
+// slotsWith mirrors both production call sites: the cover ladder first, the
+// screenshot fallback only when the banner came back empty.
+func slotsWith(svc *PublicService, covers []WorkCoverRow, shots []WorkScreenshotRow,
+	meta map[string]ImageMeta, allowSexual bool) *dto.PublicWorkCoverSlots {
+	slots := svc.pickCoverSlots(covers, meta, allowSexual)
+	if bannerMissing(slots) {
+		slots = svc.fillBannerFromScreenshots(slots, shots, meta, allowSexual)
+	}
+	return slots
+}
+
+func bannerOf(slots *dto.PublicWorkCoverSlots) *dto.PublicCoverSlot {
+	if slots == nil {
+		return nil
+	}
+	return slots.Banner
+}
+
+func portraitOf(slots *dto.PublicWorkCoverSlots) *dto.PublicCoverSlot {
+	if slots == nil {
+		return nil
+	}
+	return slots.Portrait
 }
 
 func TestDiscFaceIsNeverABanner(t *testing.T) {
@@ -40,6 +73,7 @@ func TestBannerNeedsWidthAndArtwork(t *testing.T) {
 		{"exactly 4:3 qualifies", "main", 1024, 768, true},
 		{"just short of 4:3 is not hero art", "main", 1000, 768, false},
 		{"near-square is not hero art", "main", 1084, 1080, false},
+		{"wide but a photo of the box front", "pkgfront", 1920, 1080, false},
 		{"wide but a photo of the box back", "pkgback", 1920, 1080, false},
 		{"wide but a booklet page", "pkgcontent", 1920, 1080, false},
 		{"wide but a spine", "pkgside", 1920, 1080, false},
@@ -50,29 +84,105 @@ func TestBannerNeedsWidthAndArtwork(t *testing.T) {
 			row := slotRow("bb01", c.kind, false)
 			slots := svc.pickCoverSlots([]WorkCoverRow{row},
 				map[string]ImageMeta{row.ImageHash: {Width: c.w, Height: c.h}}, false)
-			if got := slots.Banner != nil; got != c.wantBanner {
+			if got := bannerOf(slots) != nil; got != c.wantBanner {
 				t.Fatalf("banner filled = %v, want %v (%dx%d %q)", got, c.wantBanner, c.w, c.h, c.kind)
 			}
 		})
 	}
 }
 
-func TestPortraitPrefersArtworkButFallsBack(t *testing.T) {
+func TestPackageArtIsNeverElected(t *testing.T) {
 	svc := slotSvc()
-	back, front := slotRow("0bac", "pkgback", false), slotRow("0f20", "pkgfront", false)
+	front, back := slotRow("0f20", "pkgfront", false), slotRow("0bac", "pkgback", false)
 	meta := map[string]ImageMeta{
-		back.ImageHash:  {Width: 800, Height: 1200},
 		front.ImageHash: {Width: 700, Height: 1000},
+		back.ImageHash:  {Width: 800, Height: 1200},
 	}
 
-	slots := svc.pickCoverSlots([]WorkCoverRow{back, front}, meta, false)
-	if slots.Portrait == nil || slots.Portrait.URL != svc.imageURL(front.ImageHash) {
-		t.Fatalf("portrait = %+v, want the package front", slots.Portrait)
+	if slots := svc.pickCoverSlots([]WorkCoverRow{front, back}, meta, false); slots != nil {
+		t.Fatalf("slots = %+v, want null: a scan of the physical case is not this work's art", slots)
 	}
 
-	slots = svc.pickCoverSlots([]WorkCoverRow{back}, meta, false)
-	if slots.Portrait == nil || slots.Portrait.URL != svc.imageURL(back.ImageHash) {
-		t.Fatalf("portrait = %+v, want the box back as the last resort", slots.Portrait)
+	front.PortraitPinned = true
+	if slots := svc.pickCoverSlots([]WorkCoverRow{front, back}, meta, false); slots != nil {
+		t.Fatalf("slots = %+v, want null even for a pinned pkgfront: the read face neutralises "+
+			"the ~258 package pins the retired repin ladder left behind", slots)
+	}
+
+	art := slotRow("a71a", "dig", false)
+	meta[art.ImageHash] = ImageMeta{Width: 600, Height: 900}
+	slots := svc.pickCoverSlots([]WorkCoverRow{front, back, art}, meta, false)
+	if portraitOf(slots) == nil || slots.Portrait.URL != svc.imageURL(art.ImageHash) {
+		t.Fatalf("portrait = %+v, want the digital art over a pinned package front", portraitOf(slots))
+	}
+}
+
+func TestSharpestWinsWithinACategory(t *testing.T) {
+	svc := slotSvc()
+	small, big := slotRow("5111", "dig", false), slotRow("b166", "dig", false)
+	wideSmall, wideBig := slotRow("w511", "main", false), slotRow("w166", "main", false)
+	meta := map[string]ImageMeta{
+		small.ImageHash:     {Width: 600, Height: 900},
+		big.ImageHash:       {Width: 1200, Height: 1800},
+		wideSmall.ImageHash: {Width: 960, Height: 540},
+		wideBig.ImageHash:   {Width: 1920, Height: 1080},
+	}
+
+	slots := svc.pickCoverSlots([]WorkCoverRow{small, big, wideSmall, wideBig}, meta, false)
+	if portraitOf(slots) == nil || slots.Portrait.URL != svc.imageURL(big.ImageHash) {
+		t.Fatalf("portrait = %+v, want the larger portrait, not the first in sort order", portraitOf(slots))
+	}
+	if bannerOf(slots) == nil || slots.Banner.URL != svc.imageURL(wideBig.ImageHash) {
+		t.Fatalf("banner = %+v, want the larger wide cover", bannerOf(slots))
+	}
+}
+
+func TestEqualAreaBreaksOnHash(t *testing.T) {
+	svc := slotSvc()
+	a, b := slotRow("aaa1", "dig", false), slotRow("0001", "dig", false)
+	meta := map[string]ImageMeta{
+		a.ImageHash: {Width: 600, Height: 900},
+		b.ImageHash: {Width: 600, Height: 900},
+	}
+	slots := svc.pickCoverSlots([]WorkCoverRow{a, b}, meta, false)
+	if portraitOf(slots) == nil || slots.Portrait.URL != svc.imageURL(b.ImageHash) {
+		t.Fatalf("portrait = %+v, want the lexicographically smaller hash", portraitOf(slots))
+	}
+}
+
+func TestSafeCoverBeatsALargerExplicitOne(t *testing.T) {
+	svc := slotSvc()
+	huge, safe := slotRow("5e59", "dig", false), slotRow("5afe", "dig", false)
+	huge.Sexual = 2
+	meta := map[string]ImageMeta{
+		huge.ImageHash: {Width: 2000, Height: 3000},
+		safe.ImageHash: {Width: 600, Height: 900},
+	}
+	slots := svc.pickCoverSlots([]WorkCoverRow{huge, safe}, meta, true)
+	if portraitOf(slots) == nil || slots.Portrait.URL != svc.imageURL(safe.ImageHash) {
+		t.Fatalf("portrait = %+v, want the display-safe cover: the sexual pass fills only the "+
+			"categories the safe pass left empty, so area never crosses the two passes", portraitOf(slots))
+	}
+}
+
+func TestPortraitWidthTierBeatsArea(t *testing.T) {
+	svc := slotSvc()
+	narrow, wide := slotRow("2a11", "dig", false), slotRow("f011", "dig", false)
+	meta := map[string]ImageMeta{
+		narrow.ImageHash: {Width: 400, Height: 4000},
+		wide.ImageHash:   {Width: 500, Height: 750},
+	}
+
+	slots := svc.pickCoverSlots([]WorkCoverRow{narrow, wide}, meta, false)
+	if portraitOf(slots) == nil || slots.Portrait.URL != svc.imageURL(wide.ImageHash) {
+		t.Fatalf("portrait = %+v, want the 500px-wide cover: the tier is checked before area, "+
+			"so a taller sliver does not win on pixel count", portraitOf(slots))
+	}
+
+	slots = svc.pickCoverSlots([]WorkCoverRow{narrow}, meta, false)
+	if portraitOf(slots) == nil || slots.Portrait.URL != svc.imageURL(narrow.ImageHash) {
+		t.Fatalf("portrait = %+v, want the sub-500px portrait when nothing wider exists: "+
+			"500 is a tier, not a gate", portraitOf(slots))
 	}
 }
 
@@ -172,15 +282,176 @@ func TestPortraitPrefersDisplaySafeOverAnExplicitPin(t *testing.T) {
 	}
 }
 
-func TestPinnedRowWinsWhateverItsKind(t *testing.T) {
+func TestLandscapePinDoesNotTakeThePortraitSlot(t *testing.T) {
 	svc := slotSvc()
-	pinned, art := slotRow("9911", "pkgmed", true), slotRow("22aa", "dig", false)
+	promo, tall := slotRow("9d1a", "dig", true), slotRow("7a11", "dig", false)
 	meta := map[string]ImageMeta{
-		pinned.ImageHash: {Width: 900, Height: 1200},
-		art.ImageHash:    {Width: 720, Height: 1080},
+		promo.ImageHash: {Width: 1920, Height: 1080},
+		tall.ImageHash:  {Width: 600, Height: 900},
 	}
-	slots := svc.pickCoverSlots([]WorkCoverRow{art, pinned}, meta, false)
-	if slots.Portrait == nil || slots.Portrait.URL != svc.imageURL(pinned.ImageHash) {
-		t.Fatalf("portrait = %+v, want the pinned row", slots.Portrait)
+
+	slots := svc.pickCoverSlots([]WorkCoverRow{promo, tall}, meta, false)
+	if portraitOf(slots) == nil || slots.Portrait.URL != svc.imageURL(tall.ImageHash) {
+		t.Fatalf("portrait = %+v, want the portrait sibling: the pin write path has no shape "+
+			"gate, so a 1920x1080 promo banner can carry portrait_pinned", portraitOf(slots))
+	}
+	if bannerOf(slots) == nil || slots.Banner.URL != svc.imageURL(promo.ImageHash) {
+		t.Fatalf("banner = %+v, want the pinned landscape row: it is still a candidate "+
+			"everywhere its shape fits", bannerOf(slots))
+	}
+
+	slots = svc.pickCoverSlots([]WorkCoverRow{promo}, meta, false)
+	if portraitOf(slots) == nil || slots.Portrait.URL != svc.imageURL(promo.ImageHash) {
+		t.Fatalf("portrait = %+v, want the last-resort first row when nothing portrait exists",
+			portraitOf(slots))
+	}
+}
+
+func TestUnmeasuredPinIsStillHonoured(t *testing.T) {
+	svc := slotSvc()
+	blind, tall := slotRow("9d1a", "dig", true), slotRow("7a11", "dig", false)
+	meta := map[string]ImageMeta{tall.ImageHash: {Width: 600, Height: 900}}
+
+	slots := svc.pickCoverSlots([]WorkCoverRow{blind, tall}, meta, false)
+	if portraitOf(slots) == nil || slots.Portrait.URL != svc.imageURL(blind.ImageHash) {
+		t.Fatalf("portrait = %+v, want the pin: an unmeasured row cannot fail a shape guard, "+
+			"and dropping it would blank every work image_service has not measured yet",
+			portraitOf(slots))
+	}
+}
+
+func TestSlotsCarryTheirOrigin(t *testing.T) {
+	svc := slotSvc()
+	art := slotRow("0a71", "dig", false)
+	shot := shotRow("55ff", 0)
+	meta := map[string]ImageMeta{
+		art.ImageHash:  {Width: 600, Height: 900},
+		shot.ImageHash: {Width: 1920, Height: 1080},
+	}
+
+	slots := slotsWith(svc, []WorkCoverRow{art}, []WorkScreenshotRow{shot}, meta, false)
+	if portraitOf(slots) == nil || slots.Portrait.Origin != "cover" {
+		t.Fatalf("portrait = %+v, want origin \"cover\"", portraitOf(slots))
+	}
+	if bannerOf(slots) == nil || slots.Banner.Origin != "screenshot" {
+		t.Fatalf("banner = %+v, want origin \"screenshot\"", bannerOf(slots))
+	}
+	if slots.Banner.URL != svc.imageURL(shot.ImageHash) {
+		t.Fatalf("banner url = %q, want the screenshot", slots.Banner.URL)
+	}
+}
+
+func TestScreenshotFallbackOnlyFillsAnEmptyBanner(t *testing.T) {
+	svc := slotSvc()
+	wide, shot := slotRow("b166", "dig", false), shotRow("55ff", 0)
+	meta := map[string]ImageMeta{
+		wide.ImageHash: {Width: 1920, Height: 1080},
+		shot.ImageHash: {Width: 3840, Height: 2160},
+	}
+	slots := slotsWith(svc, []WorkCoverRow{wide}, []WorkScreenshotRow{shot}, meta, false)
+	if bannerOf(slots) == nil || slots.Banner.Origin != "cover" {
+		t.Fatalf("banner = %+v, want the cover: a bigger screenshot never displaces a landscape cover",
+			bannerOf(slots))
+	}
+}
+
+func TestScreenshotFallbackRanksSafeThenWideThenArea(t *testing.T) {
+	svc := slotSvc()
+	tall := slotRow("7a11", "dig", false)
+	bigHot, safe := shotRow("5e59", 1), shotRow("5afe", 0)
+	narrowBig, wideSlim, bigWide := shotRow("0011", 0), shotRow("0022", 0), shotRow("0033", 0)
+	meta := map[string]ImageMeta{
+		tall.ImageHash:      {Width: 600, Height: 900},
+		bigHot.ImageHash:    {Width: 3840, Height: 2160},
+		safe.ImageHash:      {Width: 1280, Height: 720},
+		narrowBig.ImageHash: {Width: 780, Height: 585},
+		wideSlim.ImageHash:  {Width: 800, Height: 100},
+		bigWide.ImageHash:   {Width: 1920, Height: 1080},
+	}
+
+	slots := slotsWith(svc, []WorkCoverRow{tall}, []WorkScreenshotRow{bigHot, safe}, meta, false)
+	if bannerOf(slots) == nil || slots.Banner.URL != svc.imageURL(safe.ImageHash) {
+		t.Fatalf("banner = %+v, want the sexual=0 screenshot over the far larger sexual=1 one",
+			bannerOf(slots))
+	}
+
+	slots = slotsWith(svc, []WorkCoverRow{tall}, []WorkScreenshotRow{narrowBig, wideSlim}, meta, false)
+	if bannerOf(slots) == nil || slots.Banner.URL != svc.imageURL(wideSlim.ImageHash) {
+		t.Fatalf("banner = %+v, want the 800px-wide screenshot: the wide tier is checked before area",
+			bannerOf(slots))
+	}
+
+	slots = slotsWith(svc, []WorkCoverRow{tall}, []WorkScreenshotRow{safe, bigWide}, meta, false)
+	if bannerOf(slots) == nil || slots.Banner.URL != svc.imageURL(bigWide.ImageHash) {
+		t.Fatalf("banner = %+v, want the larger screenshot inside the wide tier", bannerOf(slots))
+	}
+}
+
+func TestScreenshotFallbackHonoursTheWorksPermission(t *testing.T) {
+	svc := slotSvc()
+	tall := slotRow("7a11", "dig", false)
+	hot := shotRow("5e59", 2)
+	meta := map[string]ImageMeta{
+		tall.ImageHash: {Width: 600, Height: 900},
+		hot.ImageHash:  {Width: 1920, Height: 1080},
+	}
+
+	slots := slotsWith(svc, []WorkCoverRow{tall}, []WorkScreenshotRow{hot}, meta, false)
+	if bannerOf(slots) != nil {
+		t.Fatalf("banner = %+v, want null: an explicit screenshot is not a display-safe banner",
+			bannerOf(slots))
+	}
+	slots = slotsWith(svc, []WorkCoverRow{tall}, []WorkScreenshotRow{hot}, meta, true)
+	if bannerOf(slots) == nil || slots.Banner.URL != svc.imageURL(hot.ImageHash) {
+		t.Fatalf("banner = %+v, want the explicit screenshot once the work permits it", bannerOf(slots))
+	}
+}
+
+func TestPortraitNeverComesFromAScreenshot(t *testing.T) {
+	svc := slotSvc()
+	front := slotRow("0f20", "pkgfront", false)
+	tallShot, wideShot := shotRow("7a11", 0), shotRow("55ff", 0)
+	meta := map[string]ImageMeta{
+		front.ImageHash:    {Width: 700, Height: 1000},
+		tallShot.ImageHash: {Width: 600, Height: 900},
+		wideShot.ImageHash: {Width: 1920, Height: 1080},
+	}
+
+	slots := slotsWith(svc, []WorkCoverRow{front}, []WorkScreenshotRow{tallShot, wideShot}, meta, false)
+	if portraitOf(slots) != nil {
+		t.Fatalf("portrait = %+v, want null: a scene still never stands in for box art", portraitOf(slots))
+	}
+	if bannerOf(slots) == nil || slots.Banner.Origin != "screenshot" {
+		t.Fatalf("banner = %+v, want the landscape screenshot", bannerOf(slots))
+	}
+}
+
+func TestSlotsAreNilOnlyWhenBothEndEmpty(t *testing.T) {
+	svc := slotSvc()
+	front := slotRow("0f20", "pkgfront", false)
+	tallShot := shotRow("7a11", 0)
+	meta := map[string]ImageMeta{
+		front.ImageHash:    {Width: 700, Height: 1000},
+		tallShot.ImageHash: {Width: 600, Height: 900},
+	}
+
+	if slots := slotsWith(svc, []WorkCoverRow{front}, nil, meta, false); slots != nil {
+		t.Fatalf("slots = %+v, want null: package art only and no screenshots", slots)
+	}
+	if slots := slotsWith(svc, []WorkCoverRow{front}, []WorkScreenshotRow{tallShot}, meta, false); slots != nil {
+		t.Fatalf("slots = %+v, want null: a portrait screenshot fills neither slot", slots)
+	}
+}
+
+func TestListCoverSkipsPackageArt(t *testing.T) {
+	svc := slotSvc()
+	front, back := slotRow("0f20", "pkgfront", true), slotRow("0bac", "pkgback", false)
+	art := slotRow("a71a", "dig", false)
+
+	if got := svc.pickListCover([]WorkCoverRow{front, back}, false); got != "" {
+		t.Fatalf("cover = %q, want empty: even a pinned pkgfront is not this work's art", got)
+	}
+	if got := svc.pickListCover([]WorkCoverRow{front, back, art}, false); got != svc.imageURL(art.ImageHash) {
+		t.Fatalf("cover = %q, want the digital art", got)
 	}
 }

--- a/apps/api/internal/platform/catalog/service/public_service.go
+++ b/apps/api/internal/platform/catalog/service/public_service.go
@@ -283,7 +283,7 @@ func (s *PublicService) WorkDetail(ctx context.Context, id int64, inc PublicIncl
 		Updated:       w.UpdatedAt.UTC().Format(time.RFC3339),
 	}
 	if err = s.attachWorkFacets(ctx, &rec, detail, nsfw,
-		effectiveDisplayNSFW(w.Site, w.ProductWorkID, limits[w.ID], w.ContentRating), spoilers); err != nil {
+		effectiveDisplayNSFW(w.Site, w.ProductWorkID, limits[w.ID], w.ContentRating), spoilers, sel); err != nil {
 		return dto.PublicCatalogWork{}, false, err
 	}
 	if sel.Wants("releases") {
@@ -396,7 +396,7 @@ func (s *PublicService) publicRelations(rels []WorkRelationRow, nsfw bool, limit
 	return out
 }
 
-func (s *PublicService) attachWorkFacets(ctx context.Context, rec *dto.PublicCatalogWork, detail *WorkDetail, nsfw, displayNSFW bool, spoilers int16) error {
+func (s *PublicService) attachWorkFacets(ctx context.Context, rec *dto.PublicCatalogWork, detail *WorkDetail, nsfw, displayNSFW bool, spoilers int16, sel PublicFields) error {
 	rec.Releases = s.publicWorkReleases(detail.Releases)
 	rec.Popularity = make([]dto.PublicPopularity, 0, len(detail.Popularity))
 	for _, p := range detail.Popularity {
@@ -429,6 +429,11 @@ func (s *PublicService) attachWorkFacets(ctx context.Context, rec *dto.PublicCat
 	}
 	rec.Covers = covers
 	rec.CoverSlots = s.pickCoverSlots(detail.Covers, imgMeta, nsfw && displayNSFW)
+	if sel.Wants("cover_slots") && bannerMissing(rec.CoverSlots) {
+		if rec.CoverSlots, err = s.fillDetailBanner(ctx, rec.CoverSlots, detail, imgMeta, nsfw && displayNSFW, sel); err != nil {
+			return err
+		}
+	}
 	rec.Screenshots = s.publicScreenshots(detail.Screenshots, imgMeta)
 	rec.Characters = s.publicRoster(detail.Characters, imgMeta)
 	rec.Labels = publicWorkLabels(detail.Labels)
@@ -436,6 +441,21 @@ func (s *PublicService) attachWorkFacets(ctx context.Context, rec *dto.PublicCat
 		rec.Labels = []dto.PublicWorkLabel{}
 	}
 	return nil
+}
+
+func (s *PublicService) fillDetailBanner(
+	ctx context.Context, slots *dto.PublicWorkCoverSlots, detail *WorkDetail,
+	imgMeta map[string]ImageMeta, allowSexual bool, sel PublicFields,
+) (*dto.PublicWorkCoverSlots, error) {
+	if sel.Wants("screenshots") {
+		return s.fillBannerFromScreenshots(slots, detail.Screenshots, imgMeta, allowSexual), nil
+	}
+	byWork, err := s.read.loadWorkScreenshots(ctx, []claimSubject{{WorkID: detail.Work.ID}})
+	if err != nil {
+		return nil, err
+	}
+	shots := byWork[detail.Work.ID]
+	return s.fillBannerFromScreenshots(slots, shots, s.workMediaMetaFor(ctx, nil, shots), allowSexual), nil
 }
 
 func (s *PublicService) imageURL(hash string) string {

--- a/apps/api/internal/platform/catalog/service/public_works_include.go
+++ b/apps/api/internal/platform/catalog/service/public_works_include.go
@@ -126,14 +126,8 @@ func (s *PublicService) attachWorkListBlocks(
 		}
 	}
 	if inc.Covers {
-		all := make([]WorkCoverRow, 0, len(rows))
-		for _, r := range rows {
-			all = append(all, covers[r.ID]...)
-		}
-		meta := s.coverMetaFor(ctx, all)
-		for i, r := range rows {
-			items[i].Covers = s.pickCoverSlots(covers[r.ID], meta,
-				nsfw && effectiveDisplayNSFW(r.Site, r.ProductWorkID, displayNSFW[r.ID], r.ContentRating))
+		if err := s.attachWorkListCoverSlots(ctx, items, rows, nsfw, covers, displayNSFW); err != nil {
+			return err
 		}
 	}
 	if inc.Refs {
@@ -160,6 +154,44 @@ func (s *PublicService) attachWorkListBlocks(
 	if inc.Credits {
 		if err := s.attachWorkListCredits(ctx, items, rows, ids); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func (s *PublicService) attachWorkListCoverSlots(
+	ctx context.Context, items []dto.PublicWorkListItem, rows []workListSourceRow, nsfw bool,
+	covers map[int64][]WorkCoverRow, displayNSFW map[int64]bool,
+) error {
+	all := make([]WorkCoverRow, 0, len(rows))
+	for _, r := range rows {
+		all = append(all, covers[r.ID]...)
+	}
+	meta := s.coverMetaFor(ctx, all)
+	allow := make([]bool, len(rows))
+	var needShots []claimSubject
+	for i, r := range rows {
+		allow[i] = nsfw && effectiveDisplayNSFW(r.Site, r.ProductWorkID, displayNSFW[r.ID], r.ContentRating)
+		items[i].Covers = s.pickCoverSlots(covers[r.ID], meta, allow[i])
+		if bannerMissing(items[i].Covers) {
+			needShots = append(needShots, claimSubject{WorkID: r.ID})
+		}
+	}
+	if len(needShots) == 0 {
+		return nil
+	}
+	shots, err := s.read.loadWorkScreenshots(ctx, needShots)
+	if err != nil {
+		return err
+	}
+	flat := make([]WorkScreenshotRow, 0, len(needShots))
+	for _, sub := range needShots {
+		flat = append(flat, shots[sub.WorkID]...)
+	}
+	shotMeta := s.workMediaMetaFor(ctx, nil, flat)
+	for i, r := range rows {
+		if bannerMissing(items[i].Covers) {
+			items[i].Covers = s.fillBannerFromScreenshots(items[i].Covers, shots[r.ID], shotMeta, allow[i])
 		}
 	}
 	return nil
@@ -305,130 +337,4 @@ func (s *PublicService) publicRatings(rows []WorkRatingRow) []dto.PublicRating {
 		})
 	}
 	return out
-}
-
-func isPortraitDims(w, h int) bool { return int64(h)*20 > int64(w)*21 }
-
-func isBannerDims(w, h int) bool { return int64(w)*3 >= int64(h)*4 }
-
-const bannerMinWidth = 800
-
-func isCoverArt(kind string) bool {
-	switch kind {
-	case "pkgback", "pkgmed", "pkgcontent", "pkgside":
-		return false
-	default:
-		return true
-	}
-}
-
-func (s *PublicService) pickCoverSlots(rows []WorkCoverRow, meta map[string]ImageMeta, allowSexual bool) *dto.PublicWorkCoverSlots {
-	cand := s.scanCovers(rows, meta, false)
-	if allowSexual && !cand.complete() {
-		cand.fillFrom(s.scanCovers(rows, meta, true))
-	}
-	if cand.first == nil {
-		return nil
-	}
-	return &dto.PublicWorkCoverSlots{
-		Portrait: s.coverSlot(cand.portrait(), meta),
-		Banner:   s.coverSlot(cand.banner(), meta),
-	}
-}
-
-type coverCandidates struct {
-	pinned, portraitArt, portraitAny *WorkCoverRow
-	bannerWide, bannerAny            *WorkCoverRow
-	first                            *WorkCoverRow
-}
-
-func (c coverCandidates) portrait() *WorkCoverRow {
-	switch {
-	case c.pinned != nil:
-		return c.pinned
-	case c.portraitArt != nil:
-		return c.portraitArt
-	case c.portraitAny != nil:
-		return c.portraitAny
-	default:
-		return c.first
-	}
-}
-
-func (c coverCandidates) banner() *WorkCoverRow {
-	if c.bannerWide != nil {
-		return c.bannerWide
-	}
-	return c.bannerAny
-}
-
-func (c coverCandidates) complete() bool {
-	return c.pinned != nil && c.portraitArt != nil && c.portraitAny != nil &&
-		c.bannerWide != nil && c.bannerAny != nil && c.first != nil
-}
-
-func (c *coverCandidates) fillFrom(other coverCandidates) {
-	for _, pair := range []struct{ dst, src **WorkCoverRow }{
-		{&c.pinned, &other.pinned}, {&c.portraitArt, &other.portraitArt},
-		{&c.portraitAny, &other.portraitAny}, {&c.bannerWide, &other.bannerWide},
-		{&c.bannerAny, &other.bannerAny}, {&c.first, &other.first},
-	} {
-		if *pair.dst == nil {
-			*pair.dst = *pair.src
-		}
-	}
-}
-
-func (s *PublicService) scanCovers(rows []WorkCoverRow, meta map[string]ImageMeta, allowSexual bool) coverCandidates {
-	var out coverCandidates
-	for i := range rows {
-		c := &rows[i]
-		if !allowSexual && c.Sexual >= model.SexualExplicit {
-			continue
-		}
-		if s.imageURL(c.ImageHash) == "" {
-			continue
-		}
-		if out.first == nil {
-			out.first = c
-		}
-		if c.PortraitPinned && out.pinned == nil {
-			out.pinned = c
-		}
-		m, ok := meta[c.ImageHash]
-		if !ok || m.Width <= 0 || m.Height <= 0 {
-			continue
-		}
-		switch {
-		case isPortraitDims(m.Width, m.Height):
-			if out.portraitAny == nil {
-				out.portraitAny = c
-			}
-			if isCoverArt(c.Kind) && out.portraitArt == nil {
-				out.portraitArt = c
-			}
-		case isBannerDims(m.Width, m.Height) && isCoverArt(c.Kind):
-			if out.bannerAny == nil {
-				out.bannerAny = c
-			}
-			if m.Width >= bannerMinWidth && out.bannerWide == nil {
-				out.bannerWide = c
-			}
-		}
-	}
-	return out
-}
-
-func (s *PublicService) coverSlot(c *WorkCoverRow, meta map[string]ImageMeta) *dto.PublicCoverSlot {
-	if c == nil {
-		return nil
-	}
-	slot := &dto.PublicCoverSlot{
-		URL: s.imageURL(c.ImageHash), Sexual: c.Sexual, Violence: c.Violence,
-		Source: s.sourceKey(c.SourceID),
-	}
-	if m, ok := meta[c.ImageHash]; ok {
-		slot.Width, slot.Height, slot.Thumbhash = m.Width, m.Height, m.Thumbhash
-	}
-	return slot
 }

--- a/apps/api/internal/platform/catalog/service/public_works_list.go
+++ b/apps/api/internal/platform/catalog/service/public_works_list.go
@@ -416,6 +416,9 @@ func partialISOFromOrdinal(ord int64) string {
 func (s *PublicService) pickListCover(rows []WorkCoverRow, allowSexual bool) string {
 	var fallback string
 	for _, c := range rows {
+		if !isCoverArt(c.Kind) {
+			continue
+		}
 		if !allowSexual && c.Sexual >= model.SexualExplicit {
 			continue
 		}

--- a/apps/developer/app/generated/docs-model.ts
+++ b/apps/developer/app/generated/docs-model.ts
@@ -3177,6 +3177,16 @@ export const docsModel: DocsModel = {
                                   "type": "integer"
                                 },
                                 {
+                                  "name": "origin",
+                                  "required": true,
+                                  "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                                  "enum": [
+                                    "cover",
+                                    "screenshot"
+                                  ],
+                                  "type": "string"
+                                },
+                                {
                                   "name": "sexual",
                                   "required": true,
                                   "nullable": true,
@@ -3999,6 +4009,16 @@ export const docsModel: DocsModel = {
                                   "doc": "Pixel height. null if unknown.",
                                   "format": "int64",
                                   "type": "integer"
+                                },
+                                {
+                                  "name": "origin",
+                                  "required": true,
+                                  "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                                  "enum": [
+                                    "cover",
+                                    "screenshot"
+                                  ],
+                                  "type": "string"
                                 },
                                 {
                                   "name": "sexual",
@@ -10637,6 +10657,16 @@ export const docsModel: DocsModel = {
                                       "type": "integer"
                                     },
                                     {
+                                      "name": "origin",
+                                      "required": true,
+                                      "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                                      "enum": [
+                                        "cover",
+                                        "screenshot"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    {
                                       "name": "sexual",
                                       "required": true,
                                       "nullable": true,
@@ -11459,6 +11489,16 @@ export const docsModel: DocsModel = {
                                       "doc": "Pixel height. null if unknown.",
                                       "format": "int64",
                                       "type": "integer"
+                                    },
+                                    {
+                                      "name": "origin",
+                                      "required": true,
+                                      "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                                      "enum": [
+                                        "cover",
+                                        "screenshot"
+                                      ],
+                                      "type": "string"
                                     },
                                     {
                                       "name": "sexual",
@@ -21347,6 +21387,16 @@ export const docsModel: DocsModel = {
                                       "type": "integer"
                                     },
                                     {
+                                      "name": "origin",
+                                      "required": true,
+                                      "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                                      "enum": [
+                                        "cover",
+                                        "screenshot"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    {
                                       "name": "sexual",
                                       "required": true,
                                       "nullable": true,
@@ -22169,6 +22219,16 @@ export const docsModel: DocsModel = {
                                       "doc": "Pixel height. null if unknown.",
                                       "format": "int64",
                                       "type": "integer"
+                                    },
+                                    {
+                                      "name": "origin",
+                                      "required": true,
+                                      "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                                      "enum": [
+                                        "cover",
+                                        "screenshot"
+                                      ],
+                                      "type": "string"
                                     },
                                     {
                                       "name": "sexual",
@@ -50126,6 +50186,16 @@ export const docsModel: DocsModel = {
                                   "type": "integer"
                                 },
                                 {
+                                  "name": "origin",
+                                  "required": true,
+                                  "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                                  "enum": [
+                                    "cover",
+                                    "screenshot"
+                                  ],
+                                  "type": "string"
+                                },
+                                {
                                   "name": "sexual",
                                   "required": true,
                                   "nullable": true,
@@ -50948,6 +51018,16 @@ export const docsModel: DocsModel = {
                                   "doc": "Pixel height. null if unknown.",
                                   "format": "int64",
                                   "type": "integer"
+                                },
+                                {
+                                  "name": "origin",
+                                  "required": true,
+                                  "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                                  "enum": [
+                                    "cover",
+                                    "screenshot"
+                                  ],
+                                  "type": "string"
                                 },
                                 {
                                   "name": "sexual",
@@ -53032,6 +53112,16 @@ export const docsModel: DocsModel = {
                             "type": "integer"
                           },
                           {
+                            "name": "origin",
+                            "required": true,
+                            "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                            "enum": [
+                              "cover",
+                              "screenshot"
+                            ],
+                            "type": "string"
+                          },
+                          {
                             "name": "sexual",
                             "required": true,
                             "nullable": true,
@@ -53854,6 +53944,16 @@ export const docsModel: DocsModel = {
                             "doc": "Pixel height. null if unknown.",
                             "format": "int64",
                             "type": "integer"
+                          },
+                          {
+                            "name": "origin",
+                            "required": true,
+                            "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                            "enum": [
+                              "cover",
+                              "screenshot"
+                            ],
+                            "type": "string"
                           },
                           {
                             "name": "sexual",
@@ -64707,6 +64807,16 @@ export const docsModel: DocsModel = {
                                       "type": "integer"
                                     },
                                     {
+                                      "name": "origin",
+                                      "required": true,
+                                      "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                                      "enum": [
+                                        "cover",
+                                        "screenshot"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    {
                                       "name": "sexual",
                                       "required": true,
                                       "nullable": true,
@@ -65529,6 +65639,16 @@ export const docsModel: DocsModel = {
                                       "doc": "Pixel height. null if unknown.",
                                       "format": "int64",
                                       "type": "integer"
+                                    },
+                                    {
+                                      "name": "origin",
+                                      "required": true,
+                                      "doc": "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.",
+                                      "enum": [
+                                        "cover",
+                                        "screenshot"
+                                      ],
+                                      "type": "string"
                                     },
                                     {
                                       "name": "sexual",

--- a/apps/developer/i18n/docs-zh.json
+++ b/apps/developer/i18n/docs-zh.json
@@ -678,6 +678,7 @@
   "Which editor slot these bytes were sized for.": "这些字节是按哪个编辑槽缩放的。",
   "Which half of the range this total covers. null on the grand total.": "该总计覆盖区间的哪一半。总计行上为 null。",
   "Which of the source's two sections this item belongs to.": "该条目属于来源的两个分区中的哪一个。",
+  "Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.": "该图选自哪个池。screenshot 只会出现在 banner 上，是作品没有任何横版封面时的截图回落。",
   "While pending, edits title/summary/source_url/banner_hash/work_ids and sends the item back for machine scoring. Once published the only legal transition is {\"status\":\"withdrawn\"} with If-Match. rejected is terminal.": "处于 pending 时，可编辑 title/summary/source_url/banner_hash/work_ids 并把条目送回机器打分。一旦 published，唯一合法迁移是带 If-Match 的 {\"status\":\"withdrawn\"}。rejected 为终态。",
   "Wire code of the vocabulary's first token on an int member. 0 unless the model reserves 0 for null.": "int 成员上词表首个 token 的线上码。除非模型将 0 保留给 null，否则为 0。",
   "Wire code of the vocabulary's first token on an integer-coded field. 0 unless the model reserves 0 for null.": "整数编码字段上词表首个 token 的线上码。除非模型将 0 保留给 null，否则为 0。",

--- a/docs/catalog/v2-openapi.yaml
+++ b/docs/catalog/v2-openapi.yaml
@@ -1121,6 +1121,87 @@ components:
         - violence
         - source
       type: object
+    CoverSlot:
+      additionalProperties: true
+      properties:
+        hash:
+          description: Image-service content hash.
+          maxLength: 64
+          minLength: 64
+          pattern: ^[0-9a-f]{64}$
+          type: string
+        height:
+          description: Pixel height. null if unknown.
+          format: int64
+          maximum: 65535
+          minimum: 0
+          type:
+            - integer
+            - "null"
+        origin:
+          description: Which pool the image was elected from. screenshot only ever appears on banner, as the fallback for a work with no landscape cover.
+          enum:
+            - cover
+            - screenshot
+          type: string
+          x-vocabulary-closed: true
+        sexual:
+          description: Sexual depiction. null means not assessed.
+          enum:
+            - safe
+            - suggestive
+            - explicit
+          type:
+            - string
+            - "null"
+          x-vocabulary-closed: true
+        source:
+          description: Open vocabulary sources. Must not be used as a discriminant.
+          maxLength: 64
+          type: string
+          x-vocabulary: sources
+          x-vocabulary-closed: false
+        thumbhash:
+          description: Thumbhash. null if unknown.
+          maxLength: 128
+          pattern: ^[A-Za-z0-9+/=_-]+$
+          type:
+            - string
+            - "null"
+        url:
+          description: Absolute image URL. Never a bare hash.
+          format: uri
+          maxLength: 512
+          type: string
+        violence:
+          description: Violent depiction. null means not assessed. Currently no catalog row has an assessment; the value is always null.
+          enum:
+            - tame
+            - violent
+            - brutal
+          type:
+            - string
+            - "null"
+          x-vocabulary-closed: true
+        width:
+          description: Pixel width. null if unknown.
+          format: int64
+          maximum: 65535
+          minimum: 0
+          type:
+            - integer
+            - "null"
+      required:
+        - url
+        - hash
+        - width
+        - height
+        - thumbhash
+        - sexual
+        - violence
+        - source
+        - origin
+      type: object
     CoverVote:
       additionalProperties: true
       properties:
@@ -6250,8 +6331,8 @@ components:
           readOnly: true
           type: string
         banner:
-          $ref: "#/components/schemas/Image"
-          description: Selected landscape image. null if none.
+          $ref: "#/components/schemas/CoverSlot"
+          description: Selected landscape image. null if none. origin=screenshot marks the fallback for a work with no landscape cover.
         characters:
           description: Present when include=characters. Empty array if none.
           items:
@@ -6274,7 +6355,7 @@ components:
           type: string
           x-vocabulary-closed: true
         cover:
-          $ref: "#/components/schemas/Image"
+          $ref: "#/components/schemas/CoverSlot"
           description: Selected portrait image. null if none.
         covers:
           description: Present when include=covers. Empty array if none.
@@ -6842,7 +6923,7 @@ components:
 info:
   description: "NextMoe public API v2. Public since 2026-08-25: any application mints its own nmk_ key in the developer portal, no approval required. The shape evolves additively; a breaking change to this document fails CI."
   title: NextMoe Public API v2
-  version: 2.8.0
+  version: 2.9.0
   x-stability: stable
 openapi: 3.1.0
 paths:

--- a/docs/developer-platform/02-public-api.md
+++ b/docs/developer-platform/02-public-api.md
@@ -248,16 +248,19 @@ catalog 的 release 日期是**部分 ISO**:`YYYY` / `YYYY-MM` / `YYYY-MM-DD`,�
 - 该旗标同时出现在作品详情与列表 `include=intros` 的 `intros[]` 每个元素,以及 `characters/{id}` / `labels/{id}` / `names/{id}` / `tags/{id}` 的 `intros[]`,语义逐字一致——**wave 209 起五个 intro 面在 spec 层就是同一个 schema(`PublicIntro`)**,消费端写一个渲染器即可;tag 面的 `machine` 现阶段**恒 false**(`catalog_tag_intro` 无 provenance 列,写入方只有 curated 编辑面)。
 - **`names/{id}` 的双泳道特例**:该面的"某语言存在源文"判据跨**两条泳道**统一计算(人物级源文 + 名义级桥都算源文),故人物机翻只在两条道对该语言均无源文时才出现。
 
-**④ 两槽判据**(与三表同批落账;**wave 207 更正**:同一挑选器也产出详情面的 `cover_slots`,两面逐字同义——本节读作两面共同的判据)
+**④ 两槽判据**(与三表同批落账;**wave 207 更正**:同一挑选器也产出详情面的 `cover_slots`,两面逐字同义——本节读作两面共同的判据;**v3 波 2026-09-05 重写了择优与兜底**)
 
-`covers` / `cover_slots` 出 `{portrait, banner}`,每槽 `{url, width, height, thumbhash, sexual, violence, source}` 或 `null`。
+`covers` / `cover_slots` 出 `{portrait, banner}`,每槽 `{url, width, height, thumbhash, sexual, violence, source, origin}` 或 `null`。
 
-- **⚠️ 判据是 kind × 尺寸两道,不是只看尺寸(wave 207 更正)**:本节此前写作「朝向来自真实尺寸,不来自 `kind`」——那对 `portrait` 的兜底档成立,对 `banner` 不成立,并已实爆过一次(碟面被当成 hero 图铺上详情页顶)。`kind` 里的 `pkgback` / `pkgmed` / `pkgcontent` / `pkgside`(封底 / 碟面 / 内页 / 侧标)**一律不算封面画**,**任何尺寸都进不了 `banner` 槽**,也当不了 `portrait` 的优先档:**「不是竖版」不等于「够宽当 hero」**,一张够宽的内页跨页图同样不是 hero。
-- 尺寸那一道:竖版 = `height > width × 1.05`(沿用 `cmd/pin-portrait-covers` 的 U 轨切点);横版 = `width / height ≥ 4/3`,且 `width ≥ 800` 的那张**优先**(够宽才铺得开)。
-- `portrait` = `portrait_pinned` 行 → 否则首个**竖版封面画** → 否则首个竖版图(任意 kind)→ 否则该调用方可见的首图(按 `sort_order`, `image_hash` 序),**故有可见封面时恒非 null**。
-- `banner` = 首个**够宽的横版封面画** → 否则首个横版封面画;**无(含 image_service 查询未接线、尺寸未知时)即 `null`**,绝不猜。一张封面都不可见时**整块** `cover_slots` / `covers` 为 `null`。
+- **⚠️ 判据是 kind × 尺寸两道,不是只看尺寸(wave 207 更正)**:本节此前写作「朝向来自真实尺寸,不来自 `kind`」——那对 `portrait` 的兜底档成立,对 `banner` 不成立,并已实爆过一次(碟面被当成 hero 图铺上详情页顶)。**v3 起 `pkg` 全族(`pkgfront` / `pkgback` / `pkgmed` / `pkgcontent` / `pkgside`,即盒封正面 / 封底 / 碟面 / 内页 / 侧标)一律不算封面画**:任何尺寸、两个槽都进不去,连 `first` 兜底也不进,**`portrait_pinned` 同样不例外**——生产里约 258 个 pkg 钉是退役前的重钉阶梯留下的,读面直接中和,不等重钉跑完。列表面的单图 `cover` 跳过同一族。
+- 尺寸那一道:竖版 = `height > width × 1.05`(沿用 `cmd/pin-portrait-covers` 的 U 轨切点);横版 = `width / height ≥ 4/3`。两个朝向各有一条**宽度优先档**(是分档,不是门槛):竖版 `width ≥ 500`、横版 `width ≥ 800`(够宽才铺得开)。
+- **同档内取最清晰的一张**:面积 `width × height` 最大者胜,同面积按 `image_hash` 字典序取小。**排序不跨档、也不跨安全轮**:先用 display-safe 的图把各档填满,只有仍然空着的档才由 sexual 轮补,故一张小的安全图恒胜一张大的露骨图;分档先于面积,所以一张 500 宽的竖版胜过一张更多像素的窄条。
+- `portrait` = `portrait_pinned` 行(**v3 起限竖版或尺寸未知**:钉的写入路径没有形状门,生产里有 1920×1080 的宣传横幅被钉成卡面;量过且不是竖版的钉**不占这一槽**,但照常参与它形状合得上的其它档——一张被钉的横图仍是合格的 `banner`。尺寸未知的钉照旧生效,否则 image_service 还没量到的作品会整片空掉)→ 否则 `width ≥ 500` 竖版中最清晰者 → 否则任意宽度竖版中最清晰者 → 否则该调用方可见的首图(按 `sort_order`, `image_hash` 序)。**`portrait` 永不退到截图**:一张场景图不能替作品当门面。
+- `banner` = `width ≥ 800` 横版中最清晰者 → 否则任意横版中最清晰者 → **否则退到该作品的截图**(v3 加法):只收横版截图,同样分 display-safe / sexual 两轮,轮内按 `sexual` 升序(安全的先,哪怕更小)→ 够宽(`≥ 800`)的先 → 面积大的先 → `image_hash` 小的先。**仍无(含 image_service 查询未接线、尺寸未知时)即 `null`**,绝不猜。
+- **`origin` 指明该槽选自哪个池子**:`cover`(封面行)/ `screenshot`(截图兜底)。两槽恒带此键,`screenshot` 只可能出现在 `banner` 上。
+- **整块为 `null` 的条件是「没有可用封面**且**没有可用截图」**:一部只有 pkg 封面、但有一张横版截图的作品,仍出一个 `portrait` 为 `null`、`banner` 为截图的 `cover_slots`。
 - 只有一张可用封面时两槽可能指向同一图,这是预期。
-- `width` / `height` / `thumbhash` 来自 image_service 的按需批量查询,**未知即三键一并省略**(消费端退回骨架屏);详情面 `covers[]` **与 `screenshots[]`** 每行同样带这三个可选键(A2-1a 加法,A2-1b 补齐 screenshots——两个粒度共用**同一次**批量查询,详情面对 image_service 仍只发一趟)。
+- `width` / `height` / `thumbhash` 来自 image_service 的按需批量查询,**未知即三键一并省略**(消费端退回骨架屏);详情面 `covers[]` **与 `screenshots[]`** 每行同样带这三个可选键(A2-1a 加法,A2-1b 补齐 screenshots——两个粒度共用**同一次**批量查询,详情面对 image_service 仍只发一趟)。截图兜底只在 `banner` 落空时才额外取一趟截图行 + 一趟 meta,列表面整页合成一趟;全页都不需要兜底时零额外查询。
 - sfw 调用方在**两槽**都永不见 `sexual≠0` 的封面(与列表单图 `cover` 同一规则;`violence` 同样不入门槛)。
 
 **⑤ 实体图的 `*_meta`(加法)**


### PR DESCRIPTION
## What

Cover-slot picker v3 for the v2 public faces (`cover_slots` on detail, `include=covers` on the list, plus the legacy list `cover` URL), spec **2.8.0 → 2.9.0**.

1. **Total pkg veto.** `isCoverArt` now refuses the whole family — `pkgfront` joins pkgback/pkgmed/pkgcontent/pkgside — and the veto is applied at the top of the scan, so pinned pkg rows are neutralized too (production carries ~258 `pkgfront` pins). `pickListCover` and the repin ladder (`internal/jobs/repincovers`) drop pkgfront the same way.
2. **Pinned shape guard.** The forum-side pin write path has no shape gate; production carries landscape rows flagged `portrait_pinned` (a 1920×1080 promo banner as the portrait card face, found by a 120-image visual QA sample). A measured pin must now pass the portrait gate; an unmeasured pin is still honoured; a failing pin still competes for the banner slot.
3. **Sharpest within tier.** Within each shape tier the winner is the largest pixel area (hash tiebreak), replacing first-in-sort-order. Safe candidates still always beat explicit ones (two-pass structure unchanged).
4. **Portrait width tier.** `portraitMinWidth = 500` as a preference tier (mirrors `bannerMinWidth = 800`): ≥500-wide portraits preferred, smaller ones still fill when nothing wider exists.
5. **Screenshot banner fallback.** A work with no landscape cover falls back to its screenshots for the banner slot: safe pass first (explicit only under the caller's nsfw × display_nsfw permission), then sexual grade ascending → wide tier (≥800) → area → hash. Detail face lazy-loads screenshots only when the banner is empty; the list face batches one extra query for just the works that need it. Portrait never comes from a screenshot.
6. **`origin` on the wire.** Slots carry `origin: "cover" | "screenshot"` — new `CoverSlot` component (all `Image` fields + `origin`), the work `cover`/`banner` keys re-point to it. Purely additive.

## Gates

- `go build ./...`, `gofmt` clean on touched files.
- DB-backed suites green against an ephemeral DB (`catalog/service` 91s real run, `apiv2/...`, `repincovers`).
- `gen-openapi -catalog-v2` + `sync-specs.mjs` regenerated (docs-model + new docs-zh entry); spec diff is the new component, two `$ref` swaps and the version bump.
- `docs/developer-platform/02-public-api.md` §3.2.1 ④ updated to the new criteria.

**No schema migration.** After deploy: mcp restart required (spec snapshot coupling), then a repin report-only run to size the pkgfront pin replacement supply.
