### PR TITLE
fix(catalog): re-source byte-identical legacy cover rows to vndb on conflict

### DIFF
--- a/apps/api/internal/jobs/vndbcovers/db_test.go
+++ b/apps/api/internal/jobs/vndbcovers/db_test.go
@@ -149,6 +149,7 @@ type stubUploader struct {
 	mu    sync.Mutex
 	calls int
 	limit int
+	fixed string
 }
 
 func (s *stubUploader) UploadWithSub(_ context.Context, _ io.Reader, filename, _, _ string) (*imageclient.UploadResult, error) {
@@ -158,6 +159,9 @@ func (s *stubUploader) UploadWithSub(_ context.Context, _ io.Reader, filename, _
 	s.mu.Unlock()
 	if s.limit > 0 && n > s.limit {
 		return nil, imageclient.ErrQuotaExceeded
+	}
+	if s.fixed != "" {
+		return &imageclient.UploadResult{Hash: s.fixed}, nil
 	}
 	return &imageclient.UploadResult{Hash: fmt.Sprintf("stub-%03d-%s", n, filename)}, nil
 }
@@ -204,4 +208,50 @@ func TestDrainPoolWritesRowsAndStopsOnQuota(t *testing.T) {
 	require.NoError(t, testDB.Model(&model.CatalogWorkCover{}).Count(&n).Error)
 	assert.EqualValues(t, 6, n)
 	assert.Len(t, r.touched, 6)
+}
+
+func TestFillRelabelsTheByteIdenticalLegacyRow(t *testing.T) {
+	clean(t)
+	reg, err := resolveRegistry(context.Background(), testDB)
+	require.NoError(t, err)
+	curated := sourceID(t, "curated")
+
+	var jpg bytes.Buffer
+	require.NoError(t, jpeg.Encode(&jpg, image.NewRGBA(image.Rect(0, 0, 12, 16)), nil))
+	mirror := t.TempDir()
+	rel := filepath.Join("cv", "06", "12306.jpg")
+	require.NoError(t, os.MkdirAll(filepath.Join(mirror, filepath.Dir(rel)), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(mirror, rel), jpg.Bytes(), 0o644))
+
+	id := mkWork(t, reg, "wiki-clone")
+	mkCover(t, id, curated, "", "official-hash")
+
+	row := planRow{
+		WorkID: id, VNDBID: "v12306",
+		Img: &vnImage{URL: "https://t.vndb.org/cv/06/12306.jpg", Dims: []int{12, 16}, Sexual: 2, Violence: 0},
+	}
+	stats := &Stats{}
+	r := &runner{db: testDB, cli: &stubUploader{fixed: "official-hash"}, sourceID: reg.vndbSource,
+		imageDir: mirror, stats: stats}
+	r.fill(context.Background(), row)
+
+	var n int64
+	require.NoError(t, testDB.Model(&model.CatalogWorkCover{}).Where("work_id = ?", id).Count(&n).Error)
+	assert.EqualValues(t, 1, n, "relabel must not add a second row")
+	var got model.CatalogWorkCover
+	require.NoError(t, testDB.Where("work_id = ?", id).First(&got).Error)
+	assert.Equal(t, reg.vndbSource, got.SourceID, "byte-identical legacy row is re-sourced to vndb")
+	assert.Equal(t, "main", got.Kind, "legacy '' kind is normalized")
+	assert.Equal(t, ratingLevel(2), got.Sexual)
+	assert.True(t, got.PortraitPinned)
+	assert.Equal(t, 1, stats.Uploaded)
+	assert.Zero(t, stats.Dedup)
+	assert.Equal(t, []int64{id}, r.touched, "relabeled work must reach TouchWorks")
+
+	rerun := &runner{db: testDB, cli: &stubUploader{fixed: "official-hash"}, sourceID: reg.vndbSource,
+		imageDir: mirror, stats: &Stats{}}
+	rerun.fill(context.Background(), row)
+	assert.Equal(t, 1, rerun.stats.Dedup, "an already-vndb row must count as dedup on re-run")
+	assert.Zero(t, rerun.stats.Uploaded)
+	assert.Empty(t, rerun.touched)
 }

--- a/apps/api/internal/jobs/vndbcovers/write.go
+++ b/apps/api/internal/jobs/vndbcovers/write.go
@@ -60,9 +60,20 @@ func (r *runner) fill(ctx context.Context, row planRow) {
 		}
 		return
 	}
+	// The first full run ended uploaded=1,725 dedup=46,630: the image service
+	// dedups uploads by content, and for most candidates the legacy wiki row
+	// (source curated/upscale, kind '') already carried the byte-identical
+	// official image. DO NOTHING left those rows curated-sourced — the works
+	// stayed candidates, and the planned curated purge would have deleted the
+	// official bytes with them. A conflict therefore re-sources the identical
+	// row to vndb and normalizes the legacy '' kind; the WHERE keeps re-runs
+	// idempotent (rows already vndb-sourced count as dedup, not uploads).
 	tx := r.db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "work_id"}, {Name: "image_hash"}},
-		DoNothing: true,
+		DoUpdates: clause.AssignmentColumns([]string{"source_id", "kind", "portrait_pinned", "sexual", "violence", "updated_at"}),
+		Where: clause.Where{Exprs: []clause.Expression{
+			clause.Expr{SQL: "catalog_work_cover.source_id <> excluded.source_id"},
+		}},
 	}).Create(&model.CatalogWorkCover{
 		WorkID: row.WorkID, ImageHash: res.Hash, SortOrder: 0, Kind: coverKind,
 		PortraitPinned: portrait(row.Img.Dims),


### PR DESCRIPTION
## What

`backfill-vndb-covers`: an `ON CONFLICT (work_id, image_hash)` hit now **re-sources the existing row to vndb** (plus normalizes the legacy `''` kind to `main` and refreshes `portrait_pinned`/`sexual`/`violence` from the manifest) instead of `DO NOTHING`. A `WHERE catalog_work_cover.source_id <> excluded.source_id` keeps re-runs idempotent: rows already vndb-sourced count as `dedup`.

## Why

The first full dump-lane run (#145) finished `uploaded=1,725 dedup=46,630 errors=0`. Forensics on the 46,630 conflicts:

- The image service dedups uploads by content, so uploading the official VNDB cover returned the hash of bytes **already in the store** — and the conflicting `catalog_work_cover` row was the **legacy wiki row** (source `curated`, kind `''`): for ~94% of candidates the wiki cover is byte-identical to the official image, not a censored derivative.
- `DO NOTHING` left those rows curated-sourced. The works stayed candidates under the #143 official-gap predicate (verified live: 47,612 remaining = 49,337 − 1,725 exactly), and — the real hazard — the upcoming guarded deletion of `curated`/`upscale` covers would have deleted the official bytes with them.

Re-running the tool after this change relabels those 46,630 rows in place (no new image bytes, same hash), takes the works out of candidacy, and makes the curated purge safe.

## Tests

- `TestFillRelabelsTheByteIdenticalLegacyRow`: seeds a curated `''`-kind row whose hash equals what the upload dedups to; asserts single row, source flipped to vndb, kind normalized, ratings refreshed, work reaches `TouchWorks`; a second fill counts `dedup` and touches nothing.
- Existing pool/quota/mirror/pace tests unchanged and green (`-race -count=1 -p 1` against an ephemeral DB).

No migration. No schema change.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
