### PR TITLE
fix(catalog): the editing cap counted every first-party site as third party

### DIFF
--- a/apps/api/cmd/catalog/binding.go
+++ b/apps/api/cmd/catalog/binding.go
@@ -1,0 +1,16 @@
+package main
+
+import siteModel "api/internal/platform/site/model"
+
+// The v2 editing cap keys on this, and keying it on owner_user_id alone froze
+// the whole editing pipeline: 47 open proposals and not one merge between
+// 2026-08-28 and 2026-09-08. owner_user_id means only "the developer portal
+// owns this app", and the assumption that a site-bound client therefore has it
+// NULL is false in production — the forum, patch, sticker and LetMoe clients
+// all carry owner_user_id = 2, so all four first-party sites were capped and
+// AllowsReview/AllowsAutomerge returned false before reading any permission,
+// admins included. catalog_site is the durable marker instead: devapi never
+// writes it, so an app registered through the portal cannot have one.
+func isThirdPartyEditClient(cl *siteModel.OAuthClient) bool {
+	return cl != nil && cl.CatalogSite == "" && cl.OwnerUserID != nil
+}

--- a/apps/api/cmd/catalog/binding_test.go
+++ b/apps/api/cmd/catalog/binding_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	siteModel "api/internal/platform/site/model"
+)
+
+func TestIsThirdPartyEditClient(t *testing.T) {
+	owner := uint(2)
+	dev := uint(7311)
+
+	cases := []struct {
+		name string
+		cl   *siteModel.OAuthClient
+		want bool
+	}{
+		// The four production rows that were capped. Each is bound to a catalog
+		// site AND owned by user 2, which is the shape the old predicate missed.
+		{"forum", &siteModel.OAuthClient{CatalogSite: "kungal", OwnerUserID: &owner}, false},
+		{"patch", &siteModel.OAuthClient{CatalogSite: "kungal", OwnerUserID: &owner}, false},
+		{"sticker", &siteModel.OAuthClient{CatalogSite: "sticker", OwnerUserID: &owner}, false},
+		{"letmoe", &siteModel.OAuthClient{CatalogSite: "letmoe", OwnerUserID: &owner}, false},
+
+		// What the cap is actually for: a portal-registered app, which cannot
+		// carry a catalog_site because devapi never writes one.
+		{"developer app", &siteModel.OAuthClient{OwnerUserID: &dev}, true},
+
+		{"unowned service client", &siteModel.OAuthClient{}, false},
+		{"unowned site client", &siteModel.OAuthClient{CatalogSite: "news"}, false},
+		{"nil", nil, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isThirdPartyEditClient(c.cl); got != c.want {
+				t.Fatalf("isThirdPartyEditClient() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/apps/api/cmd/catalog/main.go
+++ b/apps/api/cmd/catalog/main.go
@@ -314,16 +314,12 @@ func setupPublicCatalog(
 		return err
 	})
 
-	// owner_user_id is set only on a developer-owned app; every client bound to
-	// a catalog site in production has it NULL. Wave R3 deleted the v1 surface
-	// that read it, and PolicyContext.ModerationCapped has been set by nothing
-	// since.
 	bindingOfClient := func(ctx context.Context, clientID string) (v2handler.SiteBinding, error) {
 		cl, err := clientRepo.FindByClientID(ctx, clientID)
 		if err != nil || cl == nil {
 			return v2handler.SiteBinding{}, err
 		}
-		return v2handler.SiteBinding{Site: cl.CatalogSite, ThirdParty: cl.OwnerUserID != nil}, nil
+		return v2handler.SiteBinding{Site: cl.CatalogSite, ThirdParty: isThirdPartyEditClient(cl)}, nil
 	}
 	siteOfClient := func(ctx context.Context, clientID string) (string, error) {
 		bind, err := bindingOfClient(ctx, clientID)


### PR DESCRIPTION
## The outage

The catalog editing pipeline has been frozen for eleven days. Measured on prod today:

| `edit_proposal.status` | rows | first | last |
|---|---|---|---|
| 0 open | **47** | 2026-08-29 | 2026-09-08 |
| 1 merged | 1,095 | 2026-06-05 | **2026-08-28** |

`edit_revision`: 12,836 rows, the last one `2026-08-28 18:03:50 UTC`. Merges ran for three months, stopped dead on 08-28, and open proposals started piling up the next day.

## Cause

74f978f7 restored `PolicyContext.ModerationCapped`, which had been set by nothing since wave R3, keying it on the client's `owner_user_id` under this comment:

> `owner_user_id` is set only on a developer-owned app; every client bound to a catalog site in production has it NULL.

That is false in production. The only four apps user 2 owns are the four first-party site clients:

```
kungal  | 鲲 Galgame 论坛   | owner_user_id=2
kungal  | 鲲 Galgame 补丁   | owner_user_id=2
sticker | 鲲 Galgame 表情包 | owner_user_id=2
letmoe  | LetMoe·一起萌     | owner_user_id=2
```

So `ThirdParty` was true for every first-party site. `AllowsReview` and `allowsAutomergeWithOwner` (`editing/registry.go:74,91`) both return on the cap **before** reading any permission, so nothing an admin holds could reach a verdict — proposals could neither automerge nor be approved. The queue still *lists* them, because moderation listing uses the uncapped `Moderates` permission. That combination is the reported symptom: an admin's own change lands in the review queue and the admin cannot review it.

## Fix

Key the cap on `catalog_site` instead. `devapi` never writes that column — a developer cannot bind an app to a catalog site — so a portal-registered app still has no site and is still capped, which is exactly what the cap was built for. The predicate changes the verdict for those four rows and for nothing else.

The alternative was to NULL `owner_user_id` on the four rows. That is worse on two counts: `devapi/repository.go:295` lists the portal by `owner_user_id != nil`, so it would drop all four apps out of the developer portal; and it would leave the same trap armed for the next site client registered through it. `catalog_site` is structurally infra-only; `owner_user_id IS NULL` is a convention no constraint protects and production had already broken it 4 rows out of 6.

## Verification

`binding_test.go` pins all four production rows plus a portal app as the positive control. Post-deploy, expect the 47 open proposals to become reviewable and merges to resume.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
