### PR TITLE
fix(import-favorites): fold a repeated pair inside one insert batch

### DIFF
--- a/apps/api/cmd/import-favorites/main_test.go
+++ b/apps/api/cmd/import-favorites/main_test.go
@@ -8,6 +8,7 @@ import (
 
 	"api/internal/platform/catalog/migrate"
 	"api/internal/platform/catalog/model"
+	"api/internal/platform/catalog/seed"
 	"api/internal/testsupport/dbtest"
 
 	"github.com/stretchr/testify/require"
@@ -33,6 +34,12 @@ func TestMain(m *testing.M) {
 	}
 	if err := migrate.Run(db); err != nil {
 		dbtest.SkipMainf("cmd/import-favorites", "catalog migration failed: %v", err)
+	}
+	// The fixture needs catalog_medium and the vndb catalog_source row, neither
+	// of which migrate.Run writes. Without this the suite only passed against a
+	// database that already held real catalog data.
+	if err := seed.Run(db); err != nil {
+		dbtest.SkipMainf("cmd/import-favorites", "catalog seed failed: %v", err)
 	}
 	testDB = db
 	os.Exit(m.Run())
@@ -281,4 +288,29 @@ func TestDryRunWritesNothing(t *testing.T) {
 	require.Zero(t, n)
 	require.NoError(t, testDB.Model(&model.CatalogUserFolderItem{}).Count(&n).Error)
 	require.Zero(t, n)
+}
+
+// Two moyu patches carrying one vndb id resolve to one work, so the lane emits
+// the same (folder, work) pair twice; with both in one batch Postgres aborts the
+// statement with "ON CONFLICT DO UPDATE command cannot affect row a second
+// time". That is how the 2026-09-07 production run died on its first moyu
+// flush, after both forum lanes had already been written.
+func TestOneBatchNeverCarriesAPairTwice(t *testing.T) {
+	fx := seedFixture(t)
+	require.NoError(t, testDB.Exec(`INSERT INTO patch (id, vndb_id) VALUES (1, 'vtest1'), (2, 'vtest1')`).Error)
+	require.NoError(t, testDB.Exec(`
+		INSERT INTO user_patch_favorite_relation (id, user_id, galgame_id, created, updated)
+		VALUES (1, 11, 1, ?, ?), (2, 11, 2, ?, ?)`, at(5), at(6), at(2), at(9)).Error)
+
+	imp := loadedImporter(t, true)
+	c, err := imp.importMoyu()
+	require.NoError(t, err)
+	require.Equal(t, 1, c.ItemsInserted)
+	require.Equal(t, 1, c.ItemsMerged)
+
+	var items []model.CatalogUserFolderItem
+	require.NoError(t, testDB.Where("work_id = ?", fx.live).Find(&items).Error)
+	require.Len(t, items, 1)
+	require.Equal(t, at(2).UTC(), items[0].CreatedAt.UTC(), "folding keeps the earliest created")
+	require.Equal(t, at(9).UTC(), items[0].UpdatedAt.UTC(), "folding keeps the latest updated")
 }

--- a/apps/api/cmd/import-favorites/passes.go
+++ b/apps/api/cmd/import-favorites/passes.go
@@ -26,9 +26,31 @@ type itemRow struct {
 type itemBatch struct {
 	imp  *importer
 	rows []itemRow
+	at   map[[2]int64]int
 }
 
+// add folds a pair the batch already carries instead of appending it twice.
+// Postgres refuses a statement whose ON CONFLICT target matches one row more
+// than once ("cannot affect row a second time"), and both flat lanes re-emit a
+// pair they have already placed precisely so the conflict clause can reconcile
+// the two timestamps. Two moyu patches sharing one vndb anchor put such a pair
+// in a single batch and killed the 2026-09-07 production run on its first moyu
+// flush; folding here applies the same LEAST/GREATEST the clause would.
 func (b *itemBatch) add(r itemRow) error {
+	key := [2]int64{r.FolderID, r.WorkID}
+	if n, held := b.at[key]; held {
+		if r.Created.Before(b.rows[n].Created) {
+			b.rows[n].Created = r.Created
+		}
+		if r.Updated.After(b.rows[n].Updated) {
+			b.rows[n].Updated = r.Updated
+		}
+		return nil
+	}
+	if b.at == nil {
+		b.at = make(map[[2]int64]int, b.imp.batch)
+	}
+	b.at[key] = len(b.rows)
 	b.rows = append(b.rows, r)
 	if len(b.rows) >= b.imp.batch {
 		return b.flush()
@@ -36,9 +58,14 @@ func (b *itemBatch) add(r itemRow) error {
 	return nil
 }
 
+func (b *itemBatch) reset() {
+	b.rows = b.rows[:0]
+	clear(b.at)
+}
+
 func (b *itemBatch) flush() error {
 	if len(b.rows) == 0 || !b.imp.apply {
-		b.rows = b.rows[:0]
+		b.reset()
 		return nil
 	}
 	var sb strings.Builder
@@ -57,7 +84,7 @@ func (b *itemBatch) flush() error {
 	if err := b.imp.cat.Exec(sb.String(), args...).Error; err != nil {
 		return err
 	}
-	b.rows = b.rows[:0]
+	b.reset()
 	return nil
 }
 


### PR DESCRIPTION
Found by running the production backfill: it wrote both forum lanes (8,246 folders, 202,526 memberships) and then aborted on its first moyu flush.

```
ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time (SQLSTATE 21000)
```

Two moyu patches carrying the same `vndb_id` resolve to one catalog work, so the lane emits the same `(folder_id, work_id)` pair twice. Both flat lanes do that on purpose — a pair the run has already placed is re-emitted so the `LEAST/GREATEST` conflict clause can pull the two sites' timestamps together — but Postgres refuses a single statement whose conflict target matches one row more than once. The batch has to fold the repeat itself, applying the same earliest-created / latest-updated rule the clause would.

The forum lanes escaped it only by luck of shape: `galgame_favorite` has one row per (user, work), so its 127,923 merges each hit a pair written by an *earlier, already flushed* statement.

### Why the suite was green

`TestMain` migrated the catalog schema but never called `seed.Run`, so `catalog_medium` and the `vndb` `catalog_source` row were missing. Every existing test only ever passed against the rehearsal database, which already held real catalog rows. On a clean database all five fail at fixture setup with a `fk_catalog_work_medium` violation — which is also why CI, where the suite skips for want of a DSN, never had an opinion.

### Verification

- 6/6 green on a freshly provisioned ephemeral database (`-count=1 -p 1`), which the suite could not reach before.
- Positive control: removing the fold makes `TestOneBatchNeverCarriesAPairTwice` fail with the production error verbatim.

Production is mid-import and stays that way until this ships — the forum rows are in, moyu wrote nothing (its first batch aborted atomically), and the importer is re-runnable by design, so a second `-apply` finishes the job and recounts `item_count`.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
