### PR TITLE
feat(vndbcovers): dump-driven manifest, rsync image mirror and a paced worker pool

### DIFF
--- a/apps/api/cmd/backfill-vndb-covers/main.go
+++ b/apps/api/cmd/backfill-vndb-covers/main.go
@@ -22,6 +22,9 @@ func main() {
 	imageBaseURL := flag.String("image-base-url", "", "image_service base override (point at the LOCAL dev service, e.g. http://127.0.0.1:9278)")
 	uploadGap := flag.Duration("upload-gap", 0, "min delay between uploads (0 = none; raise for a gentle production sweep)")
 	apiBase := flag.String("vndb-api-base", "", "VNDB API base override (default https://api.vndb.org/kana)")
+	manifest := flag.String("manifest", "", "CSV built from the daily VNDB DB dump (vndb_id,url,width,height,sexual,violence); replaces the rate-limited Kana API metadata phase")
+	imageDir := flag.String("image-dir", "", "local mirror of rsync://dl.vndb.org/vndb-img — cover bytes are read from here first, HTTP only for files the mirror lacks")
+	workers := flag.Int("workers", 1, "concurrent shrink+upload workers; --upload-gap stays a single shared pace across all of them")
 	flag.Parse()
 
 	_ = godotenv.Load("apps/api/.env")
@@ -48,6 +51,9 @@ func main() {
 		ImageBaseURL: *imageBaseURL,
 		UploadGap:    *uploadGap,
 		APIBase:      *apiBase,
+		Manifest:     *manifest,
+		ImageDir:     *imageDir,
+		Workers:      *workers,
 	})
 	if stats != nil {
 		slog.Info("backfill-vndb-covers summary", "result", stats.String())

--- a/apps/api/internal/jobs/vndbcovers/db_test.go
+++ b/apps/api/internal/jobs/vndbcovers/db_test.go
@@ -1,15 +1,22 @@
 package vndbcovers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"image"
+	"image/jpeg"
+	"io"
 	"os"
+	"path/filepath"
+	"sync"
 	"testing"
 
 	"api/internal/platform/catalog/migrate"
 	"api/internal/platform/catalog/model"
 	"api/internal/platform/catalog/seed"
 	"api/internal/testsupport/dbtest"
+	"api/pkg/imageclient"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -136,4 +143,65 @@ func TestLoadCandidatesOfficialGap(t *testing.T) {
 	assert.ElementsMatch(t, []int64{curatedOnly},
 		candidateIDs(t, reg, []int64{curatedOnly, hasVNDB}),
 		"--ids must not bypass the official-cover gate")
+}
+
+type stubUploader struct {
+	mu    sync.Mutex
+	calls int
+	limit int
+}
+
+func (s *stubUploader) UploadWithSub(_ context.Context, _ io.Reader, filename, _, _ string) (*imageclient.UploadResult, error) {
+	s.mu.Lock()
+	s.calls++
+	n := s.calls
+	s.mu.Unlock()
+	if s.limit > 0 && n > s.limit {
+		return nil, imageclient.ErrQuotaExceeded
+	}
+	return &imageclient.UploadResult{Hash: fmt.Sprintf("stub-%03d-%s", n, filename)}, nil
+}
+
+func (s *stubUploader) ReferencePing(context.Context, []string) (*imageclient.ReferencePingResult, error) {
+	return &imageclient.ReferencePingResult{}, nil
+}
+
+func (s *stubUploader) Health(context.Context) error { return nil }
+
+func TestDrainPoolWritesRowsAndStopsOnQuota(t *testing.T) {
+	clean(t)
+	reg, err := resolveRegistry(context.Background(), testDB)
+	require.NoError(t, err)
+
+	var jpg bytes.Buffer
+	require.NoError(t, jpeg.Encode(&jpg, image.NewRGBA(image.Rect(0, 0, 12, 16)), nil))
+	mirror := t.TempDir()
+
+	rows := make([]planRow, 0, 12)
+	for i := 0; i < 12; i++ {
+		id := mkWork(t, reg, fmt.Sprintf("pool-%02d", i))
+		rel := filepath.Join("cv", fmt.Sprintf("%02d", i), fmt.Sprintf("%d.jpg", 1000+i))
+		require.NoError(t, os.MkdirAll(filepath.Join(mirror, filepath.Dir(rel)), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(mirror, rel), jpg.Bytes(), 0o644))
+		rows = append(rows, planRow{
+			WorkID: id,
+			VNDBID: fmt.Sprintf("v%d", 1000+i),
+			Img:    &vnImage{URL: "https://t.vndb.org/" + filepath.ToSlash(rel), Dims: []int{12, 16}},
+		})
+	}
+
+	stats := &Stats{}
+	r := &runner{db: testDB, cli: &stubUploader{limit: 6}, sourceID: reg.vndbSource,
+		imageDir: mirror, stats: stats}
+	r.drain(context.Background(), rows, 4)
+
+	assert.Equal(t, 6, stats.Uploaded)
+	assert.True(t, stats.Quota, "quota abort must be recorded")
+	assert.Zero(t, stats.Errors)
+	assert.GreaterOrEqual(t, stats.Local, 6, "every processed row must come from the mirror")
+
+	var n int64
+	require.NoError(t, testDB.Model(&model.CatalogWorkCover{}).Count(&n).Error)
+	assert.EqualValues(t, 6, n)
+	assert.Len(t, r.touched, 6)
 }

--- a/apps/api/internal/jobs/vndbcovers/manifest.go
+++ b/apps/api/internal/jobs/vndbcovers/manifest.go
@@ -1,0 +1,75 @@
+package vndbcovers
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// The Kana API admits ~200 requests per 5 minutes, so the metadata phase alone
+// for a full-population run spends ~45 minutes being rate-limited, and VNDB asks
+// bulk consumers to use the daily database dump instead (vndb.org/d14). A
+// manifest is that dump reduced to this job's fields; rows with an empty url are
+// VNs the dump knows to have no cover.
+var manifestHeader = []string{"vndb_id", "url", "width", "height", "sexual", "violence"}
+
+func loadManifest(path string) (map[string]*vnImage, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	rd := csv.NewReader(f)
+	header, err := rd.Read()
+	if err != nil {
+		return nil, fmt.Errorf("read manifest header: %w", err)
+	}
+	if strings.Join(header, ",") != strings.Join(manifestHeader, ",") {
+		return nil, fmt.Errorf("manifest header %q, want %q", strings.Join(header, ","), strings.Join(manifestHeader, ","))
+	}
+
+	out := make(map[string]*vnImage)
+	for line := 2; ; line++ {
+		rec, err := rd.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("manifest line %d: %w", line, err)
+		}
+		id := strings.TrimSpace(rec[0])
+		if id == "" {
+			return nil, fmt.Errorf("manifest line %d: empty vndb_id", line)
+		}
+		u := strings.TrimSpace(rec[1])
+		if u == "" {
+			out[id] = nil
+			continue
+		}
+		img := &vnImage{URL: u}
+		w, err := strconv.Atoi(rec[2])
+		if err != nil {
+			return nil, fmt.Errorf("manifest line %d: width %q", line, rec[2])
+		}
+		h, err := strconv.Atoi(rec[3])
+		if err != nil {
+			return nil, fmt.Errorf("manifest line %d: height %q", line, rec[3])
+		}
+		if w > 0 && h > 0 {
+			img.Dims = []int{w, h}
+		}
+		if img.Sexual, err = strconv.ParseFloat(rec[4], 64); err != nil {
+			return nil, fmt.Errorf("manifest line %d: sexual %q", line, rec[4])
+		}
+		if img.Violence, err = strconv.ParseFloat(rec[5], 64); err != nil {
+			return nil, fmt.Errorf("manifest line %d: violence %q", line, rec[5])
+		}
+		out[id] = img
+	}
+	return out, nil
+}

--- a/apps/api/internal/jobs/vndbcovers/manifest_test.go
+++ b/apps/api/internal/jobs/vndbcovers/manifest_test.go
@@ -1,0 +1,57 @@
+package vndbcovers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeManifest(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "manifest.csv")
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
+	return p
+}
+
+func TestLoadManifest(t *testing.T) {
+	p := writeManifest(t, `vndb_id,url,width,height,sexual,violence
+v17,https://t.vndb.org/cv/17/17.jpg,560,650,1.5,0
+v99,,0,0,0,0
+`)
+	m, err := loadManifest(p)
+	require.NoError(t, err)
+	require.Len(t, m, 2)
+
+	img := m["v17"]
+	require.NotNil(t, img)
+	assert.Equal(t, "https://t.vndb.org/cv/17/17.jpg", img.URL)
+	assert.Equal(t, []int{560, 650}, img.Dims)
+	assert.Equal(t, 1.5, img.Sexual)
+	assert.Equal(t, float64(0), img.Violence)
+
+	got, known := m["v99"]
+	assert.True(t, known, "an imageless VN must stay in the map so it reads as no-image, not vn-unknown")
+	assert.Nil(t, got)
+}
+
+func TestLoadManifestRejectsAForeignHeader(t *testing.T) {
+	p := writeManifest(t, "id,link\nv1,x\n")
+	_, err := loadManifest(p)
+	assert.Error(t, err)
+}
+
+func TestLoadManifestRejectsGarbageNumbers(t *testing.T) {
+	p := writeManifest(t, `vndb_id,url,width,height,sexual,violence
+v17,https://t.vndb.org/cv/17/17.jpg,wide,650,0,0
+`)
+	_, err := loadManifest(p)
+	assert.Error(t, err)
+}
+
+func TestLoadManifestMissingFile(t *testing.T) {
+	_, err := loadManifest(filepath.Join(t.TempDir(), "absent.csv"))
+	assert.Error(t, err)
+}

--- a/apps/api/internal/jobs/vndbcovers/vndbcovers.go
+++ b/apps/api/internal/jobs/vndbcovers/vndbcovers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sync"
 	"time"
 
 	"api/internal/infrastructure/database"
@@ -26,6 +27,9 @@ type Opts struct {
 	ImageBaseURL string
 	UploadGap    time.Duration
 	APIBase      string
+	Manifest     string
+	ImageDir     string
+	Workers      int
 }
 
 type Stats struct {
@@ -38,12 +42,13 @@ type Stats struct {
 	Dedup      int
 	Rejected   int
 	Errors     int
+	Local      int
 	Quota      bool
 }
 
 func (s Stats) String() string {
-	return fmt.Sprintf("candidates=%d no_image=%d portrait=%d landscape=%d planned=%d uploaded=%d dedup=%d rejected=%d errors=%d quota=%t",
-		s.Candidates, s.NoImage, s.Portrait, s.Landscape, s.Planned, s.Uploaded, s.Dedup, s.Rejected, s.Errors, s.Quota)
+	return fmt.Sprintf("candidates=%d no_image=%d portrait=%d landscape=%d planned=%d uploaded=%d dedup=%d rejected=%d errors=%d local=%d quota=%t",
+		s.Candidates, s.NoImage, s.Portrait, s.Landscape, s.Planned, s.Uploaded, s.Dedup, s.Rejected, s.Errors, s.Local, s.Quota)
 }
 
 type imageUploader interface {
@@ -57,9 +62,59 @@ type runner struct {
 	cli        imageUploader
 	sourceID   int16
 	gap        time.Duration
+	imageDir   string
 	stats      *Stats
 	touched    []int64
 	pingHashes []string
+
+	mu       sync.Mutex
+	paceLast time.Time
+}
+
+func (r *runner) bump(f func(*Stats)) {
+	r.mu.Lock()
+	f(r.stats)
+	r.mu.Unlock()
+}
+
+func (r *runner) stopped() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stats.Quota
+}
+
+func (r *runner) drain(ctx context.Context, rows []planRow, workers int) {
+	if workers < 1 {
+		workers = 1
+	}
+	jobs := make(chan planRow)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for row := range jobs {
+				if ctx.Err() != nil || r.stopped() {
+					continue
+				}
+				r.fill(ctx, row)
+			}
+		}()
+	}
+	for i, row := range rows {
+		if ctx.Err() != nil || r.stopped() {
+			break
+		}
+		jobs <- row
+		if (i+1)%1000 == 0 {
+			r.mu.Lock()
+			slog.Info("vndb-covers progress", "queued", i+1, "of", len(rows),
+				"uploaded", r.stats.Uploaded, "dedup", r.stats.Dedup, "errors", r.stats.Errors, "local", r.stats.Local)
+			r.mu.Unlock()
+		}
+	}
+	close(jobs)
+	wg.Wait()
 }
 
 func Run(ctx context.Context, cfg *config.Config, opts Opts) (*Stats, error) {
@@ -92,10 +147,17 @@ func Run(ctx context.Context, cfg *config.Config, opts Opts) (*Stats, error) {
 	slog.Info("vndb-covers candidates", "works", len(cands), "apply", opts.Apply,
 		"offset", opts.Offset, "limit", opts.Limit, "explicit_ids", len(opts.IDs))
 
-	api := newVNDBAPI(opts.APIBase)
-	images, err := api.fetchImages(ctx, anchorIDs(cands))
-	if err != nil {
-		return stats, fmt.Errorf("query vndb api: %w", err)
+	var images map[string]*vnImage
+	if opts.Manifest != "" {
+		if images, err = loadManifest(opts.Manifest); err != nil {
+			return stats, fmt.Errorf("load manifest: %w", err)
+		}
+		slog.Info("vndb image manifest", "entries", len(images), "path", opts.Manifest)
+	} else {
+		api := newVNDBAPI(opts.APIBase)
+		if images, err = api.fetchImages(ctx, anchorIDs(cands)); err != nil {
+			return stats, fmt.Errorf("query vndb api: %w", err)
+		}
 	}
 	plan := buildPlan(cands, images, stats)
 	printForecast(plan, opts)
@@ -105,7 +167,7 @@ func Run(ctx context.Context, cfg *config.Config, opts Opts) (*Stats, error) {
 		return stats, nil
 	}
 
-	r := &runner{db: db, sourceID: reg.vndbSource, gap: opts.UploadGap, stats: stats}
+	r := &runner{db: db, sourceID: reg.vndbSource, gap: opts.UploadGap, imageDir: opts.ImageDir, stats: stats}
 	r.cli = imageclient.New(imageclient.Config{
 		BaseURL:      resolveBaseURL(cfg, clientCfg, opts.ImageBaseURL),
 		CDNBase:      cfg.ImageService.CDNBase,
@@ -119,12 +181,7 @@ func Run(ctx context.Context, cfg *config.Config, opts Opts) (*Stats, error) {
 		return stats, fmt.Errorf("image_service unreachable at %s: %w", resolveBaseURL(cfg, clientCfg, opts.ImageBaseURL), err)
 	}
 
-	for _, row := range actionable(plan, opts.Limit) {
-		if ctx.Err() != nil || stats.Quota {
-			break
-		}
-		r.fill(ctx, row)
-	}
+	r.drain(ctx, actionable(plan, opts.Limit), opts.Workers)
 	if err := repository.TouchWorks(ctx, db, r.touched); err != nil {
 		return stats, fmt.Errorf("touch works: %w", err)
 	}

--- a/apps/api/internal/jobs/vndbcovers/write.go
+++ b/apps/api/internal/jobs/vndbcovers/write.go
@@ -9,7 +9,10 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"api/internal/platform/catalog/model"
@@ -40,20 +43,20 @@ const (
 func (r *runner) fill(ctx context.Context, row planRow) {
 	body, filename, err := r.download(ctx, row.Img.URL)
 	if err != nil {
-		r.stats.Errors++
+		r.bump(func(s *Stats) { s.Errors++ })
 		slog.Warn("download vndb cover", "work", row.WorkID, "vn", row.VNDBID, "url", row.Img.URL, "err", err)
 		return
 	}
 	body, filename, err = imageshrink.Shrink(body, filename)
 	if err != nil {
-		r.stats.Errors++
+		r.bump(func(s *Stats) { s.Errors++ })
 		slog.Warn("shrink vndb cover", "work", row.WorkID, "vn", row.VNDBID, "err", err)
 		return
 	}
 	res, err := r.upload(ctx, body, filename)
 	if err != nil {
 		if r.classify(err, row) {
-			r.stats.Quota = true
+			r.bump(func(s *Stats) { s.Quota = true })
 		}
 		return
 	}
@@ -68,10 +71,12 @@ func (r *runner) fill(ctx context.Context, row planRow) {
 		SourceID:       r.sourceID,
 	})
 	if tx.Error != nil {
-		r.stats.Errors++
+		r.bump(func(s *Stats) { s.Errors++ })
 		slog.Warn("write vndb cover row", "work", row.WorkID, "vn", row.VNDBID, "err", tx.Error)
 		return
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.pingHashes = append(r.pingHashes, res.Hash)
 	if tx.RowsAffected == 0 {
 		r.stats.Dedup++
@@ -82,6 +87,10 @@ func (r *runner) fill(ctx context.Context, row planRow) {
 }
 
 func (r *runner) download(ctx context.Context, src string) ([]byte, string, error) {
+	if body, ok := r.readMirror(src); ok {
+		r.bump(func(s *Stats) { s.Local++ })
+		return body, coverFilename(src), nil
+	}
 	client := &http.Client{Timeout: downloadTimeout}
 	var lastErr error
 	for attempt := 0; attempt < downloadRetries; attempt++ {
@@ -127,6 +136,25 @@ func fetch(ctx context.Context, client *http.Client, src string) ([]byte, error)
 	return body, nil
 }
 
+func (r *runner) readMirror(src string) ([]byte, bool) {
+	if r.imageDir == "" {
+		return nil, false
+	}
+	u, err := url.Parse(src)
+	if err != nil {
+		return nil, false
+	}
+	rel := strings.TrimPrefix(path.Clean(u.Path), "/")
+	if rel == "" || rel == "." {
+		return nil, false
+	}
+	body, err := os.ReadFile(filepath.Join(r.imageDir, filepath.FromSlash(rel)))
+	if err != nil || len(body) == 0 || len(body) > maxImageBytes {
+		return nil, false
+	}
+	return body, true
+}
+
 func coverFilename(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -142,7 +170,7 @@ func coverFilename(raw string) string {
 func (r *runner) upload(ctx context.Context, body []byte, filename string) (*imageclient.UploadResult, error) {
 	var lastErr error
 	for attempt := 0; attempt < uploadRetries; attempt++ {
-		if r.gap > 0 && !sleepCtx(ctx, r.gap) {
+		if !r.pace(ctx) {
 			return nil, ctx.Err()
 		}
 		res, err := r.cli.UploadWithSub(ctx, bytes.NewReader(body), filename, coverPreset, uploaderSub)
@@ -161,6 +189,26 @@ func (r *runner) upload(ctx context.Context, body []byte, filename string) (*ima
 		}
 	}
 	return nil, lastErr
+}
+
+// The gap is a single global spacing shared by every worker, so raising
+// --workers never raises the request rate against the image service beyond
+// 1/gap; workers only overlap download+shrink time.
+func (r *runner) pace(ctx context.Context) bool {
+	if r.gap <= 0 {
+		return ctx.Err() == nil
+	}
+	r.mu.Lock()
+	next := r.paceLast.Add(r.gap)
+	if now := time.Now(); next.Before(now) {
+		next = now
+	}
+	r.paceLast = next
+	r.mu.Unlock()
+	if wait := time.Until(next); wait > 0 {
+		return sleepCtx(ctx, wait)
+	}
+	return ctx.Err() == nil
 }
 
 func (r *runner) classify(err error, row planRow) (quota bool) {

--- a/apps/api/internal/jobs/vndbcovers/write_test.go
+++ b/apps/api/internal/jobs/vndbcovers/write_test.go
@@ -1,0 +1,65 @@
+package vndbcovers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadPrefersTheLocalMirror(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "cv", "06"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cv", "06", "12306.jpg"), []byte("mirror-bytes"), 0o644))
+
+	r := &runner{imageDir: dir, stats: &Stats{}}
+	body, name, err := r.download(context.Background(), "https://127.0.0.1:1/cv/06/12306.jpg")
+	require.NoError(t, err, "an unroutable host must never be dialed on a mirror hit")
+	assert.Equal(t, "mirror-bytes", string(body))
+	assert.Equal(t, "12306.jpg", name)
+	assert.Equal(t, 1, r.stats.Local)
+}
+
+func TestDownloadFallsBackToHTTPWhenTheMirrorMisses(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/cv/06/99999.jpg" {
+			_, _ = w.Write([]byte("cdn-bytes"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	r := &runner{imageDir: t.TempDir(), stats: &Stats{}}
+	body, name, err := r.download(context.Background(), srv.URL+"/cv/06/99999.jpg")
+	require.NoError(t, err)
+	assert.Equal(t, "cdn-bytes", string(body))
+	assert.Equal(t, "99999.jpg", name)
+	assert.Equal(t, 0, r.stats.Local)
+}
+
+func TestPaceIsOneSharedGapAcrossWorkers(t *testing.T) {
+	r := &runner{gap: 20 * time.Millisecond}
+	start := time.Now()
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 3; j++ {
+				assert.True(t, r.pace(context.Background()))
+			}
+		}()
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+	assert.GreaterOrEqual(t, elapsed, 8*20*time.Millisecond,
+		"9 paced slots across 3 workers must serialize to >= 8 gaps")
+}


### PR DESCRIPTION
## What

Rebuilds the vndb cover backfill lane the way VNDB asks bulk consumers to work: dump + rsync mirror instead of hammering their API and CDN, plus a paced worker pool.

- `--manifest <csv>`: metadata (image url/dims/community sexual+violence votes) from a CSV cut of the daily `vndb-db-latest.tar.zst` dump — replaces the Kana API phase, which is rate-limited to ~200 req/5min and alone costs ~45 min per full-population run (and repeats on every restart).
- `--image-dir <dir>`: cover bytes read from a local mirror of `rsync://dl.vndb.org/vndb-img/` (cv/ subtree), HTTP per-file fallback for anything the mirror lacks. Zero bulk load on t.vndb.org.
- `--workers <n>`: concurrent download+shrink+upload. `--upload-gap` becomes a single shared pace across all workers, so concurrency never raises the request rate against our image service; quota abort stops the whole pool.

## Why now

The first full-population run (predicate fix #143) spent its entire first 45 minutes being 429-throttled through the metadata phase and would then have taken 8–16h of sequential fetch+upload. With manifest + mirror + 6 workers the same run is ~1–1.5h, restartable at near-zero cost, and polite to VNDB.

## Tests

- `loadManifest` parse/reject cases; mirror-hit (proves no dial-out), HTTP fallback; shared-pace serialization.
- DB-backed `TestDrainPoolWritesRowsAndStopsOnQuota` (4 workers, quota trip mid-pool) — full suite green under `-race` on an ephemeral DB.

No spec/API surface changes; tool-only.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
