### PR TITLE
test(apiv2): pin the folder scope gate against path variants

### DIFF
--- a/apps/api/internal/platform/apiv2/handler/me_folder_test.go
+++ b/apps/api/internal/platform/apiv2/handler/me_folder_test.go
@@ -99,6 +99,38 @@ func TestFolderScopeGateLeavesPlaytimesAlone(t *testing.T) {
 	require.Equal(t, problem.CodeServiceUnavailable, p.Code)
 }
 
+// The folder gate keys on the request path, the same shape that let one
+// trailing slash walk past the operator-scope check on /v2/catalog/claim-events.
+// It is a second copy of that pattern and what it guards is private
+// collections, so each variant is checked against a scoped token on the same
+// path: the scoped one must reach the handler (503, unbound here) and the
+// scopeless one must not get there.
+func TestFolderScopeGateSurvivesPathVariants(t *testing.T) {
+	scopeless := testAppDualCredential(t, UserIdentity{
+		UID: 42, ClientID: "manager", Scopes: []string{"openid", devapi.ScopeCatalogRead},
+	})
+	scoped := testAppDualCredential(t, UserIdentity{
+		UID: 42, ClientID: "manager", Scopes: []string{devapi.ScopeFolderRead},
+	})
+
+	routed := 0
+	for _, path := range []string{
+		"/v2/me/folders", "/v2/me/folders/", "/v2/me/folders//",
+		"/v2/Me/folders", "/v2/me/Folders",
+		"/v2/me/folders/7/items", "/v2/me/folders/7/items/",
+	} {
+		okStatus, _ := authGET(t, scoped, path, catalogUserToken)
+		if okStatus != 503 {
+			continue // fiber never routed this variant; nothing to bypass
+		}
+		routed++
+		status, p := authGET(t, scopeless, path, catalogUserToken)
+		require.Equalf(t, 403, status, "GET %s reached the folder handler with catalog:read alone", path)
+		require.Equal(t, problem.CodeScopeRequired, p.Code, path)
+	}
+	require.Greater(t, routed, 2, "too few variants actually routed for this walk to mean anything")
+}
+
 func TestFolderRoutesRequireAUserToken(t *testing.T) {
 	app := testApp(t)
 	status, _, body := do(t, app, http.MethodGet, "/v2/me/folders")


### PR DESCRIPTION
Test only — no behaviour change.

`userAuth` gates `/v2/me/folders` on the request path. That is the same shape as the operator-scope check on `/v2/catalog/claim-events`, where one trailing slash routed to the same handler and skipped the check. The folder gate reads `routepath.Normalize(c.Path())` and so is correct today, but nothing held it there, and a regression would hand any consented app somebody's private collections.

The walk pairs each variant against a **scoped** token on the same path: a variant fiber never routes answers something other than 503, and is skipped rather than counted as a pass. So the test cannot go green by matching nothing — the scoped token has to reach the handler before the scopeless one is required to be refused, and the walk asserts at least three variants actually routed.

Positive control: changing the gate to read `c.Path()` instead of the normalized path makes it fail on the case variant.

Also confirms a note I had wrong: the scopeless-token negative control was **not** missing — `TestFolderReadsRefuseAScopelessToken` and `TestFolderWritesRefuseFolderReadAlone` already cover it. The variant walk was the real gap.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
