### PR TITLE
ops(prod-cron): rotate container logs, watch the ymgal review queue

### DIFF
--- a/scripts/prod-cron/README.md
+++ b/scripts/prod-cron/README.md
@@ -24,20 +24,34 @@ the image is the fix, not a preference.
 
 ## Jobs
 
-| job | schedule (UTC) | deadman limit |
-|---|---|---|
-| bgm-refresh | Wed 11:00 | 192h |
-| vndb-refresh | Sun 17:30 | 192h |
-| reindex-catalog | daily 06:10 | 48h |
-| intromt-nightly | daily 13:00 | 48h |
-| image-grade-nightly | daily 15:00 | 48h |
-| playtime-aggregate | daily 05:20 | 48h |
-| refresh-tag-counts | hourly :40 | 6h |
-| tag-vocab-backlog | 1st 12:30 | 768h |
-| work-dedup-nightly | daily 18:30 | 48h |
-| work-dedup-watch | Mon 04:20 | 192h |
+Root's crontab fires in the box's own zone, **Asia/Shanghai (CST, +0800)** —
+not UTC, which this table used to claim. The two columns below are the same
+schedule twice. It matters: the daily reindex reads as an early-morning job and
+actually runs at 22:10 UTC, so on 2026-09-07 the "already ran today" reindex had
+in fact run *before* the cover deletion it was supposed to follow, and the index
+had to be rebuilt by hand.
 
-`metrics-sampler/` is the one non-job entry: a host-level resource sampler
+| job | schedule (CST, as written in crontab) | = UTC | deadman limit |
+|---|---|---|---|
+| bgm-refresh | Wed 11:00 | Wed 03:00 | 192h |
+| vndb-refresh | Sun 17:30 | Sun 09:30 | 192h |
+| reindex-catalog | daily 06:10 | daily 22:10 (prev. day) | 48h |
+| intromt-nightly | daily 13:00 | daily 05:00 | 48h |
+| image-grade-nightly | daily 15:00 | daily 07:00 | 48h |
+| playtime-aggregate | daily 05:20 | daily 21:20 (prev. day) | 48h |
+| refresh-tag-counts | hourly :40 | hourly :40 | 6h |
+| tag-vocab-backlog | 1st 12:30 | 1st 04:30 | 768h |
+| work-dedup-nightly | daily 18:30 | daily 10:30 | 48h |
+| work-dedup-watch | Mon 04:20 | Sun 20:20 | 192h |
+| ymgal-pending-watch | daily 09:30 | daily 01:30 | 48h |
+
+`logrotate/docker-containers` is host config, not a job: it is deployed as
+`/etc/logrotate.d/docker-containers`. Dokploy's containers are created with an
+empty `HostConfig.LogConfig.Config`, so `daemon.json`'s 100m x 3 default never
+applies to them — traefik's access log had grown to 25 GB by 2026-09-07, five
+days from filling the disk. The file's own header carries the detail.
+
+`metrics-sampler/` is the other non-job entry: a host-level resource sampler
 (docker stats + loadavg + MemAvailable/SwapFree to daily CSVs under
 `/root/metrics/`, 14-day retention) installed as `/etc/cron.d/kun-metrics-sampler`
 (`*/5 * * * *`, flock-guarded), deployed as `/root/metrics/sample.sh`. It has no

--- a/scripts/prod-cron/lib/watchdog.conf
+++ b/scripts/prod-cron/lib/watchdog.conf
@@ -15,3 +15,4 @@ image-grade-nightly	/root/image-grade-nightly/state/last-success	48
 tag-vocab-backlog	/root/tag-vocab-backlog/state/last-success	768
 work-dedup-watch	/root/work-dedup-watch/state/last-success	192
 work-dedup-nightly	/root/work-dedup-nightly/state/last-success	48
+ymgal-pending-watch	/root/ymgal-pending-watch/state/last-success	48

--- a/scripts/prod-cron/logrotate/docker-containers
+++ b/scripts/prod-cron/logrotate/docker-containers
@@ -1,0 +1,21 @@
+# Deployed as /etc/logrotate.d/docker-containers on kungal-neo.
+#
+# Docker's json-file driver only honours max-size/max-file at container
+# creation time, and the containers dokploy created carry no log opts at all
+# (`HostConfig.LogConfig.Config` is empty), so the daemon.json defaults
+# — 100m x 3 — never reached them. Traefik's access log, switched on
+# 2026-09-02 to investigate the crawler storm, had reached **25 GB** by
+# 2026-09-07 on a root filesystem at 71%: about five days from full.
+#
+# copytruncate is required, not a preference: the writer is dockerd and it
+# holds the file open, so a rename would leave it writing to an unlinked inode
+# and the visible log would stay empty forever.
+/var/lib/docker/containers/*/*-json.log {
+    size 100M
+    rotate 3
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/scripts/prod-cron/ymgal-pending-watch/run.sh
+++ b/scripts/prod-cron/ymgal-pending-watch/run.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Daily watch on the 月幕 (ymgal) review queue.
+#
+# WHY this job exists: every other news lane drains itself. 批评 is a standing
+# blanket release, so its items go straight to published and a backlog cannot
+# form. ymgal is the opposite by promise — 苍麟 was told it would never be swept
+# with the rest, so every item waits for a human in the console. Nothing told
+# that human the queue had items, which made "nobody looked for a fortnight" a
+# silent state rather than a reported one.
+#
+# It runs no Go tool, so it is the one job here outside the infra-tools
+# invariant: the whole check is a count, and `docker exec` into the postgres
+# container reads it without a DSN or a password on any command line.
+#
+# Thresholds are judgment, not physics. ymgal publishes roughly one item a day,
+# so a queue that is a week old means the review stopped, and twenty waiting
+# means it stopped a while ago. Either one is worth an email; neither is worth
+# one on the day it happens.
+#
+# Canonical copy: scripts/prod-cron/ymgal-pending-watch/run.sh in nextmoe-infra
+# — the deployed copy is /root/ymgal-pending-watch/run.sh and must stay
+# byte-identical; scp is the only sync mechanism.
+set -eu
+BASE=/root/ymgal-pending-watch
+cd "$BASE"
+mkdir -p logs state
+LOG="logs/run-$(date -u +%F).log"
+exec >>"$LOG" 2>&1
+exec 9>"$BASE/.lock"; flock -n 9 || { echo "another run holds the lock; exit"; exit 0; }
+LOCKED=1
+
+AGE_DAYS=${AGE_DAYS:-7}
+ALERT_AT=${ALERT_AT:-20}
+
+on_exit() {
+  rc=$?
+  if [ "$rc" -eq 0 ] && [ "${LOCKED:-0}" = 1 ]; then
+    date -u '+%F %T' > "$BASE/state/last-success"
+  else
+    echo "=== FAILED (exit $rc) - sending alert ==="
+    /root/lib/alert.sh "[FAIL] ymgal pending watch (exit $rc)" "$BASE/$LOG" || echo "alert delivery failed"
+  fi
+}
+trap on_exit EXIT
+echo "=== ymgal pending watch start $(date -u '+%F %T')Z ==="
+
+PG=kun-visual-novel-infra-vqvqbc-postgres-1
+REPORT="$BASE/state/pending-$(date -u +%F).txt"
+
+# status 0 is StatusPending (internal/platform/news/model/news.go).
+docker exec "$PG" psql -U postgres -d kun_news -At -F'|' -c \
+  "SELECT count(*), COALESCE(max(now()::date - created_at::date), 0)
+     FROM news_item WHERE source_key = 'ymgal' AND status = 0" > "$REPORT"
+
+N=$(cut -d'|' -f1 "$REPORT")
+AGE=$(cut -d'|' -f2 "$REPORT")
+: "${N:=0}"; : "${AGE:=0}"
+echo "ymgal pending: $N item(s), oldest $AGE day(s) (alert at count>=$ALERT_AT or age>=$AGE_DAYS)"
+
+if [ "$N" -gt 0 ] && { [ "$N" -ge "$ALERT_AT" ] || [ "$AGE" -ge "$AGE_DAYS" ]; }; then
+  docker exec "$PG" psql -U postgres -d kun_news -c \
+    "SELECT id, external_id, left(title, 60) AS title, created_at
+       FROM news_item WHERE source_key = 'ymgal' AND status = 0
+       ORDER BY created_at LIMIT 30" >> "$REPORT" || true
+  /root/lib/alert.sh "[ymgal] $N item(s) awaiting review, oldest $AGE day(s)" "$REPORT" \
+    || echo "alert delivery failed"
+fi
+
+find state -name 'pending-*.txt' -mtime +90 -delete
+find logs -name 'run-*.log' ! -name "run-$(date -u +%F).log" -exec gzip -qf {} \;
+find logs -name 'run-*.log.gz' -mtime +90 -delete
+echo "=== ymgal pending watch done $(date -u '+%F %T')Z ==="


### PR DESCRIPTION
Two prod-box tails, both already deployed; this is the canonical copy the README requires.

### 1. Container logs were never rotated

Dokploy creates its containers with an empty `HostConfig.LogConfig.Config`, so `daemon.json`'s `100m` × 3 default never applied to any of them. Traefik's access log — switched on 2026-09-02 to investigate the crawler storm — had reached **25 GB** on a root filesystem at 71% used, roughly five days from full.

Done on the box: kept the last 1 GiB as `/root/traefik-access-tail-20260907.json.gz` (85 MB), truncated, installed the rule. **24 GB reclaimed, 71% → 60%.** Verified afterwards that the log resumed growing (the writer survived the truncate) and that the site still serves.

`copytruncate` is required rather than preferred: dockerd holds the file open, so a rename would leave it writing to an unlinked inode and the visible log would stay empty forever.

### 2. Nothing watched the ymgal review queue

Every other news lane drains itself — 批评 is a standing blanket release, so its items go straight to published. ymgal is human-only by promise to 苍麟 and never swept with the rest, so its queue can only be emptied by someone opening the console, and nothing told them there was anything to open it for.

Daily count plus age of the oldest pending item; alert at 20 items or 7 days, both stated as judgment in the script. It runs no Go tool, so it is the one job outside the infra-tools invariant — the whole check is a count, and `docker exec` into postgres reads it with no DSN and no password on any command line.

Deployed, registered in `watchdog.conf` (48h), first run clean: `2 item(s), oldest 1 day(s)` — correctly below both thresholds. The alert path itself was then exercised once with `AGE_DAYS=0` and delivered, because an alert nobody has ever seen fire is not an alert.

### 3. The README's schedule table said UTC and meant CST

Root's crontab fires in `Asia/Shanghai (+0800)`. Every row in that table was CST under a UTC heading. It is not cosmetic: "daily 06:10" reindex actually runs at **22:10 UTC**, so on 2026-09-07 the reindex that looked like it would follow the cover deletion had in fact run before it, and the index had to be rebuilt by hand. Both columns are now shown.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
