### PR TITLE
fix(apiv2): restore the trusted tier, and stop dropping site role grants

### DIFF
--- a/apps/api/cmd/catalog/main.go
+++ b/apps/api/cmd/catalog/main.go
@@ -340,7 +340,8 @@ func setupPublicCatalog(
 				return v2handler.UserIdentity{}, err
 			}
 			return v2handler.UserIdentity{
-				UID: int64(claims.ID), ClientID: claims.ClientID, Roles: claims.Roles,
+				UID: int64(claims.ID), ClientID: claims.ClientID,
+				Roles:  middleware.UnionRoles(claims.Roles, claims.SiteRoles),
 				Scopes: strings.Fields(claims.Scope),
 			}, nil
 		},

--- a/apps/api/internal/middleware/jwt_auth.go
+++ b/apps/api/internal/middleware/jwt_auth.go
@@ -58,14 +58,17 @@ func JWTAuth(verifier *oidctoken.Verifier) fiber.Handler {
 func setIdentityLocals(c fiber.Ctx, claims *utils.TokenClaims) {
 	c.Locals("user_uuid", claims.UserUUID)
 	c.Locals("user_id", claims.ID)
-	c.Locals("user_roles", unionRoles(claims.Roles, claims.SiteRoles))
+	c.Locals("user_roles", UnionRoles(claims.Roles, claims.SiteRoles))
 	c.Locals("user_scope", claims.Scope)
 	c.Locals("user_site", claims.SiteID)
 	c.Locals("user_global_roles", claims.Roles)
 	c.Locals("token_client_id", claims.ClientID)
 }
 
-func unionRoles(global, site []string) []string {
+// UnionRoles is what "the roles this token carries" means everywhere. A site
+// grant is a role like any other, and a face that reads claims.Roles alone
+// cannot see one.
+func UnionRoles(global, site []string) []string {
 	if len(site) == 0 {
 		return global
 	}

--- a/apps/api/internal/middleware/roles_union_test.go
+++ b/apps/api/internal/middleware/roles_union_test.go
@@ -22,14 +22,14 @@ func TestUnionRoles(t *testing.T) {
 		{"only site roles", nil, []string{"event_organizer"}, []string{"event_organizer"}},
 	}
 	for _, tc := range cases {
-		if got := unionRoles(tc.global, tc.site); !slices.Equal(got, tc.want) {
-			t.Errorf("%s: unionRoles(%v, %v) = %v, want %v", tc.name, tc.global, tc.site, got, tc.want)
+		if got := UnionRoles(tc.global, tc.site); !slices.Equal(got, tc.want) {
+			t.Errorf("%s: UnionRoles(%v, %v) = %v, want %v", tc.name, tc.global, tc.site, got, tc.want)
 		}
 	}
 }
 
 func TestSiteRolesCannotReachAdminBundles(t *testing.T) {
-	roles := unionRoles(nil, []string{"moderator", "event_organizer"})
+	roles := UnionRoles(nil, []string{"moderator", "event_organizer"})
 
 	if catalogperm.Resolver.Can(roles, catalogperm.Review) {
 		t.Error("site roles must not grant catalog.review (ren-only)")

--- a/apps/api/internal/platform/apiv2/handler/me_claims_mint.go
+++ b/apps/api/internal/platform/apiv2/handler/me_claims_mint.go
@@ -8,7 +8,6 @@ import (
 	"api/internal/platform/apiv2/problem"
 	"api/internal/platform/apiv2/repr"
 	"api/internal/platform/catalog/editspec"
-	catalogPerm "api/internal/platform/catalog/perm"
 	catsvc "api/internal/platform/catalog/service"
 )
 
@@ -63,7 +62,7 @@ func (c *Catalog) mintClaim(ctx context.Context, site string, uid, product int64
 	res, err := c.Claims.SubmitWork(ctx, catsvc.SubmitWorkParams{
 		Site: site, ProductWorkID: product, ActorUID: uid,
 		ContentRating: rating, Fields: fields,
-		Trusted:           catalogPerm.Resolver.Can(rolesFrom(ctx), catalogPerm.EditTrusted),
+		Trusted:           actsAsTrusted(ctx),
 		ConfirmDuplicates: confirmDuplicates,
 	})
 	if err != nil {

--- a/apps/api/internal/platform/apiv2/handler/me_proposals.go
+++ b/apps/api/internal/platform/apiv2/handler/me_proposals.go
@@ -26,10 +26,29 @@ func (c *Catalog) policyActor(ctx context.Context) (editing.PolicyContext, error
 	return editing.PolicyContext{
 		UserID: uid, Site: site,
 		ModerationCapped: thirdPartyFrom(ctx),
+		TrustTier:        trustTier(ctx),
 		HasPerm: func(key string) bool {
 			return catalogPerm.Resolver.Can(roles, authz.Permission(key))
 		},
 	}, nil
+}
+
+// v1's userEditActor set the trusted tier from exactly this pair, and wave R3
+// carried neither half to v2. PolicyContext.TrustTier ended up set by nothing,
+// so every ProposeTrusted field was proposable by nobody -- which is the whole
+// of letmoe's edit surface (editspec/work.go:57). The mint lane lost the other
+// half: it read the permission without the third-party test, so a
+// developer-owned app could publish a claim straight to live.
+func actsAsTrusted(ctx context.Context) bool {
+	return !thirdPartyFrom(ctx) &&
+		catalogPerm.Resolver.Can(rolesFrom(ctx), catalogPerm.EditTrusted)
+}
+
+func trustTier(ctx context.Context) int16 {
+	if actsAsTrusted(ctx) {
+		return editing.TrustedTier
+	}
+	return 0
 }
 
 // Standing to review ONE item is the engine's own per-field rule, never a

--- a/apps/api/internal/platform/apiv2/handler/trusted_tier_test.go
+++ b/apps/api/internal/platform/apiv2/handler/trusted_tier_test.go
@@ -1,0 +1,74 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/middleware"
+	"api/internal/platform/editing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func trustCtx(roles []string, thirdParty bool) context.Context {
+	ctx := context.WithValue(context.Background(), ctxRoles, roles)
+	return context.WithValue(ctx, ctxThirdParty, thirdParty)
+}
+
+// v1's userEditActor is the reference: trusted iff the actor holds
+// catalog.edit.trusted AND the token's client is not a developer-owned app.
+// v2 kept neither half -- PolicyContext.TrustTier was set by nothing, and the
+// mint lane read the permission without the third-party test.
+func TestActsAsTrustedNeedsBothHalves(t *testing.T) {
+	cases := []struct {
+		name       string
+		roles      []string
+		thirdParty bool
+		want       bool
+	}{
+		{"trusted role, first-party client", []string{"admin"}, false, true},
+		{"trusted role, third-party client", []string{"admin"}, true, false},
+		{"no trusted role, first-party client", []string{"user"}, false, false},
+		{"no roles at all", nil, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := trustCtx(c.roles, c.thirdParty)
+			require.Equal(t, c.want, actsAsTrusted(ctx))
+
+			want := int16(0)
+			if c.want {
+				want = editing.TrustedTier
+			}
+			require.Equal(t, want, trustTier(ctx))
+		})
+	}
+}
+
+// A ProposeTrusted field is proposable by a trusted actor and by nobody else.
+// With TrustTier unset this predicate answered false for everyone, which is
+// letmoe's entire edit surface (editspec/work.go:57).
+func TestProposeTrustedIsReachable(t *testing.T) {
+	p := editing.Policy{Propose: editing.ProposeTrusted}
+
+	trusted := editing.PolicyContext{TrustTier: trustTier(trustCtx([]string{"admin"}, false))}
+	require.True(t, p.AllowsPropose(trusted), "a trusted first-party actor must be able to propose")
+
+	for _, ctx := range []context.Context{
+		trustCtx([]string{"admin"}, true),
+		trustCtx([]string{"user"}, false),
+	} {
+		require.False(t, editing.Policy{Propose: editing.ProposeTrusted}.
+			AllowsPropose(editing.PolicyContext{TrustTier: trustTier(ctx)}))
+	}
+}
+
+// A site grant is a role. Reading claims.Roles alone made 82 production
+// site-moderator grants invisible to /v2.
+func TestSiteRolesJoinTheRoleSet(t *testing.T) {
+	require.ElementsMatch(t, []string{"user", "moderator"},
+		middleware.UnionRoles([]string{"user"}, []string{"moderator"}))
+	require.ElementsMatch(t, []string{"user"},
+		middleware.UnionRoles([]string{"user"}, []string{"user"}), "the union must not duplicate")
+	require.ElementsMatch(t, []string{"user"}, middleware.UnionRoles([]string{"user"}, nil))
+}


### PR DESCRIPTION
Two things wave R3 dropped on the way to /v2, both invisible until someone went looking.

## One rule, lost twice

v1's `userEditActor` decided the trusted tier from a single pair:

```go
if catperm.Resolver.Can(roles, catperm.EditTrusted) && !isThirdPartyClient(clientFromCtx(ctx)) {
    actor.TrustTier = editing.TrustedTier
}
```

v2 kept neither half, in two different places.

**`PolicyContext.TrustTier` was set by nothing at all.** `AllowsPropose` answers `pc.TrustTier >= TrustedTier` for a `ProposeTrusted` field (`editing/registry.go:65`), so every such field was proposable by **nobody** — and that is the whole of letmoe's edit surface (`editspec/work.go:57`). No traffic ever reported it, because letmoe has filed zero proposals. Which is exactly what a face nobody can write to looks like.

**The mint lane lost the other half.** `me_claims_mint.go` read the permission but not the third-party test, so a developer-owned app acting for a trusted user could publish a claim straight to `live` instead of `pending` — the same cap the moderation plane spends a flag to enforce, opened by a different door.

Both now come from one predicate, `actsAsTrusted`, so the pair cannot drift apart again.

## Site role grants were being dropped

`/v2` built its `UserIdentity` from `claims.Roles` alone, while the OP's own middleware has always used `unionRoles(claims.Roles, claims.SiteRoles)`. A site grant is a role like any other, and production holds **82 site-level moderator grants** that `/v2` could not see.

`unionRoles` is exported as `UnionRoles` and reused rather than reimplemented, so the two faces cannot disagree about what "the roles this token carries" means.

## Verification

`trusted_tier_test.go` walks all four combinations of (holds the permission) × (third-party client) and asserts `AllowsPropose` on a real `ProposeTrusted` policy — including the negative cases, so "trusted for everyone" cannot pass as a fix. The union test pins that a duplicate role is not doubled.

`go vet` clean; full `go test ./...` green against an ephemeral database. No spec change, so no version bump.

https://claude.ai/code/session_018vWvQJX8aSAwPiVRFD3hvD
