### PR TITLE
fix(apiv2): the news face pays its partner obligations (spec 2.17.0)

### DIFF
--- a/apps/api/cmd/catalog/main.go
+++ b/apps/api/cmd/catalog/main.go
@@ -151,7 +151,7 @@ func main() {
 		}()
 		newsSvc = newsService.NewPublicService(newsDB.DB(), cfg.ImageService.CDNBase)
 		newsAdminSvc = newsService.NewAdminService(newsDB.DB(), cfg.ImageService.CDNBase)
-		newsWriteSvc = newsService.NewSubmissionService(newsDB.DB())
+		newsWriteSvc = newsService.NewSubmissionService(newsDB.DB(), cfg.ImageService.CDNBase)
 	}
 
 	// The moderation face is the human half of the gate 月幕 asked for. It is a

--- a/apps/api/internal/platform/apiv2/collect/work.go
+++ b/apps/api/internal/platform/apiv2/collect/work.go
@@ -112,7 +112,7 @@ func NewsSpec() Spec {
 		Sort:    []string{"published"},
 		Include: []string{},
 		FullSet: []string{},
-		Fields:  []string{"object", "id", "title", "summary", "source", "source_url", "published_at"},
+		Fields:  []string{"object", "id", "title", "summary", "source", "source_url", "banner", "published_at"},
 		Facets:  []string{},
 		NoBatch: true,
 	}

--- a/apps/api/internal/platform/apiv2/handler/catalog.go
+++ b/apps/api/internal/platform/apiv2/handler/catalog.go
@@ -165,6 +165,9 @@ func (c *Catalog) NewsItem(ctx context.Context, id int64) (repr.NewsItem, error)
 	}
 	rec, err := c.News.Item(ctx, id)
 	if err != nil {
+		if errors.Is(err, newssvc.ErrGone) {
+			return repr.NewsItem{}, problem.New(problem.CodeGone, "", "", "this news item was withdrawn by its source.")
+		}
 		if errors.Is(err, newssvc.ErrNotFound) {
 			return repr.NewsItem{}, problem.New(problem.CodeNotFound, "", "", "news item not found.")
 		}
@@ -213,10 +216,25 @@ func newsFromDTO(rec newsdto.PublicNewsItem) repr.NewsItem {
 	return repr.NewsItem{
 		Object: "news_item", ID: repr.ID(rec.ID), Title: rec.Title, Summary: rec.Preview,
 		Source: newsSourceFromDTO(rec.Source), SourceURL: rec.SourceURL,
+		Banner:      newsBanner(rec.BannerHash, rec.BannerURL),
 		PublishedAt: rec.PublishedAt.UTC().Format("2006-01-02T15:04:05Z"),
 	}
 }
 
+// The news service already built the URL off the same cdnBase, so this reuses
+// it rather than threading the base in a second time. source stays empty: it
+// is the `sources` vocabulary, which names catalog anchors, and a partner's
+// banner belongs to none of them.
+func newsBanner(hash, url string) *repr.Image {
+	if hash == "" || url == "" {
+		return nil
+	}
+	return &repr.Image{URL: url, Hash: hash}
+}
+
 func newsSourceFromDTO(s newsdto.PublicNewsSource) repr.NewsSource {
-	return repr.NewsSource{Object: "news_source", Name: s.Key, DisplayName: s.DisplayName}
+	return repr.NewsSource{
+		Object: "news_source", Name: s.Key, DisplayName: s.DisplayName,
+		HomepageURL: s.HomepageURL,
+	}
 }

--- a/apps/api/internal/platform/apiv2/handler/live_news_obligations_test.go
+++ b/apps/api/internal/platform/apiv2/handler/live_news_obligations_test.go
@@ -1,0 +1,113 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"api/internal/platform/apiv2/problem"
+	newsmodel "api/internal/platform/news/model"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The three obligations D16 traded the credential gate for live in
+// refs/api-v2/03-resources.md §2.4. Two of them were unmet on the wire: the
+// source shipped without its homepage, and a withdrawn item answered 404.
+type newsPublicView struct {
+	ID     string `json:"id"`
+	Banner *struct {
+		URL  string `json:"url"`
+		Hash string `json:"hash"`
+	} `json:"banner"`
+	Source struct {
+		Name        string `json:"name"`
+		DisplayName string `json:"display_name"`
+		HomepageURL string `json:"homepage_url"`
+	} `json:"source"`
+	SourceURL string `json:"source_url"`
+}
+
+const obligHash = "1111111111111111111111111111111111111111111111111111111111111111"
+
+func seedObligationItem(t *testing.T, env *liveEnv, external string, status int16, hash string) string {
+	t.Helper()
+	require.NoError(t, env.db.Exec(`
+		INSERT INTO news_source (key, display_name, homepage_url, attribution, publisher_uid, column_url, active)
+		VALUES ('oblig_src', 'Oblig Source', 'https://source.example.test', 'reprinted from Oblig', ?, '', true)
+		ON CONFLICT (key) DO UPDATE SET homepage_url = EXCLUDED.homepage_url, active = true`, liveUID).Error)
+	require.NoError(t, env.db.Exec(`DELETE FROM news_item WHERE external_id = ?`, external).Error)
+	require.NoError(t, env.db.Exec(`
+		INSERT INTO news_item (source_key, lane, upstream_category, external_id, title, preview,
+			source_url, banner_hash, banner_origin_url, published_at, status)
+		VALUES ('oblig_src', ?, '', ?, 't', 'p', 'https://source.example.test/x', ?, '', now(), ?)`,
+		newsmodel.LaneNews, external, hash, status).Error)
+	var id int64
+	require.NoError(t, env.db.Raw(`SELECT id FROM news_item WHERE external_id = ?`, external).Scan(&id).Error)
+	return idstr(id)
+}
+
+// Obligation 1: 署名必发 -- the source object must carry display_name AND the
+// site homepage, on every item, so a consumer rendering one item alone can
+// still attribute it.
+func TestLiveNewsSourceCarriesItsHomepage(t *testing.T) {
+	env := liveCatalog(t)
+	id := seedObligationItem(t, env, "oblig-home", newsmodel.StatusPublished, "")
+
+	status, _, raw := liveDo(t, env, http.MethodGet, "/v2/news/"+id, "", "")
+	require.Equal(t, http.StatusOK, status, string(raw))
+
+	var v newsPublicView
+	require.NoError(t, json.Unmarshal(raw, &v), string(raw))
+	require.Equal(t, "Oblig Source", v.Source.DisplayName)
+	require.Equal(t, "https://source.example.test", v.Source.HomepageURL,
+		"obligation 1 requires the source's own site, not just its name")
+	require.NotEmpty(t, v.SourceURL)
+}
+
+// Obligation 2: the type carries `banner`, and B10 forbids publishing a bare
+// content hash -- so it ships as the one Image type, url and all.
+func TestLiveNewsBannerIsAnImageNotAHash(t *testing.T) {
+	env := liveCatalog(t)
+	id := seedObligationItem(t, env, "oblig-banner", newsmodel.StatusPublished, obligHash)
+
+	_, _, raw := liveDo(t, env, http.MethodGet, "/v2/news/"+id, "", "")
+	var v newsPublicView
+	require.NoError(t, json.Unmarshal(raw, &v), string(raw))
+	require.NotNil(t, v.Banner, "an item with a banner_hash must ship a banner")
+	require.Equal(t, obligHash, v.Banner.Hash)
+	require.NotEmpty(t, v.Banner.URL, "B10: never a bare hash")
+	require.Contains(t, v.Banner.URL, liveNewsCDNBase)
+	require.Contains(t, v.Banner.URL, obligHash)
+
+	// Negative control: no hash means null, not an empty Image.
+	none := seedObligationItem(t, env, "oblig-nobanner", newsmodel.StatusPublished, "")
+	_, _, raw2 := liveDo(t, env, http.MethodGet, "/v2/news/"+none, "", "")
+	var v2 newsPublicView
+	require.NoError(t, json.Unmarshal(raw2, &v2), string(raw2))
+	require.Nil(t, v2.Banner)
+}
+
+// Obligation 3: a withdrawn item answers 410, not 404. The face is public and
+// credential-less, so mirrors exist; one that only sees the item leave the list
+// never learns the copy it already took was pulled.
+func TestLiveNewsWithdrawnDetailIsGone(t *testing.T) {
+	env := liveCatalog(t)
+	gone := seedObligationItem(t, env, "oblig-withdrawn", newsmodel.StatusWithdrawn, "")
+
+	status, _, raw := liveDo(t, env, http.MethodGet, "/v2/news/"+gone, "", "")
+	require.Equal(t, http.StatusGone, status, string(raw))
+	require.Equal(t, problem.CodeGone, liveProblem(t, raw).Code)
+
+	// Positive control: an id that never existed is still 404, so "everything
+	// is 410 now" cannot pass as a fix.
+	status, _, raw = liveDo(t, env, http.MethodGet, "/v2/news/98765432", "", "")
+	require.Equal(t, http.StatusNotFound, status, string(raw))
+	require.Equal(t, problem.CodeNotFound, liveProblem(t, raw).Code)
+
+	// And a pending item stays 404: it was never published, so no mirror can
+	// hold a copy to invalidate.
+	pending := seedObligationItem(t, env, "oblig-pending", newsmodel.StatusPending, "")
+	status, _, _ = liveDo(t, env, http.MethodGet, "/v2/news/"+pending, "", "")
+	require.Equal(t, http.StatusNotFound, status)
+}

--- a/apps/api/internal/platform/apiv2/handler/live_setup_test.go
+++ b/apps/api/internal/platform/apiv2/handler/live_setup_test.go
@@ -137,9 +137,12 @@ const liveBulkRows = 105
 const (
 	liveNewsSource = "moyu"
 	liveCDNBase    = "https://img.example.test/image"
-	liveLogoHash   = "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809"
-	livePhotoHash  = "9f8e7d6c5b4a39281706f5e4d3c2b1a09f8e7d6c5b4a39281706f5e4d3c2b1a0"
-	liveCoverHash  = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	// The news services have always used their own base; naming it keeps the two
+	// news constructors from drifting apart.
+	liveNewsCDNBase = "https://image.example.test/image"
+	liveLogoHash    = "1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f809"
+	livePhotoHash   = "9f8e7d6c5b4a39281706f5e4d3c2b1a09f8e7d6c5b4a39281706f5e4d3c2b1a0"
+	liveCoverHash   = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 )
 
 type liveEnv struct {
@@ -205,8 +208,8 @@ func liveCatalog(t *testing.T) *liveEnv {
 			CoverVotes: catsvc.NewCoverVoteService(db),
 			Claims:     catsvc.NewClaimLifecycleService(db),
 			Engine:     editing.NewEngine(db, reg),
-			News:       newssvc.NewPublicService(db, "https://image.example.test/image"),
-			NewsWrite:  newssvc.NewSubmissionService(db),
+			News:       newssvc.NewPublicService(db, liveNewsCDNBase),
+			NewsWrite:  newssvc.NewSubmissionService(db, liveNewsCDNBase),
 		}
 		cat.EditHistory = catsvc.NewEditHistoryService(db)
 		app := fiber.New(fiber.Config{ErrorHandler: problem.WriteFiberError})

--- a/apps/api/internal/platform/apiv2/handler/me_news_map.go
+++ b/apps/api/internal/platform/apiv2/handler/me_news_map.go
@@ -138,15 +138,16 @@ func newsSubmissionRecord(s newssvc.Submission) repr.NewsSubmission {
 		works = append(works, repr.ID(id))
 	}
 	return repr.NewsSubmission{
-		Object:      "news_submission",
-		ID:          repr.ID(s.ID),
-		Source:      repr.NewsSource{Object: "news_source", Name: s.SourceKey, DisplayName: s.SourceDisplayName},
+		Object: "news_submission",
+		ID:     repr.ID(s.ID),
+		Source: repr.NewsSource{Object: "news_source", Name: s.SourceKey,
+			DisplayName: s.SourceDisplayName, HomepageURL: s.SourceHomepageURL},
 		Lane:        s.Lane,
 		Status:      newsStatusToken(s.Status),
 		Title:       s.Title,
 		Summary:     s.Preview,
 		SourceURL:   s.SourceURL,
-		BannerHash:  s.BannerHash,
+		Banner:      newsBanner(s.BannerHash, s.BannerURL),
 		PublishedAt: repr.TimeUTC(s.PublishedAt),
 		WorkIDs:     works,
 	}

--- a/apps/api/internal/platform/apiv2/handler/setup.go
+++ b/apps/api/internal/platform/apiv2/handler/setup.go
@@ -57,7 +57,7 @@ func SetupWith(app *fiber.App, opt Options) huma.API {
 	app.Use(protocol.RateLimit(opt.Store, credentialLimitIdentity))
 	app.Use(protocol.Idempotency(opt.Store, credentialLimitIdentity))
 
-	cfg := huma.DefaultConfig("NextMoe Public API v2", "2.16.0")
+	cfg := huma.DefaultConfig("NextMoe Public API v2", "2.17.0")
 	cfg.OpenAPIPath = ""
 	cfg.DocsPath = ""
 	cfg.SchemasPath = ""

--- a/apps/api/internal/platform/apiv2/repr/entity.go
+++ b/apps/api/internal/platform/apiv2/repr/entity.go
@@ -174,6 +174,7 @@ type NewsSource struct {
 	Object      string   `json:"object" enum:"news_source" doc:"Type discriminant. Always news_source."`
 	Name        string   `json:"name" maxLength:"64" pattern:"^[a-z][a-z0-9_]*$" doc:"Source key."`
 	DisplayName string   `json:"display_name" maxLength:"512" doc:"Must not be used as a discriminant."`
+	HomepageURL string   `json:"homepage_url" format:"uri" maxLength:"512" doc:"The source's own site. Empty string when the source has none."`
 }
 
 type NewsItem struct {
@@ -184,6 +185,7 @@ type NewsItem struct {
 	Summary     string     `json:"summary" maxLength:"8000" doc:"Source-provided lede. Must not be used as a discriminant."`
 	Source      NewsSource `json:"source" doc:"Attribution. Required on view=basic."`
 	SourceURL   string     `json:"source_url" format:"uri" maxLength:"1024" doc:"Canonical link to the original item."`
+	Banner      *Image     `json:"banner" doc:"Lead image. null when the item has none."`
 	PublishedAt string     `json:"published_at" format:"date-time" maxLength:"32" doc:"RFC 3339 UTC."`
 }
 

--- a/apps/api/internal/platform/apiv2/repr/me.go
+++ b/apps/api/internal/platform/apiv2/repr/me.go
@@ -124,7 +124,7 @@ type NewsSubmission struct {
 	Title       string     `json:"title" maxLength:"512" doc:"Must not be used as a discriminant."`
 	Summary     string     `json:"summary" maxLength:"200" doc:"Lede, at most 200 runes. Must not be used as a discriminant."`
 	SourceURL   string     `json:"source_url" format:"uri" maxLength:"1024" doc:"Canonical link to the original item."`
-	BannerHash  string     `json:"banner_hash" maxLength:"64" pattern:"^([0-9a-f]{64})?$" doc:"Image-service content hash of the banner. Empty string when there is none."`
+	Banner      *Image     `json:"banner" doc:"Lead image. null when there is none. B10: never a bare hash."`
 	PublishedAt string     `json:"published_at" format:"date-time" maxLength:"32" doc:"RFC 3339 UTC."`
 	WorkIDs     []string   `json:"work_ids" doc:"Catalog work ids linked by hand. Empty array, never null."`
 }

--- a/apps/api/internal/platform/news/dto/public_dto.go
+++ b/apps/api/internal/platform/news/dto/public_dto.go
@@ -24,6 +24,7 @@ type PublicNewsItem struct {
 	Title       string           `json:"title"`
 	Preview     string           `json:"preview"`
 	BannerURL   string           `json:"banner_url,omitempty"`
+	BannerHash  string           `json:"banner_hash,omitempty"`
 	Images      []string         `json:"images,omitempty"`
 	PublishedAt time.Time        `json:"published_at"`
 	WorkIDs     []int64          `json:"work_ids,omitempty"`

--- a/apps/api/internal/platform/news/service/public.go
+++ b/apps/api/internal/platform/news/service/public.go
@@ -20,6 +20,11 @@ import (
 var (
 	ErrBadCursor = stderrors.New("news: malformed or mismatched cursor")
 	ErrNotFound  = stderrors.New("news: item not found")
+	// A withdrawn item is not a 404. Public and credential-less means mirrors
+	// exist, and a mirror that only sees the item leave the list never learns
+	// the copy it already took was pulled -- which is why the detail face owes
+	// a 410 (03-resources.md:142, obligation 3 of D16).
+	ErrGone = stderrors.New("news: item withdrawn")
 )
 
 // cursorSort names the ordering a cursor was minted under, so a cursor from a
@@ -129,6 +134,8 @@ type itemRow struct {
 	SourceURL   string `gorm:"column:source_url"`
 	BannerHash  string `gorm:"column:banner_hash"`
 	PublishedAt time.Time
+	// Only Item() selects this; Feed already filters on status in SQL.
+	Status int16
 }
 
 func (s *PublicService) Feed(ctx context.Context, f FeedFilter, cursor string, limit int) (dto.PublicNewsFeedData, error) {
@@ -170,12 +177,18 @@ func (s *PublicService) Feed(ctx context.Context, f FeedFilter, cursor string, l
 
 func (s *PublicService) Item(ctx context.Context, id int64) (dto.PublicNewsItem, error) {
 	var rows []itemRow
-	q := `SELECT i.id, i.source_key, i.lane, i.title, i.preview, i.source_url, i.banner_hash, i.published_at
-		FROM news_item i WHERE i.id = ? AND i.status = ? AND i.dead_at IS NULL`
-	if err := s.db.WithContext(ctx).Raw(q, id, model.StatusPublished).Scan(&rows).Error; err != nil {
+	q := `SELECT i.id, i.source_key, i.lane, i.title, i.preview, i.source_url, i.banner_hash, i.published_at, i.status
+		FROM news_item i WHERE i.id = ? AND i.dead_at IS NULL`
+	if err := s.db.WithContext(ctx).Raw(q, id).Scan(&rows).Error; err != nil {
 		return dto.PublicNewsItem{}, err
 	}
 	if len(rows) == 0 {
+		return dto.PublicNewsItem{}, ErrNotFound
+	}
+	if rows[0].Status == model.StatusWithdrawn {
+		return dto.PublicNewsItem{}, ErrGone
+	}
+	if rows[0].Status != model.StatusPublished {
 		return dto.PublicNewsItem{}, ErrNotFound
 	}
 	items, err := s.buildItems(ctx, rows)
@@ -234,6 +247,7 @@ func (s *PublicService) buildItems(ctx context.Context, rows []itemRow) ([]dto.P
 			Title:       r.Title,
 			Preview:     r.Preview,
 			BannerURL:   s.imageURL(r.BannerHash),
+			BannerHash:  r.BannerHash,
 			Images:      images[r.ID],
 			PublishedAt: r.PublishedAt.UTC(),
 			WorkIDs:     works[r.ID],

--- a/apps/api/internal/platform/news/service/public_test.go
+++ b/apps/api/internal/platform/news/service/public_test.go
@@ -87,9 +87,19 @@ func TestVisibilityContract(t *testing.T) {
 	if len(feed.Items) != 1 || feed.Items[0].ID != live {
 		t.Fatalf("feed must contain only the live item, got %d items", len(feed.Items))
 	}
+	// Withdrawn is the one state that owes a distinguishable answer: the face is
+	// public and credential-less, so mirrors exist, and a mirror that only sees
+	// the item leave the list never learns its copy was pulled. 03-resources.md
+	// obligation 3 makes that a 410, which needs an error 404 cannot carry.
+	// dead_at is not a withdrawal -- it means the upstream item vanished on us --
+	// so it stays a 404.
+	want := map[string]error{
+		"pending": ErrNotFound, "rejected": ErrNotFound,
+		"withdrawn": ErrGone, "dead": ErrNotFound,
+	}
 	for name, id := range hidden {
-		if _, err := svc.Item(context.Background(), id); err != ErrNotFound {
-			t.Errorf("detail of a %s item returned %v, want ErrNotFound", name, err)
+		if _, err := svc.Item(context.Background(), id); err != want[name] {
+			t.Errorf("detail of a %s item returned %v, want %v", name, err, want[name])
 		}
 	}
 	if _, err := svc.Item(context.Background(), live); err != nil {

--- a/apps/api/internal/platform/news/service/submission.go
+++ b/apps/api/internal/platform/news/service/submission.go
@@ -13,6 +13,8 @@ import (
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+
+	"api/pkg/imageclient"
 )
 
 var (
@@ -30,22 +32,25 @@ var (
 const nativeExternalIDPrefix = "api_"
 
 type SubmissionService struct {
-	db *gorm.DB
+	db      *gorm.DB
+	cdnBase string
 }
 
-func NewSubmissionService(db *gorm.DB) *SubmissionService {
-	return &SubmissionService{db: db}
+func NewSubmissionService(db *gorm.DB, cdnBase string) *SubmissionService {
+	return &SubmissionService{db: db, cdnBase: cdnBase}
 }
 
 type Submission struct {
 	ID                int64
 	SourceKey         string
 	SourceDisplayName string
+	SourceHomepageURL string
 	Lane              string
 	Title             string
 	Preview           string
 	SourceURL         string
 	BannerHash        string
+	BannerURL         string
 	PublishedAt       time.Time
 	Status            int16
 	UpdatedAt         time.Time
@@ -299,8 +304,10 @@ func (s *SubmissionService) decorate(ctx context.Context, rows []model.NewsItem)
 		return nil, err
 	}
 	names := make(map[string]string, len(sources))
+	homes := make(map[string]string, len(sources))
 	for _, src := range sources {
 		names[src.Key] = src.DisplayName
+		homes[src.Key] = src.HomepageURL
 	}
 	var links []model.NewsItemWork
 	if err := s.db.WithContext(ctx).Where("item_id IN ?", ids).
@@ -314,8 +321,10 @@ func (s *SubmissionService) decorate(ctx context.Context, rows []model.NewsItem)
 	for _, r := range rows {
 		out = append(out, Submission{
 			ID: r.ID, SourceKey: r.SourceKey, SourceDisplayName: names[r.SourceKey],
-			Lane: r.Lane, Title: r.Title, Preview: r.Preview, SourceURL: r.SourceURL,
-			BannerHash: r.BannerHash, PublishedAt: r.PublishedAt.UTC(), Status: r.Status,
+			SourceHomepageURL: homes[r.SourceKey],
+			Lane:              r.Lane, Title: r.Title, Preview: r.Preview, SourceURL: r.SourceURL,
+			BannerHash: r.BannerHash, BannerURL: s.imageURL(r.BannerHash),
+			PublishedAt: r.PublishedAt.UTC(), Status: r.Status,
 			UpdatedAt: r.UpdatedAt.UTC(), WorkIDs: works[r.ID],
 		})
 	}
@@ -326,4 +335,11 @@ func mintExternalID() string {
 	var raw [16]byte
 	_, _ = rand.Read(raw[:])
 	return nativeExternalIDPrefix + hex.EncodeToString(raw[:])
+}
+
+func (s *SubmissionService) imageURL(hash string) string {
+	if hash == "" || s.cdnBase == "" {
+		return ""
+	}
+	return imageclient.MainURL(s.cdnBase, hash, "webp")
 }

--- a/apps/api/internal/platform/news/service/submission_test.go
+++ b/apps/api/internal/platform/news/service/submission_test.go
@@ -22,7 +22,7 @@ func newSubmissionFixture(t *testing.T) *SubmissionService {
 	seedSource(t, "moyu", minePublisher, true)
 	seedSource(t, "sleeping", minePublisher, false)
 	seedSource(t, "someone_else", otherPublisher, true)
-	return NewSubmissionService(testDB)
+	return NewSubmissionService(testDB, "https://img.example.test")
 }
 
 func seedSource(t *testing.T, key string, uid int64, active bool) {

--- a/apps/developer/app/generated/docs-model.ts
+++ b/apps/developer/app/generated/docs-model.ts
@@ -72665,6 +72665,79 @@ export const docsModel: DocsModel = {
                           "type": "object",
                           "children": [
                             {
+                              "name": "banner",
+                              "required": true,
+                              "type": "object",
+                              "children": [
+                                {
+                                  "name": "hash",
+                                  "required": true,
+                                  "doc": "Image-service content hash.",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "height",
+                                  "required": true,
+                                  "nullable": true,
+                                  "doc": "Pixel height. null if unknown.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                {
+                                  "name": "sexual",
+                                  "required": true,
+                                  "nullable": true,
+                                  "doc": "Sexual depiction. null means not assessed.",
+                                  "enum": [
+                                    "safe",
+                                    "suggestive",
+                                    "explicit"
+                                  ],
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "source",
+                                  "required": true,
+                                  "doc": "Open vocabulary sources. Must not be used as a discriminant.",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "thumbhash",
+                                  "required": true,
+                                  "nullable": true,
+                                  "doc": "Thumbhash. null if unknown.",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "url",
+                                  "required": true,
+                                  "doc": "Absolute image URL. Never a bare hash.",
+                                  "format": "uri",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "violence",
+                                  "required": true,
+                                  "nullable": true,
+                                  "doc": "Violent depiction. null means not assessed. Currently no catalog row has an assessment; the value is always null.",
+                                  "enum": [
+                                    "tame",
+                                    "violent",
+                                    "brutal"
+                                  ],
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "width",
+                                  "required": true,
+                                  "nullable": true,
+                                  "doc": "Pixel width. null if unknown.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                }
+                              ]
+                            },
+                            {
                               "name": "id",
                               "required": true,
                               "doc": "News item id.",
@@ -72695,6 +72768,13 @@ export const docsModel: DocsModel = {
                                   "name": "display_name",
                                   "required": true,
                                   "doc": "Must not be used as a discriminant.",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "homepage_url",
+                                  "required": true,
+                                  "doc": "The source's own site. Empty string when the source has none.",
+                                  "format": "uri",
                                   "type": "string"
                                 },
                                 {
@@ -73458,6 +73538,13 @@ export const docsModel: DocsModel = {
                               "type": "string"
                             },
                             {
+                              "name": "homepage_url",
+                              "required": true,
+                              "doc": "The source's own site. Empty string when the source has none.",
+                              "format": "uri",
+                              "type": "string"
+                            },
+                            {
                               "name": "name",
                               "required": true,
                               "doc": "Source key.",
@@ -74035,6 +74122,79 @@ export const docsModel: DocsModel = {
                     "type": "object",
                     "children": [
                       {
+                        "name": "banner",
+                        "required": true,
+                        "type": "object",
+                        "children": [
+                          {
+                            "name": "hash",
+                            "required": true,
+                            "doc": "Image-service content hash.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "height",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Pixel height. null if unknown.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "sexual",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Sexual depiction. null means not assessed.",
+                            "enum": [
+                              "safe",
+                              "suggestive",
+                              "explicit"
+                            ],
+                            "type": "string"
+                          },
+                          {
+                            "name": "source",
+                            "required": true,
+                            "doc": "Open vocabulary sources. Must not be used as a discriminant.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "thumbhash",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Thumbhash. null if unknown.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "url",
+                            "required": true,
+                            "doc": "Absolute image URL. Never a bare hash.",
+                            "format": "uri",
+                            "type": "string"
+                          },
+                          {
+                            "name": "violence",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Violent depiction. null means not assessed. Currently no catalog row has an assessment; the value is always null.",
+                            "enum": [
+                              "tame",
+                              "violent",
+                              "brutal"
+                            ],
+                            "type": "string"
+                          },
+                          {
+                            "name": "width",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Pixel width. null if unknown.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        ]
+                      },
+                      {
                         "name": "id",
                         "required": true,
                         "doc": "News item id.",
@@ -74065,6 +74225,13 @@ export const docsModel: DocsModel = {
                             "name": "display_name",
                             "required": true,
                             "doc": "Must not be used as a discriminant.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "homepage_url",
+                            "required": true,
+                            "doc": "The source's own site. Empty string when the source has none.",
+                            "format": "uri",
                             "type": "string"
                           },
                           {
@@ -100150,10 +100317,77 @@ export const docsModel: DocsModel = {
                           "type": "object",
                           "children": [
                             {
-                              "name": "banner_hash",
+                              "name": "banner",
                               "required": true,
-                              "doc": "Image-service content hash of the banner. Empty string when there is none.",
-                              "type": "string"
+                              "type": "object",
+                              "children": [
+                                {
+                                  "name": "hash",
+                                  "required": true,
+                                  "doc": "Image-service content hash.",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "height",
+                                  "required": true,
+                                  "nullable": true,
+                                  "doc": "Pixel height. null if unknown.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                },
+                                {
+                                  "name": "sexual",
+                                  "required": true,
+                                  "nullable": true,
+                                  "doc": "Sexual depiction. null means not assessed.",
+                                  "enum": [
+                                    "safe",
+                                    "suggestive",
+                                    "explicit"
+                                  ],
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "source",
+                                  "required": true,
+                                  "doc": "Open vocabulary sources. Must not be used as a discriminant.",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "thumbhash",
+                                  "required": true,
+                                  "nullable": true,
+                                  "doc": "Thumbhash. null if unknown.",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "url",
+                                  "required": true,
+                                  "doc": "Absolute image URL. Never a bare hash.",
+                                  "format": "uri",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "violence",
+                                  "required": true,
+                                  "nullable": true,
+                                  "doc": "Violent depiction. null means not assessed. Currently no catalog row has an assessment; the value is always null.",
+                                  "enum": [
+                                    "tame",
+                                    "violent",
+                                    "brutal"
+                                  ],
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "width",
+                                  "required": true,
+                                  "nullable": true,
+                                  "doc": "Pixel width. null if unknown.",
+                                  "format": "int64",
+                                  "type": "integer"
+                                }
+                              ]
                             },
                             {
                               "name": "id",
@@ -100196,6 +100430,13 @@ export const docsModel: DocsModel = {
                                   "name": "display_name",
                                   "required": true,
                                   "doc": "Must not be used as a discriminant.",
+                                  "type": "string"
+                                },
+                                {
+                                  "name": "homepage_url",
+                                  "required": true,
+                                  "doc": "The source's own site. Empty string when the source has none.",
+                                  "format": "uri",
                                   "type": "string"
                                 },
                                 {
@@ -101360,10 +101601,77 @@ export const docsModel: DocsModel = {
                     "type": "object",
                     "children": [
                       {
-                        "name": "banner_hash",
+                        "name": "banner",
                         "required": true,
-                        "doc": "Image-service content hash of the banner. Empty string when there is none.",
-                        "type": "string"
+                        "type": "object",
+                        "children": [
+                          {
+                            "name": "hash",
+                            "required": true,
+                            "doc": "Image-service content hash.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "height",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Pixel height. null if unknown.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "sexual",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Sexual depiction. null means not assessed.",
+                            "enum": [
+                              "safe",
+                              "suggestive",
+                              "explicit"
+                            ],
+                            "type": "string"
+                          },
+                          {
+                            "name": "source",
+                            "required": true,
+                            "doc": "Open vocabulary sources. Must not be used as a discriminant.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "thumbhash",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Thumbhash. null if unknown.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "url",
+                            "required": true,
+                            "doc": "Absolute image URL. Never a bare hash.",
+                            "format": "uri",
+                            "type": "string"
+                          },
+                          {
+                            "name": "violence",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Violent depiction. null means not assessed. Currently no catalog row has an assessment; the value is always null.",
+                            "enum": [
+                              "tame",
+                              "violent",
+                              "brutal"
+                            ],
+                            "type": "string"
+                          },
+                          {
+                            "name": "width",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Pixel width. null if unknown.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        ]
                       },
                       {
                         "name": "id",
@@ -101406,6 +101714,13 @@ export const docsModel: DocsModel = {
                             "name": "display_name",
                             "required": true,
                             "doc": "Must not be used as a discriminant.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "homepage_url",
+                            "required": true,
+                            "doc": "The source's own site. Empty string when the source has none.",
+                            "format": "uri",
                             "type": "string"
                           },
                           {
@@ -102854,10 +103169,77 @@ export const docsModel: DocsModel = {
                     "type": "object",
                     "children": [
                       {
-                        "name": "banner_hash",
+                        "name": "banner",
                         "required": true,
-                        "doc": "Image-service content hash of the banner. Empty string when there is none.",
-                        "type": "string"
+                        "type": "object",
+                        "children": [
+                          {
+                            "name": "hash",
+                            "required": true,
+                            "doc": "Image-service content hash.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "height",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Pixel height. null if unknown.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "sexual",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Sexual depiction. null means not assessed.",
+                            "enum": [
+                              "safe",
+                              "suggestive",
+                              "explicit"
+                            ],
+                            "type": "string"
+                          },
+                          {
+                            "name": "source",
+                            "required": true,
+                            "doc": "Open vocabulary sources. Must not be used as a discriminant.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "thumbhash",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Thumbhash. null if unknown.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "url",
+                            "required": true,
+                            "doc": "Absolute image URL. Never a bare hash.",
+                            "format": "uri",
+                            "type": "string"
+                          },
+                          {
+                            "name": "violence",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Violent depiction. null means not assessed. Currently no catalog row has an assessment; the value is always null.",
+                            "enum": [
+                              "tame",
+                              "violent",
+                              "brutal"
+                            ],
+                            "type": "string"
+                          },
+                          {
+                            "name": "width",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Pixel width. null if unknown.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        ]
                       },
                       {
                         "name": "id",
@@ -102900,6 +103282,13 @@ export const docsModel: DocsModel = {
                             "name": "display_name",
                             "required": true,
                             "doc": "Must not be used as a discriminant.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "homepage_url",
+                            "required": true,
+                            "doc": "The source's own site. Empty string when the source has none.",
+                            "format": "uri",
                             "type": "string"
                           },
                           {
@@ -104032,10 +104421,77 @@ export const docsModel: DocsModel = {
                     "type": "object",
                     "children": [
                       {
-                        "name": "banner_hash",
+                        "name": "banner",
                         "required": true,
-                        "doc": "Image-service content hash of the banner. Empty string when there is none.",
-                        "type": "string"
+                        "type": "object",
+                        "children": [
+                          {
+                            "name": "hash",
+                            "required": true,
+                            "doc": "Image-service content hash.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "height",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Pixel height. null if unknown.",
+                            "format": "int64",
+                            "type": "integer"
+                          },
+                          {
+                            "name": "sexual",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Sexual depiction. null means not assessed.",
+                            "enum": [
+                              "safe",
+                              "suggestive",
+                              "explicit"
+                            ],
+                            "type": "string"
+                          },
+                          {
+                            "name": "source",
+                            "required": true,
+                            "doc": "Open vocabulary sources. Must not be used as a discriminant.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "thumbhash",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Thumbhash. null if unknown.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "url",
+                            "required": true,
+                            "doc": "Absolute image URL. Never a bare hash.",
+                            "format": "uri",
+                            "type": "string"
+                          },
+                          {
+                            "name": "violence",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Violent depiction. null means not assessed. Currently no catalog row has an assessment; the value is always null.",
+                            "enum": [
+                              "tame",
+                              "violent",
+                              "brutal"
+                            ],
+                            "type": "string"
+                          },
+                          {
+                            "name": "width",
+                            "required": true,
+                            "nullable": true,
+                            "doc": "Pixel width. null if unknown.",
+                            "format": "int64",
+                            "type": "integer"
+                          }
+                        ]
                       },
                       {
                         "name": "id",
@@ -104078,6 +104534,13 @@ export const docsModel: DocsModel = {
                             "name": "display_name",
                             "required": true,
                             "doc": "Must not be used as a discriminant.",
+                            "type": "string"
+                          },
+                          {
+                            "name": "homepage_url",
+                            "required": true,
+                            "doc": "The source's own site. Empty string when the source has none.",
+                            "format": "uri",
                             "type": "string"
                           },
                           {

--- a/apps/developer/i18n/docs-zh.json
+++ b/apps/developer/i18n/docs-zh.json
@@ -316,7 +316,7 @@
   "id is the catalog work id. Site-fenced. Requires a user access token bound to a catalog site. The token must carry the catalog:edit scope.": "id 为 catalog 作品 id。按站点隔离。需要绑定到 catalog 站点的用户访问令牌。令牌须带 catalog:edit scope。",
   "ids requested but not visible. Present only on the ids=/refs= batch lane.": "已请求但不可见的 ids。仅出现在 ids=/refs= 批量车道。",
   "If-Match required. Requires a user access token. The token must carry the catalog:edit scope.": "需要 If-Match。需要用户访问令牌。令牌须带 catalog:edit scope。",
-  "Image-service content hash of the banner. Empty string when there is none.": "横幅的图床内容哈希。没有时为空字符串。",
+  "The source's own site. Empty string when the source has none.": "来源自己的站点主页。该来源没有时为空字符串。",
   "Image-service content hash of the banner. The format is checked; existence is not.": "横幅的图床内容哈希。校验格式，不校验是否存在。",
   "Image-service content hash.": "图床内容哈希。",
   "Image-service content hash. The empty string clears the banner.": "图床内容哈希。空字符串清除横幅。",

--- a/docs/catalog/v2-openapi-breaking-ignore.txt
+++ b/docs/catalog/v2-openapi-breaking-ignore.txt
@@ -40,3 +40,25 @@ in API PATCH /v2/me/proposals/{id} the `header` request parameter `if-match` bec
 in API POST /v2/me/proposals/{id}/amendments the `header` request parameter `if-match` became required
 in API POST /v2/moderation/claims/{id}/decisions the `header` request parameter `if-match` became required
 in API POST /v2/moderation/proposals/{id}/decisions the `header` request parameter `if-match` became required
+
+# News partner obligations (2026-09-08): repr.NewsSubmission shipped `banner_hash`,
+# a bare image content hash, which B10 (01-axioms.md) forbids and 04 §7 replaces
+# with the one Image type -- "永远发完整 url". The four /v2/me/news responses now
+# carry `banner` (url + hash) instead, so the four entries below declare the
+# removal of the bare hash.
+#
+# No working client stops working, and that is measured rather than assumed: the
+# write face has never been used. Of 4,608 rows in news_item, 0 carry the `api_`
+# external_id prefix that marks a native submission -- every item came from the
+# hihyou (4,573) or ymgal (35) ingest job. Keeping the field alongside `banner`
+# was the alternative and it is the worse one: it would leave a standing axiom
+# violation on the wire forever to protect a consumer that does not exist.
+#
+# The public face /v2/news gained `banner` and `source.homepage_url` in the same
+# wave and needs no entry -- both are additive, and 07 §3.2 makes additions safe
+# under GA.
+
+in API GET /v2/me/news removed the required property `items/items/banner_hash` from the response with the `200` status
+in API POST /v2/me/news removed the required property `banner_hash` from the response with the `201` status
+in API GET /v2/me/news/{id} removed the required property `banner_hash` from the response with the `200` status
+in API PATCH /v2/me/news/{id} removed the required property `banner_hash` from the response with the `200` status

--- a/docs/catalog/v2-openapi.yaml
+++ b/docs/catalog/v2-openapi.yaml
@@ -4384,6 +4384,9 @@ components:
           format: uri
           readOnly: true
           type: string
+        banner:
+          $ref: "#/components/schemas/Image"
+          description: Lead image. null when the item has none.
         id:
           description: News item id.
           maxLength: 20
@@ -4424,6 +4427,7 @@ components:
         - summary
         - source
         - source_url
+        - banner
         - published_at
       type: object
     NewsSource:
@@ -4431,6 +4435,11 @@ components:
       properties:
         display_name:
           description: Must not be used as a discriminant.
+          maxLength: 512
+          type: string
+        homepage_url:
+          description: The source's own site. Empty string when the source has none.
+          format: uri
           maxLength: 512
           type: string
         name:
@@ -4448,6 +4457,7 @@ components:
         - object
         - name
         - display_name
+        - homepage_url
       type: object
     NewsSubmission:
       additionalProperties: true
@@ -4459,11 +4469,9 @@ components:
           format: uri
           readOnly: true
           type: string
-        banner_hash:
-          description: Image-service content hash of the banner. Empty string when there is none.
-          maxLength: 64
-          pattern: ^([0-9a-f]{64})?$
-          type: string
+        banner:
+          $ref: "#/components/schemas/Image"
+          description: "Lead image. null when there is none. B10: never a bare hash."
         id:
           description: News item id. Same id space as /v2/news.
           maxLength: 20
@@ -4527,7 +4535,7 @@ components:
         - title
         - summary
         - source_url
-        - banner_hash
+        - banner
         - published_at
         - work_ids
       type: object
@@ -7372,7 +7380,7 @@ components:
 info:
   description: "NextMoe public API v2. Public since 2026-08-25: any application mints its own nmk_ key in the developer portal, no approval required. The shape evolves additively; a breaking change to this document fails CI."
   title: NextMoe Public API v2
-  version: 2.16.0
+  version: 2.17.0
   x-stability: stable
 openapi: 3.1.0
 paths:


### PR DESCRIPTION
D16 traded the credential gate on `/v2/news` for four obligations (`refs/api-v2/03-resources.md` §2.4). Two of them were unmet on the wire, and a third axiom was being violated on the write face.

## What was broken

| Obligation | Spec | On the wire before |
|---|---|---|
| 1 · 署名必发 | `source` must carry `display_name` **和站点主页** | `NewsSource` was `object` / `name` / `display_name`. No homepage. Both sources have one populated (2/2). |
| 2 · the type carries `banner` | 「有 `title`、`summary`、`banner`、`published_at`、`source_url`」 | absent, while 4,598 of 4,608 rows carry a `banner_hash` |
| 3 · 撤回可表达 | withdrawn → `410 GONE` | all 9 withdrawn rows answered **404** |
| B10 (write face) | never a bare content hash | `repr.NewsSubmission` published `banner_hash` directly |

Obligation 3 is the one worth spelling out: the face is public and credential-less, so mirrors exist, and a mirror that only sees an item leave the list never learns the copy it already took was pulled. One `ErrNotFound` covered both "never existed" and "withdrawn", so the 410 branch was inexpressible. `dead_at` stays a 404 — the upstream item vanished on us, which is not a withdrawal.

## The declared breaking change

Replacing `banner_hash` with `banner` removes a required response property on four `/v2/me/news` operations. Declared in `v2-openapi-breaking-ignore.txt` with a measured — not assumed — justification:

```
news_item rows                                4,608
external_id LIKE 'api_%'  (native submission)     0
  from the hihyou ingest job                  4,573
  from the ymgal ingest job                      35
```

The write face has never been used, so nothing breaks. Keeping the field beside `banner` was the alternative and it is worse: a standing axiom violation on the wire forever, to protect a consumer that does not exist.

## What is deliberately NOT in here

**`work_ids`** — `news_item_work` has **0 rows**, and its only writer is `submission.go:247`, the partner submission face nobody has used. Adding it would ship `[]` on all 4,608 items: a field that looks answered and never is. Populating it needs the ingest jobs to resolve entities, which is a feature, not a repr fix.

**`lane`, `attribution`, `column_url`, `publisher_uid`** — obligation 2 closes the type (「类型里不存在的东西不会被某一波顺手加上」). These need a deliberate spec amendment, not a quiet addition here. That is the next wave; `attribution` matters most, since it is the condition Galgame 批评 attached.

`NewsSpec`'s `fields=` allowlist gained `banner` in the same change — without it `fields=banner` would answer 400 for a field the face now ships.

## Verification

`live_news_obligations_test.go` covers all three obligations against a real database, each with a control: the 410 test asserts a never-existing id is still 404 and a pending item is still 404, so "everything is 410 now" cannot pass as a fix; the banner test asserts an item without a hash ships `null`, not an empty Image.

Gates: `oasdiff breaking` → *No breaking changes to report*; `docs:check` and `docs:verify` 0 errors; `go vet` clean; full `go test ./...` green against an ephemeral database.

Spec 2.16.0 → **2.17.0**. v2 changed, so **the MCP face needs a restart**.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
