### PR TITLE
ops: put postgres and redis on the shared 60s healthcheck

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,12 +23,16 @@
 #   # full data cutover (16-data-cutover.md): docker compose ... --profile jobs run --rm tools <job> ...
 name: kun-galgame-infra
 
-# A steady-state check is a container exec, and dockerd pays for it: at 10s
-# across ~30 containers (plus postgres/redis at 5s) the box ran 279 exec/min and
-# dockerd itself burned 1.16 cores — more than any single service. start_interval
-# keeps the deploy path fast (2s granularity until the first success) while the
-# steady-state cadence drops 6x; nothing here restarts on unhealthy, so a slower
-# steady interval costs observability lag only.
+# A steady-state check is a container exec; at 10s across ~30 containers the
+# box ran 279 exec/min. start_interval keeps the deploy path fast (2s
+# granularity until the first success) while the steady cadence drops 6x, and
+# nothing here restarts on unhealthy, so a slower steady interval costs
+# observability lag only.
+# Do NOT attribute dockerd CPU to this block. The 1.16 -> 2.85 cores it was
+# first blamed for were leaked `docker logs` readers spinning in tailfile;
+# killing the hung clients on 2026-09-07 took dockerd to 0.03 cores at an
+# unchanged 226 exec/min. At this scale the exec rate is not a measurable
+# dockerd cost, so tune these for observability, never for CPU.
 x-svc-health: &svc-health
   interval: 60s
   timeout: 5s
@@ -175,12 +179,12 @@ services:
       - ./docker/initdb.d:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d kun_galgame_infra"]
-      # Deliberately still 5s: retuning this recreates the postgres container
-      # (brief DB outage), so it rides a quiet-window deploy of its own rather
-      # than the next merge. 72 of the box's 279 execs/min live here and in redis.
-      interval: 5s
-      timeout: 5s
-      retries: 20
+      <<: *svc-health
+      # Three services gate on this with `condition: service_healthy`, so the
+      # start period has to outlast a crash-recovery boot. Failures inside it do
+      # not count against `retries` and start_interval holds 2s granularity, so
+      # this is strictly more tolerant than the 5s x 20 it replaces.
+      start_period: 120s
     restart: unless-stopped
 
   redis:
@@ -191,9 +195,10 @@ services:
     volumes: ["redis:/data"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 5s
-      retries: 20
+      <<: *svc-health
+      # redis-cli ping answers LOADING while a large appendonly file replays,
+      # so redis takes the same widened start period as postgres.
+      start_period: 120s
     restart: unless-stopped
 
   minio:


### PR DESCRIPTION
Postgres and redis were the last two services left on a 5s healthcheck interval. They were held back deliberately: retuning a healthcheck changes the container config hash, so applying it **recreates both containers** — a brief DB and cache outage.

## What changes

Both move onto the shared `x-svc-health` anchor (`interval: 60s`, `retries: 3`, `start_interval: 2s`) with a **widened `start_period: 120s`** instead of the anchor's 30s. Infra healthcheck exec rate: **34 → 12 exec/min**.

Three services gate on both with `condition: service_healthy`. Inside the start period a failing check does **not** count against `retries`, and `start_interval` keeps 2s granularity until the first success — so the boot path is strictly more tolerant than the `5s x 20` (100s) it replaces. `redis-cli ping` answers `LOADING` while a large appendonly file replays, which is why redis gets the same 120s.

Resolved by `docker compose config`:

```
postgres  interval=1m0s  start_period=2m0s  start_interval=2s  retries=3
redis     interval=1m0s  start_period=2m0s  start_interval=2s  retries=3
```

## Read this before merging: the CPU case for it is gone

This was queued as the tail of C1, whose premise was that healthcheck execs were driving dockerd's CPU. **That premise was wrong, and the same commit corrects the comment that carried it.**

Turning off the traefik access log took container log throughput from 88 KB/s to 0 B/s and dockerd did not move. A 20s pprof capture put **99.50% of dockerd's CPU in `pkg/tailfile.(*scanner).Scan`** — leaked `docker logs` readers spinning on `pread`, one holding a json.log of a container that no longer exists. There were five in total, all from ad-hoc `docker logs --tail N` diagnostics that hang forever on this box's large logs; each one costs about 0.9 of a core permanently.

Killing the hung client processes took dockerd **3.83 → 0.029 cores** (120s window), with no restart and no downtime. Box loadavg went 8.11 → 3.69.

So dockerd's real cost at **226 exec/min is 0.03 cores**. The exec rate is not a measurable dockerd expense at this scale, and this PR is worth approximately zero CPU.

## Recommendation

**Do not merge this on its own.** It is correct configuration and it should land — but the deploy recreates `postgres` and `redis` (~10s of DB/cache errors site-wide) to buy consistency and slightly better start semantics, not capacity. Let it ride the next deploy that touches those two for another reason, or merge it in a genuinely quiet window if you want it closed out.

No CI gates it — no workflow matches `docker-compose.prod.yml`.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
