### PR TITLE
fix(import-favorites): read the answer moyu already wrote down

### DIFF
--- a/apps/api/cmd/import-favorites/main_test.go
+++ b/apps/api/cmd/import-favorites/main_test.go
@@ -60,7 +60,8 @@ CREATE TABLE galgame_collection_item (
 CREATE TABLE galgame_favorite (
   id serial PRIMARY KEY, galgame_id integer NOT NULL, user_id integer NOT NULL,
   created timestamptz NOT NULL DEFAULT now(), updated timestamptz NOT NULL DEFAULT now());
-CREATE TABLE patch (id serial PRIMARY KEY, vndb_id varchar(107) NOT NULL);
+CREATE TABLE patch (id serial PRIMARY KEY, vndb_id varchar(107) NOT NULL,
+  catalog_work_id bigint);
 CREATE TABLE user_patch_favorite_relation (
   id serial PRIMARY KEY, user_id integer NOT NULL, galgame_id integer NOT NULL,
   created timestamptz NOT NULL DEFAULT now(), updated timestamptz NOT NULL DEFAULT now());

--- a/apps/api/cmd/import-favorites/mirror_fallback_test.go
+++ b/apps/api/cmd/import-favorites/mirror_fallback_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+
+	"api/internal/platform/catalog/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// catalog identifies only 29% of its live works by a vndb anchor (65,058 of
+// 225,238), so a moyu page can be perfectly well known to catalog and still be
+// invisible to the vndb-only route. On 2026-09-08 four such pages were mapped by
+// hand from bangumi / erogamescape / dlsite anchors into patch.catalog_work_id
+// and the lane read none of them: 34 favourites stranded with the answer already
+// sitting in the row.
+//
+// The fallback is deliberately narrow — it fires only when the vndb route came
+// back empty — and it still goes through resolve(), so a hand-written id naming
+// a merged work is followed rather than written dead.
+func TestMoyuFallsBackToTheMirrorColumnOnlyWhenVndbCannotAnswer(t *testing.T) {
+	fx := seedFixture(t)
+	require.NoError(t, testDB.Exec(`
+		INSERT INTO patch (id, vndb_id, catalog_work_id) VALUES
+			(1, 'pending-1', ?),
+			(2, 'vtest-absent', ?),
+			(3, 'vtest1', ?),
+			(4, 'pending-4', NULL),
+			(5, 'pending-5', ?)`,
+		fx.live, fx.live, fx.merged, fx.merged).Error)
+	require.NoError(t, testDB.Exec(`
+		INSERT INTO user_patch_favorite_relation (id, user_id, galgame_id, created, updated)
+		VALUES (1, 21, 1, ?, ?), (2, 22, 2, ?, ?), (3, 23, 3, ?, ?),
+		       (4, 24, 4, ?, ?), (5, 25, 5, ?, ?)`,
+		at(1), at(1), at(1), at(1), at(1), at(1), at(1), at(1), at(1), at(1)).Error)
+
+	imp := loadedImporter(t, true)
+	c, err := imp.importMoyu()
+	require.NoError(t, err)
+
+	require.Equal(t, 4, c.ItemsInserted,
+		"patches 1, 2, 3 and 5 all resolve; only patch 4 has no answer anywhere")
+	require.Equal(t, 1, c.SkippedPending,
+		"a pending- placeholder with an empty mirror column is still skipped")
+	require.Zero(t, c.SkippedNoAnchor)
+
+	// Patch 3's own vndb id resolves, so the mirror column must not be consulted:
+	// were it consulted, this favourite would land on the merged work instead.
+	require.Equal(t, fx.live, soleWorkOf(t, 23), "the vndb route wins whenever it can answer")
+
+	// Patch 5's mirror column names a merged work, so the fallback has to follow
+	// the redirect rather than write a dead id.
+	require.Equal(t, fx.survivor, soleWorkOf(t, 25), "the fallback still follows a merge")
+}
+
+func soleWorkOf(t *testing.T, uid int64) int64 {
+	t.Helper()
+	var items []model.CatalogUserFolderItem
+	require.NoError(t, testDB.
+		Joins("JOIN catalog_user_folder f ON f.id = catalog_user_folder_item.folder_id").
+		Where("f.owner_uid = ?", uid).Find(&items).Error)
+	require.Len(t, items, 1)
+	return items[0].WorkID
+}

--- a/apps/api/cmd/import-favorites/passes.go
+++ b/apps/api/cmd/import-favorites/passes.go
@@ -242,10 +242,10 @@ func (i *importer) importForumFlat() (counters, error) {
 }
 
 func (i *importer) importMoyu() (counters, error) {
-	return i.importFlat(i.moyu, `SELECT r.user_id, p.vndb_id, r.created, r.updated
+	return i.importFlat(i.moyu, `SELECT r.user_id, p.vndb_id, p.catalog_work_id, r.created, r.updated
 		FROM user_patch_favorite_relation r
 		JOIN patch p ON p.id = r.galgame_id
-		ORDER BY r.user_id, r.id`, i.works.resolveVNDB)
+		ORDER BY r.user_id, r.id`, i.works.resolveMoyuPatch)
 }
 
 // importFlat is the shared body of the two flat lanes. A flat favorite lands
@@ -256,7 +256,7 @@ func (i *importer) importMoyu() (counters, error) {
 // first. That is the rule the forum used for its own July fold, and doing it
 // here too keeps the two flat lanes from disagreeing. resolveKey is nil when
 // the source already stores catalog work ids, and the vndb resolver for moyu.
-func (i *importer) importFlat(src *gorm.DB, query string, resolveKey func(string) (int64, bool, vndbOutcome)) (counters, error) {
+func (i *importer) importFlat(src *gorm.DB, query string, resolveKey func(string, sql.NullInt64) (int64, bool, vndbOutcome)) (counters, error) {
 	var c counters
 	rows, err := src.Raw(query).Rows()
 	if err != nil {
@@ -280,11 +280,12 @@ func (i *importer) importFlat(src *gorm.DB, query string, resolveKey func(string
 			work, live, redirects = i.works.resolve(id)
 		} else {
 			var raw sql.NullString
-			if err := rows.Scan(&uid, &raw, &created, &updated); err != nil {
+			var mirror sql.NullInt64
+			if err := rows.Scan(&uid, &raw, &mirror, &created, &updated); err != nil {
 				return c, err
 			}
 			var outcome vndbOutcome
-			work, redirects, outcome = resolveKey(raw.String)
+			work, redirects, outcome = resolveKey(raw.String, mirror)
 			switch outcome {
 			case vndbPending:
 				c.SkippedPending++

--- a/apps/api/cmd/import-favorites/resolve.go
+++ b/apps/api/cmd/import-favorites/resolve.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"strconv"
 	"strings"
 
@@ -121,4 +122,29 @@ func (w *workResolver) resolveVNDB(raw string) (int64, bool, vndbOutcome) {
 		return 0, redirected, vndbNoAnchor
 	}
 	return work, redirected, vndbResolved
+}
+
+// resolveMoyuPatch prefers the vndb route and falls back to the patch row's own
+// catalog_work_id.
+//
+// That column normally adds nothing: it is derived from vndb_id by moyu's own
+// backfill, so wherever it is set the vndb route already resolved. It earns its
+// place on the rows the vndb route cannot see at all. Catalog identifies only
+// 29% of its live works by a vndb anchor (65,058 of 225,238), and on 2026-09-08
+// four moyu pages were mapped by hand from bangumi / erogamescape / dlsite
+// anchors instead — 34 favourites that would otherwise stay stranded with the
+// answer sitting in a column nothing read.
+//
+// The fallback still goes through resolve(), so a hand-written id that names a
+// merged or retired work is followed or refused rather than trusted.
+func (w *workResolver) resolveMoyuPatch(raw string, mirror sql.NullInt64) (int64, bool, vndbOutcome) {
+	work, redirected, outcome := w.resolveVNDB(raw)
+	if outcome == vndbResolved || !mirror.Valid {
+		return work, redirected, outcome
+	}
+	fallback, ok, viaRedirect := w.resolve(mirror.Int64)
+	if !ok {
+		return 0, redirected, outcome
+	}
+	return fallback, viaRedirect, vndbResolved
 }


### PR DESCRIPTION
The moyu favourites lane resolves a patch page through `patch.vndb_id` and nothing else, which quietly assumes catalog identifies its works by vndb. Measured on production 2026-09-08, it mostly does not:

| live works | 225,238 |
|---|---|
| carrying a vndb identity anchor | **65,058 (29%)** |
| identified only by bangumi / erogamescape / dmm / steam | 15,405 |
| no external identity anchor at all | 144,775 |

`patch.catalog_work_id` is moyu's own statement of which work a page is about. Where the vndb route works, the column adds nothing — it is *derived* from `vndb_id`. It earns its place on the rows the vndb route cannot see at all: four moyu pages were mapped by hand from bangumi / erogamescape / dlsite anchors, and the lane read none of them. **34 favourites, 34 people, stranded with the answer already sitting in the row.**

The fallback is deliberately narrow:

- it fires **only** when the vndb route came back empty (`pending-` placeholder, or a v-number with no exact anchor);
- it still goes through `resolve()`, so a hand-written id naming a merged work is followed to its survivor and one naming a dead work is refused rather than trusted.

### The four rows it unlocks

| patch | vndb_id | → work | resolved by |
|---|---|---|---|
| 7494 | `pending-7494` | 7323 | bangumi 550808 *and* egs 38246 (both exact) *and* dlsite RJ01341157 |
| 6682 | `pending-6682` | 6526 | bangumi 83843 (exact) + dlsite VJ003627 |
| 1245 | `v7635` | 1241 | bangumi 63070 (exact); the patch's own v7635 is a probable anchor on that same work, so the two agree |
| 4107 | `v8739` | 4082 | bangumi 224744 (exact); same corroboration via v8739 |

### One candidate deliberately left out

Patch **7668** carries 34 favourites and its bangumi id resolves to work 2755 — but that work's own **exact** vndb anchor is `v54849` while the patch claims `v134628`. Two different VNDB entries, and catalog has never held a `v134628` anchor at all, dead or alive. One of the two ids is wrong and nothing in the data says which, so those 34 favourites stay where they are rather than being hung on a guess.

### Test stub drift

The test's stub `patch` table had no `catalog_work_id` column, so the new `SELECT` failed outright until it grew one. That is the loud, good case of stub-vs-table drift — worth noting because the quiet case is what this repo has been bitten by before.

### Verification

`gofmt` clean, `go vet` clean, `go test ./cmd/import-favorites/ -count=1 -p 1` green — 7 tests, 1.777s against a real ephemeral Postgres (not the millisecond finish of a skipped DB suite). The new test discriminates: without the change `ItemsInserted` is 1, not 4.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
