### PR TITLE
feat(auth): charge moemoepoints for username changes

### DIFF
--- a/apps/api/internal/platform/auth/model/moemoepoint_log.go
+++ b/apps/api/internal/platform/auth/model/moemoepoint_log.go
@@ -11,6 +11,7 @@ const (
 	MoemoepointReasonDailyCheckin    = "daily_checkin"
 	MoemoepointReasonLiked           = "liked"
 	MoemoepointReasonRegisterGift    = "register_gift"
+	MoemoepointReasonNameChange      = "name_change"
 )
 
 func IsValidMoemoepointReason(r string) bool {
@@ -18,7 +19,8 @@ func IsValidMoemoepointReason(r string) bool {
 	case MoemoepointReasonAdminGrant, MoemoepointReasonAdminDeduct,
 		MoemoepointReasonMigration, MoemoepointReasonContentApproved,
 		MoemoepointReasonContentRemoved, MoemoepointReasonDailyCheckin,
-		MoemoepointReasonLiked, MoemoepointReasonRegisterGift:
+		MoemoepointReasonLiked, MoemoepointReasonRegisterGift,
+		MoemoepointReasonNameChange:
 		return true
 	}
 	return false

--- a/apps/api/internal/platform/auth/repository/user_repository.go
+++ b/apps/api/internal/platform/auth/repository/user_repository.go
@@ -2,13 +2,18 @@ package repository
 
 import (
 	"context"
+	"errors"
+	"strconv"
 	"strings"
+	"time"
 
 	"api/internal/platform/auth/model"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
+
+var ErrMoemoepointInsufficient = errors.New("moemoepoint balance insufficient")
 
 var userSortColumns = map[string]string{
 	"created_at":  "created_at",
@@ -175,6 +180,37 @@ func (r *UserRepository) UpdateProfile(ctx context.Context, uuid string, fields 
 		Model(&model.User{}).
 		Where("uuid = ?", uuid).
 		Updates(fields).Error
+}
+
+// RenameWithCharge renames the user and charges `cost` moemoepoints in one
+// transaction. Returns ErrMoemoepointInsufficient when the balance cannot cover
+// the cost; a no-op (nil) when the name is unchanged.
+func (r *UserRepository) RenameWithCharge(ctx context.Context, uuid, newName string, cost int) error {
+	var user model.User
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("uuid = ?", uuid).First(&user).Error; err != nil {
+			return err
+		}
+		if user.Name == newName {
+			return nil
+		}
+		if user.Moemoepoint < cost {
+			return ErrMoemoepointInsufficient
+		}
+		if err := tx.Model(&model.User{}).Where("id = ?", user.ID).
+			Updates(map[string]any{"name": newName, "moemoepoint": user.Moemoepoint - cost}).Error; err != nil {
+			return err
+		}
+		return tx.Create(&model.MoemoepointLog{
+			UserID:         user.ID,
+			Delta:          -cost,
+			Reason:         model.MoemoepointReasonNameChange,
+			SourceApp:      "oauth",
+			ActorUserID:    user.ID,
+			IdempotencyKey: "name_change:" + uuid + ":" + strconv.FormatInt(time.Now().UnixNano(), 10),
+		}).Error
+	})
 }
 
 func (r *UserRepository) Delete(ctx context.Context, id uint) error {

--- a/apps/api/internal/platform/auth/service/auth_service.go
+++ b/apps/api/internal/platform/auth/service/auth_service.go
@@ -730,6 +730,10 @@ func (s *AuthService) SendEmailChangeCode(ctx context.Context, userUUID, newEmai
 	return nil
 }
 
+// nameChangeCost matches the forum's CostChangeUsername (17); charging lives
+// here because a username is an OAuth-global attribute and the balance is too.
+const nameChangeCost = 17
+
 func (s *AuthService) UpdateProfile(ctx context.Context, userUUID string, req *dto.UpdateProfileRequest) (*model.User, error) {
 	fields := map[string]any{}
 
@@ -741,7 +745,12 @@ func (s *AuthService) UpdateProfile(ctx context.Context, userUUID string, req *d
 		if exists {
 			return nil, errors.NewWithCode(errors.ErrAuthNameExists)
 		}
-		fields["name"] = *req.Name
+		if err := s.userRepo.RenameWithCharge(ctx, userUUID, *req.Name, nameChangeCost); err != nil {
+			if err == repository.ErrMoemoepointInsufficient {
+				return nil, errors.NewWithCode(errors.ErrMoemoepointInsufficient)
+			}
+			return nil, err
+		}
 	}
 	if req.Avatar != nil {
 		fields["avatar"] = *req.Avatar

--- a/apps/api/pkg/errors/codes.go
+++ b/apps/api/pkg/errors/codes.go
@@ -50,6 +50,7 @@ const (
 	ErrMoemoepointInvalidReason = 16003
 	ErrMoemoepointIdemConflict  = 16004
 	ErrMoemoepointNotAwarder    = 16005
+	ErrMoemoepointInsufficient  = 16006
 
 	ErrCreatorAlreadyHas    = 17001
 	ErrCreatorAppPending    = 17002
@@ -169,6 +170,7 @@ var codeMessages = map[int]string{
 	ErrMoemoepointInvalidReason: "未知的萌萌点变动原因",
 	ErrMoemoepointIdemConflict:  "幂等键已存在但请求内容不一致",
 	ErrMoemoepointNotAwarder:    "该客户端无权发放萌萌点",
+	ErrMoemoepointInsufficient:  "萌萌点不足",
 
 	ErrGalgameNotFound:           "Galgame 不存在",
 	ErrGalgameAlreadyExists:      "Galgame 已存在",

--- a/apps/web/app/constants/moemoepoint.ts
+++ b/apps/web/app/constants/moemoepoint.ts
@@ -5,7 +5,8 @@ const STATIC_REASON_LABEL: Record<string, string> = {
   migration: '积分迁移',
   register_gift: '注册欢迎礼',
   daily_checkin: '每日签到',
-  content_removed: '内容被下架'
+  content_removed: '内容被下架',
+  name_change: '修改用户名'
 }
 
 const REF_TYPE_NOUN: Record<string, string> = {


### PR DESCRIPTION
## Bug / 问题

Changing a username currently costs nothing. The forum has long shipped a `CostChangeUsername = 17` constant that is dead code — the rename path (`PATCH /auth/me` → `UpdateProfile`) never charged anything. The product intent is that a username change costs **17 moemoepoints**, and an insufficient balance should be refused with "萌萌点不足".

当前修改用户名是**免费的**。论坛里 `CostChangeUsername = 17` 这个常量长期存在但从未被调用——改名路径（`PATCH /auth/me` → `UpdateProfile`）没有任何扣费。产品预期是**改名消耗 17 萌萌点**，余额不足时拒绝并提示"萌萌点不足"。

## Root cause / 成因

A username is an **OAuth-global attribute** and the authoritative moemoepoint balance lives on the same OAuth `users` row. Rename therefore had to be charged where the balance is, atomically — but `UpdateProfile` only wrote the new name, and the charge constant was never wired on either side.

用户名是 **OAuth 全局属性**，余额的权威账本也在 OAuth 的 `users` 行上。所以改名扣费必须在余额所在处**原子完成**——而此前 `UpdateProfile` 只写名字，扣费常量在两侧都没有被接线。

## Fix / 解决方式

Charge atomically inside `UpdateProfile`:

- Added `RenameWithCharge` in the user repository: in **one transaction** it locks the user row, returns when the name is unchanged (no charge), rejects with `ErrMoemoepointInsufficient` when `balance < 17`, otherwise updates the name, deducts 17, and writes a `moemoepoint_log` row with a new **`name_change`** reason.
- Added error `16006` (`ErrMoemoepointInsufficient`, message **"萌萌点不足"**) so a refused rename surfaces to the caller (forum surfaces the same message in the UI) without applying the name.
- Added the `name_change` reason to the valid-reason set and to the OAuth web ledger label (`修改用户名`).
- Forum-facing ledger label is covered by the companion forum PR (#170).

在 `UpdateProfile` 内原子扣费：

- 用户仓库新增 `RenameWithCharge`：**同一事务**内锁用户行；名字未变则直接返回（不扣费）；余额 <17 返回 `ErrMoemoepointInsufficient`；否则更新用户名、扣 17，并写入一条新 reason **`name_change`** 的 `moemoepoint_log`。
- 新增错误码 `16006`（`ErrMoemoepointInsufficient`，文案 **"萌萌点不足"**）：余额不足时拒绝改名且**不生效**，论坛会把同一文案透出给用户。
- 把 `name_change` 加入合法 reason 集合并补充 OAuth 后台流水文案（`修改用户名`）。
- 论坛侧明细展示文案由配套的 forum PR（#170）补齐。

## Verification / 验证

- `go build ./...` in `apps/api` passes.
- Logic reviewed against the existing ledger writer: rename, insufficient-balance rejection and idempotent no-op (unchanged name) all live in one transaction.

- `apps/api` 下 `go build ./...` 通过；
- 逻辑与现有流水写入一致：改名成功扣费、余额不足拒绝、名字未变不扣费，三者处于同一事务。

> Note: no DB migration required — reasons are plain strings, not a DB enum/constraint.
> 说明：无需数据库迁移——reason 是纯字符串，没有 DB 枚举或约束。
