### PR TITLE
feat(catalog): widen vndb cover backfill to wiki-lineage-only works

### DIFF
--- a/apps/api/cmd/backfill-vndb-covers/main.go
+++ b/apps/api/cmd/backfill-vndb-covers/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	apply := flag.Bool("apply", false, "write changes (default: dry-run forecast only)")
 	dsn := flag.String("dsn", "", "catalog DSN — REQUIRED; the rehearsal copy locally (kun_catalog_rehearsal), the live catalog only in the production run")
-	ids := flag.String("ids", "", "restrict to these catalog_work ids (comma separated); the anchor / no-cover predicates still apply")
+	ids := flag.String("ids", "", "restrict to these catalog_work ids (comma separated); the anchor / no-official-cover predicates still apply")
 	limit := flag.Int("limit", 0, "max covers to upload in --apply (0 = all); the dry-run forecast always covers the whole population")
 	offset := flag.Int("offset", 0, "skip this many candidate works (for chunking)")
 	imageBaseURL := flag.String("image-base-url", "", "image_service base override (point at the LOCAL dev service, e.g. http://127.0.0.1:9278)")

--- a/apps/api/internal/jobs/vndbcovers/db_test.go
+++ b/apps/api/internal/jobs/vndbcovers/db_test.go
@@ -1,0 +1,139 @@
+package vndbcovers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"api/internal/platform/catalog/migrate"
+	"api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/seed"
+	"api/internal/testsupport/dbtest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var testDB *gorm.DB
+
+func TestMain(m *testing.M) {
+	dsn, ok := dbtest.DSN()
+	if !ok {
+		fmt.Fprintln(os.Stderr, "SKIP: no TEST_DATABASE_DSN — DB-backed vndbcovers tests will skip individually")
+		os.Exit(m.Run())
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "FAIL: cannot connect to the assigned test database")
+		os.Exit(1)
+	}
+	if err := migrate.Run(db); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: catalog migrate failed: %v\n", err)
+		os.Exit(1)
+	}
+	if err := seed.Run(db); err != nil {
+		fmt.Fprintf(os.Stderr, "FAIL: catalog seed failed: %v\n", err)
+		os.Exit(1)
+	}
+	testDB = db
+	os.Exit(m.Run())
+}
+
+func clean(t *testing.T) {
+	t.Helper()
+	if testDB == nil {
+		dbtest.Skip(t)
+	}
+	require.NoError(t, testDB.Exec("TRUNCATE catalog_external_ref CASCADE").Error)
+	for _, table := range []string{"catalog_work_cover", "catalog_work"} {
+		require.NoError(t, testDB.Exec("TRUNCATE "+table+" RESTART IDENTITY CASCADE").Error)
+	}
+}
+
+func sourceID(t *testing.T, key string) int16 {
+	t.Helper()
+	var id int16
+	require.NoError(t, testDB.Raw(`SELECT id FROM catalog_source WHERE key = ?`, key).Scan(&id).Error)
+	require.NotZero(t, id, "source %q not seeded", key)
+	return id
+}
+
+func mkWork(t *testing.T, reg registry, name string) int64 {
+	t.Helper()
+	w := model.CatalogWork{MediumID: reg.galgameMedium, OLang: "ja", DisplayName: name}
+	require.NoError(t, testDB.Create(&w).Error)
+	return w.ID
+}
+
+func mkAnchor(t *testing.T, reg registry, workID int64, vndbID string, linkKind int16) {
+	t.Helper()
+	require.NoError(t, testDB.Exec(`
+		INSERT INTO catalog_external_ref (entity_type, entity_id, source_id, external_id, link_kind, matched_by)
+		VALUES (?,?,?,?,?,?)`,
+		model.EntityTypeWork, workID, reg.vndbSource, vndbID, linkKind, "test").Error)
+}
+
+func mkCover(t *testing.T, workID int64, source int16, kind, hash string) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&model.CatalogWorkCover{
+		WorkID: workID, ImageHash: hash, Kind: kind, SourceID: source,
+	}).Error)
+}
+
+func candidateIDs(t *testing.T, reg registry, ids []int64) []int64 {
+	t.Helper()
+	cands, err := loadCandidates(context.Background(), testDB, reg, ids)
+	require.NoError(t, err)
+	out := make([]int64, 0, len(cands))
+	for _, c := range cands {
+		out = append(out, c.WorkID)
+	}
+	return out
+}
+
+func TestLoadCandidatesOfficialGap(t *testing.T) {
+	clean(t)
+	reg, err := resolveRegistry(context.Background(), testDB)
+	require.NoError(t, err)
+	curated, upscale, bangumi := sourceID(t, "curated"), sourceID(t, "upscale"), sourceID(t, "bangumi")
+
+	coverless := mkWork(t, reg, "coverless")
+	mkAnchor(t, reg, coverless, "v1", model.LinkKindExact)
+
+	curatedOnly := mkWork(t, reg, "curated-only")
+	mkAnchor(t, reg, curatedOnly, "v2", model.LinkKindExact)
+	mkCover(t, curatedOnly, curated, "main", "hash-cur")
+
+	wikiLineage := mkWork(t, reg, "curated+upscale")
+	mkAnchor(t, reg, wikiLineage, "v3", model.LinkKindExact)
+	mkCover(t, wikiLineage, curated, "", "hash-cur2")
+	mkCover(t, wikiLineage, upscale, "main", "hash-ups")
+
+	pkgOnly := mkWork(t, reg, "official-pkg-only")
+	mkAnchor(t, reg, pkgOnly, "v4", model.LinkKindExact)
+	mkCover(t, pkgOnly, reg.vndbSource, "pkgfront", "hash-pkg")
+
+	hasVNDB := mkWork(t, reg, "vndb-covered")
+	mkAnchor(t, reg, hasVNDB, "v5", model.LinkKindExact)
+	mkCover(t, hasVNDB, reg.vndbSource, "main", "hash-vndb")
+
+	hasBangumi := mkWork(t, reg, "bangumi-covered")
+	mkAnchor(t, reg, hasBangumi, "v6", model.LinkKindExact)
+	mkCover(t, hasBangumi, bangumi, "main", "hash-bgm")
+	mkCover(t, hasBangumi, curated, "main", "hash-cur3")
+
+	probable := mkWork(t, reg, "probable-anchor")
+	mkAnchor(t, reg, probable, "v7", model.LinkKindProbable)
+
+	assert.ElementsMatch(t,
+		[]int64{coverless, curatedOnly, wikiLineage, pkgOnly},
+		candidateIDs(t, reg, nil))
+
+	assert.ElementsMatch(t, []int64{curatedOnly},
+		candidateIDs(t, reg, []int64{curatedOnly, hasVNDB}),
+		"--ids must not bypass the official-cover gate")
+}

--- a/apps/api/internal/jobs/vndbcovers/source.go
+++ b/apps/api/internal/jobs/vndbcovers/source.go
@@ -33,6 +33,12 @@ type candidate struct {
 	VNDBID string `gorm:"column:vndb_id"`
 }
 
+// A work "has a cover" only when an official source put one there. The first
+// production run gated on NOT EXISTS(any cover row) and stalled at 13.3k of
+// 65k vndb anchors: legacy-wiki rows (source 'curated', plus their AI-upscaled
+// 'upscale' twins — both frequently hand-censored) counted as covers and kept
+// 48k works out of the queue, while upstream coverage probed 60/60. pkg* kinds
+// are box scans the public picker vetoes, so they do not count either.
 func loadCandidates(ctx context.Context, db *gorm.DB, reg registry, ids []int64) ([]candidate, error) {
 	sql := `
 		SELECT DISTINCT ON (w.id) w.id AS work_id, r.external_id AS vndb_id
@@ -40,7 +46,13 @@ func loadCandidates(ctx context.Context, db *gorm.DB, reg registry, ids []int64)
 		JOIN catalog_external_ref r ON r.entity_type = ? AND r.entity_id = w.id
 			AND r.source_id = ? AND r.link_kind = ?
 		WHERE w.medium_id = ? AND w.deleted_at IS NULL
-			AND NOT EXISTS (SELECT 1 FROM catalog_work_cover c WHERE c.work_id = w.id)`
+			AND NOT EXISTS (
+				SELECT 1 FROM catalog_work_cover c
+				JOIN catalog_source cs ON cs.id = c.source_id
+				WHERE c.work_id = w.id
+					AND c.kind NOT IN ('pkgfront','pkgback','pkgmed','pkgcontent','pkgside')
+					AND cs.key NOT IN ('curated','upscale')
+			)`
 	args := []any{model.EntityTypeWork, reg.vndbSource, model.LinkKindExact, reg.galgameMedium}
 	if len(ids) > 0 {
 		sql += "\n\t\t\tAND w.id IN ?"


### PR DESCRIPTION
## What

Step ① of the censored-cover remediation (delete curated covers wherever official art exists): widen `backfill-vndb-covers`' candidate gate so works whose only covers are legacy-wiki rows become candidates.

- The old gate was `NOT EXISTS (any cover row)`. Legacy-wiki `curated` rows (and their AI-upscaled `upscale` twins — both frequently hand-censored uploads) counted as covers, so 48,213 works with exact vndb anchors were never queued: vndb cover coverage stalled at 13,309 of 65,014 anchors.
- New gate: a cover row blocks candidacy only when its source is official (neither `curated` nor `upscale`) **and** its kind is not a `pkg*` box scan (the public picker vetoes those anyway).
- Upstream coverage probe on a random 60-work sample from the target set: **60/60 have a vndb image** (56 SFW by community votes, 14 portrait, 37 narrower than 500px).

## Behavior

- Old candidates (born cover-less) remain a strict subset of the new gate.
- Landscape vndb covers are still never `portrait_pinned` (unchanged `write.go` logic), so they cannot displace an existing portrait card face; they fill the banner slot.
- The binary stays a manual one-shot (`--dsn` required, dry-run by default); it is not registered in the job scheduler.

## Tests

- New DB-backed `TestLoadCandidatesOfficialGap`: curated-only, curated+upscale, official-pkg-only and cover-less works are candidates; vndb- or bangumi-covered works and probable-only anchors are not; `--ids` cannot bypass the gate. Verified against an ephemeral catalog DB (migrate + seed), confirmed running (not skip-green).
- `go build` / `go vet` / `gofmt` clean.

## Rollout

After merge I will run the backfill against production (dry-run forecast first, then chunked `--apply` with an upload gap), which is the precondition for the guarded deletion of curated + upscale rows where official art now exists.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
