### PR TITLE
fix(vndbcovers): relabel a byte-identical package row of our own source

### DIFF
--- a/apps/api/internal/jobs/vndbcovers/db_test.go
+++ b/apps/api/internal/jobs/vndbcovers/db_test.go
@@ -255,3 +255,48 @@ func TestFillRelabelsTheByteIdenticalLegacyRow(t *testing.T) {
 	assert.Zero(t, rerun.stats.Uploaded)
 	assert.Empty(t, rerun.touched)
 }
+
+// The relabel re-run ended dedup=26: for those works vndb's main cover is
+// byte-identical to a vndb *package* row already held, so the source matched
+// and the conflict clause held the update back. The work then owned nothing
+// but pkg* rows, which the cover picker vetoes as a family, and it stayed a
+// residual the guarded wiki purge could not clear.
+func TestFillRelabelsAByteIdenticalPackageRowOfItsOwnSource(t *testing.T) {
+	clean(t)
+	reg, err := resolveRegistry(context.Background(), testDB)
+	require.NoError(t, err)
+
+	var jpg bytes.Buffer
+	require.NoError(t, jpeg.Encode(&jpg, image.NewRGBA(image.Rect(0, 0, 12, 16)), nil))
+	mirror := t.TempDir()
+	rel := filepath.Join("cv", "07", "12307.jpg")
+	require.NoError(t, os.MkdirAll(filepath.Join(mirror, filepath.Dir(rel)), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(mirror, rel), jpg.Bytes(), 0o644))
+
+	id := mkWork(t, reg, "pkg-clone")
+	mkCover(t, id, reg.vndbSource, "pkgfront", "official-hash")
+
+	row := planRow{
+		WorkID: id, VNDBID: "v12307",
+		Img: &vnImage{URL: "https://t.vndb.org/cv/07/12307.jpg", Dims: []int{12, 16}, Sexual: 0, Violence: 0},
+	}
+	r := &runner{db: testDB, cli: &stubUploader{fixed: "official-hash"}, sourceID: reg.vndbSource,
+		imageDir: mirror, stats: &Stats{}}
+	r.fill(context.Background(), row)
+
+	var n int64
+	require.NoError(t, testDB.Model(&model.CatalogWorkCover{}).Where("work_id = ?", id).Count(&n).Error)
+	assert.EqualValues(t, 1, n, "relabel must not add a second row")
+	var got model.CatalogWorkCover
+	require.NoError(t, testDB.Where("work_id = ?", id).First(&got).Error)
+	assert.Equal(t, "main", got.Kind, "a package row carrying the main cover bytes is what vndb serves as the cover")
+	assert.Equal(t, reg.vndbSource, got.SourceID)
+	assert.Equal(t, 1, r.stats.Uploaded)
+	assert.Equal(t, []int64{id}, r.touched)
+
+	rerun := &runner{db: testDB, cli: &stubUploader{fixed: "official-hash"}, sourceID: reg.vndbSource,
+		imageDir: mirror, stats: &Stats{}}
+	rerun.fill(context.Background(), row)
+	assert.Equal(t, 1, rerun.stats.Dedup, "source and kind now both agree, so a re-run must not write")
+	assert.Zero(t, rerun.stats.Uploaded)
+}

--- a/apps/api/internal/jobs/vndbcovers/write.go
+++ b/apps/api/internal/jobs/vndbcovers/write.go
@@ -68,11 +68,19 @@ func (r *runner) fill(ctx context.Context, row planRow) {
 	// official bytes with them. A conflict therefore re-sources the identical
 	// row to vndb and normalizes the legacy '' kind; the WHERE keeps re-runs
 	// idempotent (rows already vndb-sourced count as dedup, not uploads).
+	//
+	// The re-run then ended dedup=26, and those 26 works were the same story a
+	// second time with a different row: vndb's own main cover is byte-identical
+	// to a vndb *package* row we already held, so the source matched, the WHERE
+	// held the update back, and the work kept only pkg* rows — which the cover
+	// picker vetoes as a family. Matching on kind as well relabels that row to
+	// what vndb actually serves it as, and stays idempotent because the second
+	// pass then agrees on both columns.
 	tx := r.db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "work_id"}, {Name: "image_hash"}},
 		DoUpdates: clause.AssignmentColumns([]string{"source_id", "kind", "portrait_pinned", "sexual", "violence", "updated_at"}),
 		Where: clause.Where{Exprs: []clause.Expression{
-			clause.Expr{SQL: "catalog_work_cover.source_id <> excluded.source_id"},
+			clause.Expr{SQL: "catalog_work_cover.source_id <> excluded.source_id OR catalog_work_cover.kind <> excluded.kind"},
 		}},
 	}).Create(&model.CatalogWorkCover{
 		WorkID: row.WorkID, ImageHash: res.Hash, SortOrder: 0, Kind: coverKind,


### PR DESCRIPTION
Clears one of the two residual buckets the guarded wiki-cover purge left behind (26 works).

The relabel wave taught the conflict clause to re-source a byte-identical *wiki* row to vndb. Its re-run then ended `dedup=26`, and a census of the post-purge residuals shows those 26 works are the same story with a different row: vndb's main cover is byte-identical to a vndb **package** row we already held, so `source_id <> excluded.source_id` was false and the update was held back. The work ended up owning nothing but `pkg*` rows, which the cover picker vetoes as a family, so its wiki image stayed the only usable face and the purge guard kept it.

Adding the kind test relabels that row to what vndb actually serves it as — `c_image`, the VN's cover. It remains idempotent: after the write both columns agree, so a second pass counts the row as dedup rather than an upload.

### Verification

- `internal/jobs/vndbcovers` green (`-count=1 -p 1`).
- New `TestFillRelabelsAByteIdenticalPackageRowOfItsOwnSource` covers the case and its re-run.
- Positive control: dropping the `OR kind` term makes only that test fail; the pre-existing relabel test stays green either way, which is why the class went unnoticed.

### Residual census behind this (read-only, prod)

337 works still hold wiki rows, split cleanly:

| bucket | works | remedy |
|---|---|---|
| non-wiki rows are all package art | 26 | this PR, then re-run the lane on them |
| wiki only — no non-wiki cover row at all | 311 | none available (below) |

The 311 have nothing upstream to pull from: 190 carry no external anchor of any source, and all 30 that do carry a vndb anchor are absent from the 66,170-row dump manifest, i.e. vndb holds no image for them (positive control: `v1` and `v17` are present). The rest anchor only to dlsite/erogamescape/bangumi, whose product images are package art the picker vetoes anyway. They keep their wiki cover until official art appears.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
